### PR TITLE
Made members of SourceLocation publicly readable.

### DIFF
--- a/Nimble/Utils/SourceLocation.swift
+++ b/Nimble/Utils/SourceLocation.swift
@@ -2,8 +2,8 @@ import Foundation
 
 
 @objc public class SourceLocation : Printable {
-    let file: String
-    let line: UInt
+    public let file: String
+    public let line: UInt
 
     init() {
         file = "Unknown File"


### PR DESCRIPTION
I'm writing a [matcher](https://github.com/AshFurrow/Nimble-Snapshots) that requires these properties to be public (compatible with Xcode 6 beta 5). 
