### PR TITLE
Fix "Build Active Architecture Only" build setting for iOS target

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1065,7 +1065,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-framework",
 					XCTest,


### PR DESCRIPTION
The `ONLY_ACTIVE_ARCH` ("Build Active Architecture Only") build setting should be set to `NO` for iOS targets, as per jspahrsummers/xcconfigs@ae4762d:

> If a library only built one architecture, then was used in a parent project that wanted all of them, things asplode.

This should _partially_ fix Quick/Quick#111, i.e. phantom "unresolved identifier" errors.
