### PR TITLE
Exit polling early if condition is already met

### DIFF
--- a/Nimble/Utils/Poll.swift
+++ b/Nimble/Utils/Poll.swift
@@ -61,9 +61,13 @@ func _pollBlock(#pollInterval: NSTimeInterval, #timeoutInterval: NSTimeInterval,
     var pass: Bool = false
     do {
         pass = expression()
+        if pass {
+            break
+        }
+
         let runDate = NSDate().dateByAddingTimeInterval(pollInterval) as NSDate
         runLoop.runUntilDate(runDate)
-    } while(!pass && NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
+    } while(NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
 
     return pass ? .Success : .Failure
 }


### PR DESCRIPTION
Prevents spinning for `pollInterval` when the condition is already met.
