### PR TITLE
Uses built-in equality instead of custom equality.

### DIFF
--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -31,18 +31,7 @@ public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]?) -> NonNilM
             }
             return false
         }
-        var expectedGen = expectedValue!.generate()
-        var actualGen = actualExpression.evaluate()!.generate()
-
-        var expectedItem = expectedGen.next()
-        var actualItem = actualGen.next()
-        var matches = elementsAreEqual(expectedItem, actualItem)
-        while (matches && (actualItem != nil || expectedItem != nil)) {
-            actualItem = actualGen.next()
-            expectedItem = expectedGen.next()
-            matches = elementsAreEqual(expectedItem, actualItem)
-        }
-        return matches
+        return expectedValue! == actualExpression.evaluate()!
     }
 }
 
@@ -57,17 +46,7 @@ public func equal<T: Equatable>(expectedValue: [T]?) -> NonNilMatcherFunc<[T]> {
             }
             return false
         }
-        var expectedGen = expectedValue!.generate()
-        var actualGen = actualExpression.evaluate()!.generate()
-        var expectedItem = expectedGen.next()
-        var actualItem = actualGen.next()
-        var matches = actualItem == expectedItem
-        while (matches && (actualItem != nil || expectedItem != nil)) {
-            actualItem = actualGen.next()
-            expectedItem = expectedGen.next()
-            matches = actualItem == expectedItem
-        }
-        return matches
+        return expectedValue! == actualExpression.evaluate()!
     }
 }
 
@@ -102,15 +81,3 @@ extension NMBObjCMatcher {
         }
     }
 }
-
-
-internal func elementsAreEqual<T: Equatable, C: Equatable>(a: (T, C)?, b: (T, C)?) -> Bool {
-    if a == nil || b == nil {
-        return a == nil && b == nil
-    } else {
-        let (aKey, aValue) = a!
-        let (bKey, bValue) = b!
-        return (aKey == bKey && aValue == bValue)
-    }
-}
-

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -128,4 +128,43 @@ class EqualTest: XCTestCase {
 
         expect(1).toNot(equal(nil))
     }
+
+    func testDictionariesWithDifferentSequences() {
+        // see: https://github.com/Quick/Nimble/issues/61
+        // these dictionaries generate different orderings of sequences.
+        let result = ["how":1, "think":1, "didnt":2, "because":1,
+            "interesting":1, "always":1, "right":1, "such":1,
+            "to":3, "say":1, "cool":1, "you":1,
+            "weather":3, "be":1, "went":1, "was":2,
+            "sometimes":1, "and":3, "mind":1, "rain":1,
+            "whole":1, "everything":1, "weather.":1, "down":1,
+            "kind":1, "mood.":1, "it":2, "everyday":1, "might":1,
+            "more":1, "have":2, "person":1, "could":1, "tenth":2,
+            "night":1, "write":1, "Youd":1, "affects":1, "of":3,
+            "Who":1, "us":1, "an":1, "I":4, "my":1, "much":2,
+            "wrong.":1, "peacefully.":1, "amazing":3, "would":4,
+            "just":1, "grade.":1, "Its":2, "The":2, "had":1, "that":1,
+            "the":5, "best":1, "but":1, "essay":1, "for":1, "summer":2,
+            "your":1, "grade":1, "vary":1, "pretty":1, "at":1, "rain.":1,
+            "about":1, "allow":1, "thought":1, "in":1, "sleep":1, "a":1,
+            "hot":1, "really":1, "beach":1, "life.":1, "we":1, "although":1]
+
+        let storyCount = ["The":2, "summer":2, "of":3, "tenth":2, "grade":1,
+            "was":2, "the":5, "best":1, "my":1, "life.":1, "I":4,
+            "went":1, "to":3, "beach":1, "everyday":1, "and":3,
+            "we":1, "had":1, "amazing":3, "weather.":1, "weather":3,
+            "didnt":2, "really":1, "vary":1, "much":2, "always":1,
+            "pretty":1, "hot":1, "although":1, "sometimes":1, "at":1,
+            "night":1, "it":2, "would":4, "rain.":1, "mind":1, "rain":1,
+            "because":1, "cool":1, "everything":1, "down":1, "allow":1,
+            "us":1, "sleep":1, "peacefully.":1, "Its":2, "how":1,
+            "affects":1, "your":1, "mood.":1, "Who":1, "have":2,
+            "thought":1, "that":1, "could":1, "write":1, "a":1,
+            "whole":1, "essay":1, "just":1, "about":1, "in":1,
+            "grade.":1, "kind":1, "right":1, "Youd":1, "think":1,
+            "for":1, "such":1, "an":1, "interesting":1, "person":1,
+            "might":1, "more":1, "say":1, "but":1, "you":1, "be":1, "wrong.":1]
+
+        expect(result).to(equal(storyCount))
+    }
 }


### PR DESCRIPTION
For swift dictionaries and arrays.

In a beta, Swift dropped support for equality of certain collections.
But the custom implementation Nimble did was broken.

Fixes #61.
