### PR TITLE
Added support for Dictionary equality.

### DIFF
--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -25,6 +25,7 @@ class EqualTest: XCTestCase {
     func testArrayEquality() {
         expect([1, 2, 3]).to(equal([1, 2, 3]))
         expect([1, 2, 3]).toNot(equal([1, 2]))
+        expect([1, 2, 3]).toNot(equal([1, 2, 4]))
 
         let array1: Array<Int> = [1, 2, 3]
         let array2: Array<Int> = [1, 2, 3]
@@ -59,6 +60,30 @@ class EqualTest: XCTestCase {
         failsWithErrorMessage("expected <[1]> to not equal <nil> (will not match nils, use beNil() instead)") {
             expect([1]).toNot(equal(nil as [Int]?))
         }
+
+        failsWithErrorMessage("expected <nil> to equal <nil> (will not match nils, use beNil() instead)") {
+            expect(nil as [Int: Int]?).to(equal(nil as [Int: Int]?))
+        }
+        failsWithErrorMessage("expected <nil> to not equal <[1: 1]> (will not match nils, use beNil() instead)") {
+            expect(nil as [Int: Int]?).toNot(equal([1: 1]))
+        }
+        failsWithErrorMessage("expected <[1: 1]> to not equal <nil> (will not match nils, use beNil() instead)") {
+            expect([1: 1]).toNot(equal(nil as [Int: Int]?))
+        }
+    }
+
+    func testDictionaryEquality() {
+        expect(["foo": "bar"]).to(equal(["foo": "bar"]))
+        expect(["foo": "bar"]).toNot(equal(["foo": "baz"]))
+
+        let actual = ["foo": "bar"]
+        let expected = ["foo": "bar"]
+        let unexpected = ["foo": "baz"]
+        expect(actual).to(equal(expected))
+        expect(actual).toNot(equal(unexpected))
+
+        expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
+        expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(expected))
     }
 
     func testNSObjectEquality() {
@@ -80,6 +105,22 @@ class EqualTest: XCTestCase {
             expect("hello") != "hello"
             return
         }
+    }
+
+    func testOperatorEqualityWithArrays() {
+        let array1: Array<Int> = [1, 2, 3]
+        let array2: Array<Int> = [1, 2, 3]
+        let array3: Array<Int> = [1, 2]
+        expect(array1) == array2
+        expect(array1) != array3
+    }
+
+    func testOperatorEqualityWithDictionaries() {
+        let dict1 = ["foo": "bar"]
+        let dict2 = ["foo": "bar"]
+        let dict3 = ["foo": "baz"]
+        expect(dict1) == dict2
+        expect(dict1) != dict3
     }
 
     func testOptionalEquality() {


### PR DESCRIPTION
 Swift doesn't support == operators on dictionaries.

Closes #29.
