### PR TITLE
Reduce default toEventually() polling interval to 0.01s

### DIFF
--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -35,21 +35,21 @@ struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Matcher {
 }
 
 extension Expectation {
-    public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.1) {
+    public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         to(AsyncMatcherWrapper(
             fullMatcher: matcher,
             timeoutInterval: timeout,
             pollInterval: pollInterval))
     }
 
-    public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.1) {
+    public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         toNot(AsyncMatcherWrapper(
             fullMatcher: matcher,
             timeoutInterval: timeout,
             pollInterval: pollInterval))
     }
 
-    public func toEventually<U where U: BasicMatcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.1) {
+    public func toEventually<U where U: BasicMatcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         toEventually(
             FullMatcherWrapper(
                 matcher: matcher,
@@ -59,7 +59,7 @@ extension Expectation {
             pollInterval: pollInterval)
     }
 
-    public func toEventuallyNot<U where U: BasicMatcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.1) {
+    public func toEventuallyNot<U where U: BasicMatcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         toEventuallyNot(
             FullMatcherWrapper(
                 matcher: matcher,


### PR DESCRIPTION
This matches Expecta's default polling interval, and can reduce test times (because you don't have to wait ~100ms if you miss the window for passing the test).
