### PR TITLE
Format nested code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ within a 1 second. You can explicitly pass the ``timeout`` parameter:
 ```swift
 expect(value).toEventually(equal(1), timeout: 1)
 
-If you prefer the callback-style that some testing frameworks do, use ``waitUntil``:
+If you prefer the callback-style that some testing frameworks do, use `waitUntil`:
 
-```swift
 waitUntil { done in
     // do some stuff that takes a while...
     NSThread.sleepForTimeInterval(0.5)


### PR DESCRIPTION
Remove double backticks inside of already formatted code blocks.
