### PR TITLE
Exit polling early if condition is already met

### DIFF
--- a/Nimble/Utils/Poll.swift
+++ b/Nimble/Utils/Poll.swift
@@ -5,8 +5,13 @@ func _pollBlock(#pollInterval: NSTimeInterval, #timeoutInterval: NSTimeInterval,
     var pass: Bool
     do {
         pass = expression()
+        if pass {
+            break
+        }
+
         let runDate = NSDate().dateByAddingTimeInterval(pollInterval) as NSDate
         NSRunLoop.mainRunLoop().runUntilDate(runDate)
-    } while(!pass && NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
+    } while(NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
+
     return pass
 }


### PR DESCRIPTION
Prevents spinning for `pollInterval` when the condition is already met.
