### PR TITLE
Updated failure message style

### DIFF
--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -10,10 +10,21 @@ public class FailureMessage {
     public init() {
     }
 
-    public func stringValue() -> String {
+    var description : String {
         var value = "\(expected) \(to) \(postfixMessage)"
         if let actualValue = actualValue {
             value = "\(expected) \(actualValue) \(to) \(postfixMessage)"
+        }
+        var lines: [String] = (value as NSString).componentsSeparatedByString("\n") as [String]
+        let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
+        return "".join(lines)
+    }
+
+    public func stringValue() -> String {
+        var value = "\(expected) \(to) \(postfixMessage)"
+        if let actualValue = actualValue {
+            value = "\(expected) \(to) \(postfixMessage), got \(actualValue)"
         }
         var lines: [String] = (value as NSString).componentsSeparatedByString("\n") as [String]
         let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -11,10 +11,10 @@ class AsyncTest: XCTestCase {
         deferToMainQueue { value = 0 }
         expect(value).toEventuallyNot(equal(1))
 
-        failsWithErrorMessage("expected <0> to eventually not equal <0>") {
+        failsWithErrorMessage("expected to eventually not equal <0>, got <0>") {
             expect(value).toEventuallyNot(equal(0))
         }
-        failsWithErrorMessage("expected <0> to eventually equal <1>") {
+        failsWithErrorMessage("expected to eventually equal <1>, got <0>") {
             expect(value).toEventually(equal(1))
         }
     }
@@ -31,14 +31,14 @@ class AsyncTest: XCTestCase {
         failsWithErrorMessage("Waited more than 1.0 second") {
             waitUntil(timeout: 1) { done in return }
         }
-        failsWithErrorMessage("Waited more than 0.1 seconds") {
-            waitUntil(timeout: 0.1) { done in
-                NSThread.sleepForTimeInterval(3.0)
+        failsWithErrorMessage("Waited more than 0.01 seconds") {
+            waitUntil(timeout: 0.01) { done in
+                NSThread.sleepForTimeInterval(0.1)
                 done()
             }
         }
 
-        failsWithErrorMessage("expected <1> to equal <2>") {
+        failsWithErrorMessage("expected to equal <2>, got <1>") {
             waitUntil { done in
                 NSThread.sleepForTimeInterval(0.1)
                 expect(1).to(equal(2))

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -14,7 +14,7 @@ func failsWithErrorMessage(message: String, closure: () -> Void, file: String = 
         }
     }
     if lastFailureMessage != nil {
-        let msg = "Got failure message: '\(lastFailureMessage!)', but expected '\(message)'"
+        let msg = "Got failure message: \"\(lastFailureMessage!)\", but expected \"\(message)\""
         XCTFail(msg, file: file, line: UInt(line))
     } else {
         XCTFail("expected failure message, but got none", file: file, line: UInt(line))

--- a/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -13,13 +13,13 @@ class BeAKindOfTest: XCTestCase {
     }
 
     func testFailureMessages() {
-        failsWithErrorMessage("expected <nil> to be a kind of NSString") {
+        failsWithErrorMessage("expected to be a kind of NSString, got <nil>") {
             expect(nil as NSString?).to(beAKindOf(NSString))
         }
-        failsWithErrorMessage("expected <__NSCFNumber instance> to be a kind of NSString") {
+        failsWithErrorMessage("expected to be a kind of NSString, got <__NSCFNumber instance>") {
             expect(NSNumber(integer:1)).to(beAKindOf(NSString))
         }
-        failsWithErrorMessage("expected <__NSCFNumber instance> to not be a kind of NSNumber") {
+        failsWithErrorMessage("expected to not be a kind of NSNumber, got <__NSCFNumber instance>") {
             expect(NSNumber(integer:1)).toNot(beAKindOf(NSNumber))
         }
     }

--- a/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -10,13 +10,13 @@ class BeAnInstanceOfTest: XCTestCase {
     }
 
     func testFailureMessages() {
-        failsWithErrorMessage("expected <nil> to be an instance of NSString") {
+        failsWithErrorMessage("expected to be an instance of NSString, got <nil>") {
             expect(nil as NSString?).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected <__NSCFNumber instance> to be an instance of NSString") {
+        failsWithErrorMessage("expected to be an instance of NSString, got <__NSCFNumber instance>") {
             expect(NSNumber(integer:1)).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected <__NSCFNumber instance> to not be an instance of NSNumber") {
+        failsWithErrorMessage("expected to not be an instance of NSNumber, got <__NSCFNumber instance>") {
             expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSNumber))
         }
     }

--- a/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/NimbleTests/Matchers/BeCloseToTest.swift
@@ -7,7 +7,7 @@ class BeCloseToTest: XCTestCase {
         expect(1.2 as CDouble).to(beCloseTo(1.2001))
         expect(1.2 as Float).to(beCloseTo(1.2001))
 
-        failsWithErrorMessage("expected <1.2000> to not be close to <1.2001> (within 0.0001)") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2000>") {
             expect(1.2).toNot(beCloseTo(1.2001))
         }
     }
@@ -15,7 +15,7 @@ class BeCloseToTest: XCTestCase {
     func testBeCloseToWithin() {
         expect(1.2).to(beCloseTo(9.300, within: 10))
 
-        failsWithErrorMessage("expected <1.2000> to not be close to <1.2001> (within 1.0000)") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
             expect(1.2).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }
@@ -25,7 +25,7 @@ class BeCloseToTest: XCTestCase {
         expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
         expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
 
-        failsWithErrorMessage("expected <1.2000> to not be close to <1.2001> (within 1.0000)") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
             expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }

--- a/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/NimbleTests/Matchers/BeEmptyTest.swift
@@ -32,19 +32,17 @@ class BeEmptyTest: XCTestCase {
     }
 
     func testBeEmptyNegative() {
-        failsWithErrorMessage("expected <()> to not be empty") {
+        failsWithErrorMessage("expected to not be empty, got <()>") {
             expect([]).toNot(beEmpty())
         }
-        // TODO: figure out how to not dispatch to NMBCollection
-//        failsWithErrorMessage("expected <[1]> to be empty") {
-        failsWithErrorMessage("expected <[1]> to be empty") {
+        failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())
         }
 
-        failsWithErrorMessage("expected <> to not be empty") {
+        failsWithErrorMessage("expected to not be empty, got <>") {
             expect("").toNot(beEmpty())
         }
-        failsWithErrorMessage("expected <foo> to be empty") {
+        failsWithErrorMessage("expected to be empty, got <foo>") {
             expect("foo").to(beEmpty())
         }
     }

--- a/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -11,11 +11,11 @@ class BeGreaterThanOrEqualToTest: XCTestCase {
         expect(NSNumber(int:2)).to(beGreaterThanOrEqualTo(NSNumber(int:2)))
         expect(1).to(beGreaterThanOrEqualTo(NSNumber(int:0)))
 
-        failsWithErrorMessage("expected <0> to be greater than or equal to <2>") {
+        failsWithErrorMessage("expected to be greater than or equal to <2>, got <0>") {
             expect(0).to(beGreaterThanOrEqualTo(2))
             return
         }
-        failsWithErrorMessage("expected <1> to not be greater than or equal to <1>") {
+        failsWithErrorMessage("expected to not be greater than or equal to <1>, got <1>") {
             expect(1).toNot(beGreaterThanOrEqualTo(1))
             return
         }
@@ -27,7 +27,7 @@ class BeGreaterThanOrEqualToTest: XCTestCase {
         expect(NSNumber(int:1)) >= 1
         expect(NSNumber(int:1)) >= NSNumber(int:1)
 
-        failsWithErrorMessage("expected <1> to be greater than or equal to <2>") {
+        failsWithErrorMessage("expected to be greater than or equal to <2>, got <1>") {
             expect(1) >= 2
             return
         }

--- a/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -8,11 +8,11 @@ class BeGreaterThanTest: XCTestCase {
         expect(NSNumber(int:3)).to(beGreaterThan(2))
         expect(NSNumber(int:1)).toNot(beGreaterThan(NSNumber(int:2)))
 
-        failsWithErrorMessage("expected <0> to be greater than <2>") {
+        failsWithErrorMessage("expected to be greater than <2>, got <0>") {
             expect(0).to(beGreaterThan(2))
             return
         }
-        failsWithErrorMessage("expected <1> to not be greater than <0>") {
+        failsWithErrorMessage("expected to not be greater than <0>, got <1>") {
             expect(1).toNot(beGreaterThan(0))
             return
         }
@@ -23,7 +23,7 @@ class BeGreaterThanTest: XCTestCase {
         expect(NSNumber(int:1)) > NSNumber(int:0)
         expect(NSNumber(int:1)) > 0
 
-        failsWithErrorMessage("expected <1.0000> to be greater than <2.0000>") {
+        failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
             expect(1) > 2
             return
         }

--- a/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -15,15 +15,15 @@ class BeIdenticalToObjectTest:XCTestCase {
     }
     
     func testBeIdenticalToPositiveMessage() {
-        let message = NSString(format: "expected <%p> to be identical to <%p>",
-            unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectB, Int.self))
+        let message = NSString(format: "expected to be identical to <%p>, got <%p>",
+            unsafeBitCast(testObjectB, Int.self), unsafeBitCast(testObjectA, Int.self))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).to(beIdenticalTo(self.testObjectB))
         }
     }
     
     func testBeIdenticalToNegativeMessage() {
-        let message = NSString(format: "expected <%p> to not be identical to <%p>",
+        let message = NSString(format: "expected to not be identical to <%p>, got <%p>",
             unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectA, Int.self))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).toNot(beIdenticalTo(self.testObjectA))

--- a/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -14,7 +14,7 @@ class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToPositiveMessage() {
         let num1 = NSNumber(integer:1)
         let num2 = NSNumber(integer:2)
-        let message = NSString(format: "expected <%p> to be identical to <%p>", num1, num2)
+        let message = NSString(format: "expected to be identical to <%p>, got <%p>", num2, num1)
         failsWithErrorMessage(message) {
             expect(num1).to(beIdenticalTo(num2))
         }
@@ -23,7 +23,7 @@ class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToNegativeMessage() {
         let value1 = NSArray(array: [])
         let value2 = NSArray(array: [])
-        let message = NSString(format: "expected <%p> to not be identical to <%p>", value1, value2)
+        let message = NSString(format: "expected to not be identical to <%p>, got <%p>", value2, value1)
         failsWithErrorMessage(message) {
             expect(value1).toNot(beIdenticalTo(value2))
         }

--- a/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -12,11 +12,11 @@ class BeLessThanOrEqualToTest: XCTestCase {
         expect(2).to(beLessThanOrEqualTo(NSNumber(int:10)))
         expect(2).toNot(beLessThanOrEqualTo(NSNumber(int:1)))
 
-        failsWithErrorMessage("expected <2> to be less than or equal to <0>") {
+        failsWithErrorMessage("expected to be less than or equal to <0>, got <2>") {
             expect(2).to(beLessThanOrEqualTo(0))
             return
         }
-        failsWithErrorMessage("expected <0> to not be less than or equal to <0>") {
+        failsWithErrorMessage("expected to not be less than or equal to <0>, got <0>") {
             expect(0).toNot(beLessThanOrEqualTo(0))
             return
         }
@@ -26,7 +26,7 @@ class BeLessThanOrEqualToTest: XCTestCase {
         expect(0) <= 1
         expect(1) <= 1
 
-        failsWithErrorMessage("expected <2> to be less than or equal to <1>") {
+        failsWithErrorMessage("expected to be less than or equal to <1>, got <2>") {
             expect(2) <= 1
             return
         }

--- a/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/NimbleTests/Matchers/BeLessThanTest.swift
@@ -12,11 +12,11 @@ class BeLessThanTest: XCTestCase {
         expect(2).to(beLessThan(NSNumber(integer:10)))
         expect(2).toNot(beLessThan(NSNumber(integer:1)))
 
-        failsWithErrorMessage("expected <2> to be less than <0>") {
+        failsWithErrorMessage("expected to be less than <0>, got <2>") {
             expect(2).to(beLessThan(0))
             return
         }
-        failsWithErrorMessage("expected <0> to not be less than <1>") {
+        failsWithErrorMessage("expected to not be less than <1>, got <0>") {
             expect(0).toNot(beLessThan(1))
             return
         }
@@ -26,7 +26,7 @@ class BeLessThanTest: XCTestCase {
         expect(0) < 1
         expect(NSNumber(int:0)) < 1
 
-        failsWithErrorMessage("expected <2.0000> to be less than <1.0000>") {
+        failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
             expect(2) < 1
             return
         }

--- a/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/NimbleTests/Matchers/BeLogicalTest.swift
@@ -23,7 +23,7 @@ class BeTruthyTest : XCTestCase {
     func testShouldMatchTrue() {
         expect(true).to(beTruthy())
 
-        failsWithErrorMessage("expected <true> to not be truthy") {
+        failsWithErrorMessage("expected to not be truthy, got <true>") {
             expect(true).toNot(beTruthy())
         }
     }
@@ -31,7 +31,7 @@ class BeTruthyTest : XCTestCase {
     func testShouldNotMatchFalse() {
         expect(false).toNot(beTruthy())
 
-        failsWithErrorMessage("expected <false> to be truthy") {
+        failsWithErrorMessage("expected to be truthy, got <false>") {
             expect(false).to(beTruthy())
         }
     }
@@ -39,7 +39,7 @@ class BeTruthyTest : XCTestCase {
     func testShouldNotMatchNilBools() {
         expect(nil as Bool?).toNot(beTruthy())
 
-        failsWithErrorMessage("expected <nil> to be truthy") {
+        failsWithErrorMessage("expected to be truthy, got <nil>") {
             expect(nil as Bool?).to(beTruthy())
         }
     }
@@ -47,7 +47,7 @@ class BeTruthyTest : XCTestCase {
     func testShouldMatchBoolConvertibleTypesThatConvertToTrue() {
         expect(ConvertsToBool.TrueLike).to(beTruthy())
 
-        failsWithErrorMessage("expected <TrueLike> to not be truthy") {
+        failsWithErrorMessage("expected to not be truthy, got <TrueLike>") {
             expect(ConvertsToBool.TrueLike).toNot(beTruthy())
         }
     }
@@ -55,7 +55,7 @@ class BeTruthyTest : XCTestCase {
     func testShouldNotMatchBoolConvertibleTypesThatConvertToFalse() {
         expect(ConvertsToBool.FalseLike).toNot(beTruthy())
 
-        failsWithErrorMessage("expected <FalseLike> to be truthy") {
+        failsWithErrorMessage("expected to be truthy, got <FalseLike>") {
             expect(ConvertsToBool.FalseLike).to(beTruthy())
         }
     }
@@ -65,7 +65,7 @@ class BeTrueTest : XCTestCase {
     func testShouldMatchTrue() {
         expect(true).to(beTrue())
 
-        failsWithErrorMessage("expected <true> to not be true") {
+        failsWithErrorMessage("expected to not be true, got <true>") {
             expect(true).toNot(beTrue())
         }
     }
@@ -73,7 +73,7 @@ class BeTrueTest : XCTestCase {
     func testShouldNotMatchFalse() {
         expect(false).toNot(beTrue())
 
-        failsWithErrorMessage("expected <false> to be true") {
+        failsWithErrorMessage("expected to be true, got <false>") {
             expect(false).to(beTrue())
         }
     }
@@ -81,7 +81,7 @@ class BeTrueTest : XCTestCase {
     func testShouldNotMatchNilBools() {
         expect(nil as Bool?).toNot(beTrue())
 
-        failsWithErrorMessage("expected <nil> to be true") {
+        failsWithErrorMessage("expected to be true, got <nil>") {
             expect(nil as Bool?).to(beTrue())
         }
     }
@@ -91,7 +91,7 @@ class BeFalsyTest : XCTestCase {
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalsy())
 
-        failsWithErrorMessage("expected <true> to be falsy") {
+        failsWithErrorMessage("expected to be falsy, got <true>") {
             expect(true).to(beFalsy())
         }
     }
@@ -99,7 +99,7 @@ class BeFalsyTest : XCTestCase {
     func testShouldMatchFalse() {
         expect(false).to(beFalsy())
 
-        failsWithErrorMessage("expected <false> to not be falsy") {
+        failsWithErrorMessage("expected to not be falsy, got <false>") {
             expect(false).toNot(beFalsy())
         }
     }
@@ -107,7 +107,7 @@ class BeFalsyTest : XCTestCase {
     func testShouldMatchNilBools() {
         expect(nil as Bool?).to(beFalsy())
 
-        failsWithErrorMessage("expected <nil> to not be falsy") {
+        failsWithErrorMessage("expected to not be falsy, got <nil>") {
             expect(nil as Bool?).toNot(beFalsy())
         }
     }
@@ -117,7 +117,7 @@ class BeFalseTest : XCTestCase {
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalse())
 
-        failsWithErrorMessage("expected <true> to be false") {
+        failsWithErrorMessage("expected to be false, got <true>") {
             expect(true).to(beFalse())
         }
     }
@@ -125,17 +125,17 @@ class BeFalseTest : XCTestCase {
     func testShouldMatchFalse() {
         expect(false).to(beFalse())
 
-        failsWithErrorMessage("expected <false> to not be false") {
+        failsWithErrorMessage("expected to not be false, got <false>") {
             expect(false).toNot(beFalse())
         }
     }
 
     func testShouldNotMatchNilBools() {
-        failsWithErrorMessage("expected <nil> to be false") {
+        failsWithErrorMessage("expected to be false, got <nil>") {
             expect(nil as Bool?).to(beFalse())
         }
 
-        failsWithErrorMessage("expected <nil> to not be false") {
+        failsWithErrorMessage("expected to not be false, got <nil>") {
             expect(nil as Bool?).toNot(beFalse())
         }
     }

--- a/NimbleTests/Matchers/BeNilTest.swift
+++ b/NimbleTests/Matchers/BeNilTest.swift
@@ -11,11 +11,11 @@ class BeNilTest: XCTestCase {
         expect(1 as Int?).toNot(beNil())
         expect(producesNil()).to(beNil())
 
-        failsWithErrorMessage("expected <nil> to not be nil") {
+        failsWithErrorMessage("expected to not be nil, got <nil>") {
             expect(nil as Int?).toNot(beNil())
         }
 
-        failsWithErrorMessage("expected <1> to be nil") {
+        failsWithErrorMessage("expected to be nil, got <1>") {
             expect(1 as Int?).to(beNil())
         }
     }

--- a/NimbleTests/Matchers/BeginWithTest.swift
+++ b/NimbleTests/Matchers/BeginWithTest.swift
@@ -19,16 +19,16 @@ class BeginWithTest: XCTestCase {
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected <[1, 2, 3]> to begin with <2>") {
+        failsWithErrorMessage("expected to begin with <2>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).to(beginWith(2))
         }
-        failsWithErrorMessage("expected <[1, 2, 3]> to not begin with <1>") {
+        failsWithErrorMessage("expected to not begin with <1>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).toNot(beginWith(1))
         }
-        failsWithErrorMessage("expected <batman> to begin with <atm>") {
+        failsWithErrorMessage("expected to begin with <atm>, got <batman>") {
             expect("batman").to(beginWith("atm"))
         }
-        failsWithErrorMessage("expected <batman> to not begin with <bat>") {
+        failsWithErrorMessage("expected to not begin with <bat>, got <batman>") {
             expect("batman").toNot(beginWith("bat"))
         }
     }

--- a/NimbleTests/Matchers/ContainTest.swift
+++ b/NimbleTests/Matchers/ContainTest.swift
@@ -14,10 +14,10 @@ class ContainTest: XCTestCase {
         expect(NSArray(object: 1) as NSArray?).to(contain(1))
         expect(nil as NSArray?).toNot(contain(1))
 
-        failsWithErrorMessage("expected <[a, b, c]> to contain <bar>") {
+        failsWithErrorMessage("expected to contain <bar>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).to(contain("bar"))
         }
-        failsWithErrorMessage("expected <[a, b, c]> to not contain <b>") {
+        failsWithErrorMessage("expected to not contain <b>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).toNot(contain("b"))
         }
     }
@@ -28,10 +28,10 @@ class ContainTest: XCTestCase {
         expect("foo").toNot(contain("z"))
         expect("foo").toNot(contain("zz"))
 
-        failsWithErrorMessage("expected <foo> to contain <bar>") {
+        failsWithErrorMessage("expected to contain <bar>, got <foo>") {
             expect("foo").to(contain("bar"))
         }
-        failsWithErrorMessage("expected <foo> to not contain <oo>") {
+        failsWithErrorMessage("expected to not contain <oo>, got <foo>") {
             expect("foo").toNot(contain("oo"))
         }
     }
@@ -48,11 +48,11 @@ class ContainTest: XCTestCase {
         expect([1, 2, 3]).to(contain(1, 2))
         expect([1, 2, 3]).toNot(contain(1, 4))
 
-        failsWithErrorMessage("expected <[a, b, c]> to contain <a, bar>") {
+        failsWithErrorMessage("expected to contain <a, bar>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).to(contain("a", "bar"))
         }
 
-        failsWithErrorMessage("expected <[a, b, c]> to not contain <bar, b>") {
+        failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).toNot(contain("bar", "b"))
         }
     }

--- a/NimbleTests/Matchers/EndWithTest.swift
+++ b/NimbleTests/Matchers/EndWithTest.swift
@@ -19,16 +19,16 @@ class EndWithTest: XCTestCase {
     }
 
     func testEndWithNegatives() {
-        failsWithErrorMessage("expected <[1, 2, 3]> to end with <2>") {
+        failsWithErrorMessage("expected to end with <2>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).to(endWith(2))
         }
-        failsWithErrorMessage("expected <[1, 2, 3]> to not end with <3>") {
+        failsWithErrorMessage("expected to not end with <3>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).toNot(endWith(3))
         }
-        failsWithErrorMessage("expected <batman> to end with <atm>") {
+        failsWithErrorMessage("expected to end with <atm>, got <batman>") {
             expect("batman").to(endWith("atm"))
         }
-        failsWithErrorMessage("expected <batman> to not end with <man>") {
+        failsWithErrorMessage("expected to not end with <man>, got <batman>") {
             expect("batman").toNot(endWith("man"))
         }
     }

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -13,10 +13,10 @@ class EqualTest: XCTestCase {
             1
         }.to(equal(1))
 
-        failsWithErrorMessage("expected <hello> to equal <world>") {
+        failsWithErrorMessage("expected to equal <world>, got <hello>") {
             expect("hello").to(equal("world"))
         }
-        failsWithErrorMessage("expected <hello> to not equal <hello>") {
+        failsWithErrorMessage("expected to not equal <hello>, got <hello>") {
             expect("hello").toNot(equal("hello"))
         }
     }
@@ -34,39 +34,39 @@ class EqualTest: XCTestCase {
 
         expect(NSArray(array: [1, 2, 3])).to(equal(NSArray(array: [1, 2, 3])))
 
-        failsWithErrorMessage("expected <[1, 2, 3]> to equal <[1, 2]>") {
+        failsWithErrorMessage("expected to equal <[1, 2]>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).to(equal([1, 2]))
         }
     }
 
     func testDoesNotMatchNils() {
-        failsWithErrorMessage("expected <nil> to equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to equal <nil> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as String?).to(equal(nil as String?))
         }
-        failsWithErrorMessage("expected <foo> to not equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <nil> (will not match nils, use beNil() instead), got <foo>") {
             expect("foo").toNot(equal(nil as String?))
         }
-        failsWithErrorMessage("expected <nil> to not equal <bar> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <bar> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as String?).toNot(equal("bar"))
         }
 
-        failsWithErrorMessage("expected <nil> to equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to equal <nil> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as [Int]?).to(equal(nil as [Int]?))
         }
-        failsWithErrorMessage("expected <nil> to not equal <[1]> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <[1]> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as [Int]?).toNot(equal([1]))
         }
-        failsWithErrorMessage("expected <[1]> to not equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <nil> (will not match nils, use beNil() instead), got <[1]>") {
             expect([1]).toNot(equal(nil as [Int]?))
         }
 
-        failsWithErrorMessage("expected <nil> to equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to equal <nil> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as [Int: Int]?).to(equal(nil as [Int: Int]?))
         }
-        failsWithErrorMessage("expected <nil> to not equal <[1: 1]> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <[1: 1]> (will not match nils, use beNil() instead), got <nil>") {
             expect(nil as [Int: Int]?).toNot(equal([1: 1]))
         }
-        failsWithErrorMessage("expected <[1: 1]> to not equal <nil> (will not match nils, use beNil() instead)") {
+        failsWithErrorMessage("expected to not equal <nil> (will not match nils, use beNil() instead), got <[1: 1]>") {
             expect([1: 1]).toNot(equal(nil as [Int: Int]?))
         }
     }
@@ -96,11 +96,11 @@ class EqualTest: XCTestCase {
         expect("foo") == "foo"
         expect("foo") != "bar"
 
-        failsWithErrorMessage("expected <hello> to equal <world>") {
+        failsWithErrorMessage("expected to equal <world>, got <hello>") {
             expect("hello") == "world"
             return
         }
-        failsWithErrorMessage("expected <hello> to not equal <hello>") {
+        failsWithErrorMessage("expected to not equal <hello>, got <hello>") {
             expect("hello") != "hello"
             return
         }

--- a/NimbleTests/Matchers/MatchTest.swift
+++ b/NimbleTests/Matchers/MatchTest.swift
@@ -11,14 +11,14 @@ class MatchTest:XCTestCase {
     }
     
     func testMatchPositiveMessage() {
-        let message = "expected <hello> to match <\\d{2}:\\d{2}>"
+        let message = "expected to match <\\d{2}:\\d{2}>, got <hello>"
         failsWithErrorMessage(message) {
             expect("hello").to(match("\\d{2}:\\d{2}"))
         }
     }
     
     func testMatchNegativeMessage() {
-        let message = "expected <11:14> to not match <\\d{2}:\\d{2}>"
+        let message = "expected to not match <\\d{2}:\\d{2}>, got <11:14>"
         failsWithErrorMessage(message) {
             expect("11:14").toNot(match("\\d{2}:\\d{2}"))
         }

--- a/NimbleTests/Matchers/beOneOfTest.swift
+++ b/NimbleTests/Matchers/beOneOfTest.swift
@@ -14,10 +14,10 @@ class beOneOfTest: XCTestCase {
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected <1> to not be one of: [1, 2, 3]") {
+        failsWithErrorMessage("expected to not be one of: [1, 2, 3], got <1>") {
             expect(1).toNot(beOneOf([1, 2, 3]))
         }
-        failsWithErrorMessage("expected <4> to be one of: [1, 2, 3]") {
+        failsWithErrorMessage("expected to be one of: [1, 2, 3], got <4>") {
             expect(4).to(beOneOf([1, 2, 3]))
         }
     }

--- a/NimbleTests/SynchronousTests.swift
+++ b/NimbleTests/SynchronousTests.swift
@@ -82,7 +82,7 @@ class SynchronousTest: XCTestCase {
     }
 
     func testToNotNegativeMatches() {
-        failsWithErrorMessage("expected <1> to not match") {
+        failsWithErrorMessage("expected to not match, got <1>") {
             expect(1).toNot(MatcherFunc { expr, failure in true })
         }
     }

--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ By default, Nimble outputs the following failure message when an
 expectation fails:
 
 ```
-expected <\(actual)> to match
+expected to match, got <\(actual)>
 ```
 
 You can customize this message by modifying the `failureMessage` struct
@@ -785,7 +785,7 @@ something else, update the `postfixMessage` property:
 ```swift
 // Swift
 
-// Outputs: expected <\(actual)> to be under the sea
+// Outputs: expected to be under the sea, got <\(actual)>
 failureMessage.postfixMessage = "be under the sea"
 ```
 


### PR DESCRIPTION
Now reported as 'expected to <match>, got <actual>'.

Closes #5.

@Quick/contributors - This does have the incidental consequence of truncating the actual value before the expected value. If it's not an issue, then feel free to merge it in.
