### PR TITLE
DSL: Support waitUntil in Objective-C

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		1FD8CD751968AB07008ED995 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */; };
 		1FD8CD761968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
 		1FD8CD771968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
+		DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
+		DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DD9A9A8F19CF439B00706F49 /* BeIdenticalToObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */; };
 		DD9A9A9019CF43AD00706F49 /* BeIdenticalToObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */; };
 		DDB4D5ED19FE43C200E9D9FE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EC19FE43C200E9D9FE /* Match.swift */; };
@@ -324,6 +326,7 @@
 		1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCMatcher.swift; sourceTree = "<group>"; };
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1FFD729C1963FCAB00CD29A2 /* Nimble-OSXTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Nimble-OSXTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DSL+Wait.swift"; sourceTree = "<group>"; };
 		DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeIdenticalToObjectTest.swift; sourceTree = "<group>"; };
 		DDB4D5EC19FE43C200E9D9FE /* Match.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Match.swift; sourceTree = "<group>"; };
 		DDB4D5EF19FE442800E9D9FE /* MatchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatchTest.swift; sourceTree = "<group>"; };
@@ -398,6 +401,7 @@
 			children = (
 				1FD8CD041968AB07008ED995 /* Adapters */,
 				1FD8CD081968AB07008ED995 /* DSL.swift */,
+				DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */,
 				1FD8CD091968AB07008ED995 /* Expectation.swift */,
 				1FD8CD0A1968AB07008ED995 /* Expression.swift */,
 				1FD8CD0B1968AB07008ED995 /* FailureMessage.swift */,
@@ -762,6 +766,7 @@
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
 				1FD8CD661968AB07008ED995 /* NMBExceptionCapture.m in Sources */,
+				DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */,
 				1FD8CD3E1968AB07008ED995 /* BeAKindOf.swift in Sources */,
 				DDB4D5ED19FE43C200E9D9FE /* Match.swift in Sources */,
 				1FD8CD2E1968AB07008ED995 /* AssertionRecorder.swift in Sources */,
@@ -855,6 +860,7 @@
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,
 				1FD8CD671968AB07008ED995 /* NMBExceptionCapture.m in Sources */,
+				DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */,
 				1FD8CD3F1968AB07008ED995 /* BeAKindOf.swift in Sources */,
 				1FD8CD2F1968AB07008ED995 /* AssertionRecorder.swift in Sources */,
 				DDB4D5EE19FE43C200E9D9FE /* Match.swift in Sources */,

--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Only classes, protocols, methods, properties, and subscript declarations can be
+/// bridges to Objective-C via the @objc keyword. This class encapsulates callback-style
+/// asynchronous waiting logic so that it may be called from Objective-C and Swift.
+@objc public class NMBWait {
+    public class func until(#timeout: NSTimeInterval, action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
+        var completed = false
+        var token: dispatch_once_t = 0
+        let result = pollBlock(pollInterval: 0.01, timeoutInterval: timeout) {
+            dispatch_once(&token) {
+                dispatch_async(dispatch_get_main_queue()) {
+                    action() { completed = true }
+                }
+            }
+            return completed
+        }
+        if result == PollResult.Failure {
+            let pluralize = (timeout == 1 ? "" : "s")
+            fail("Waited more than \(timeout) second\(pluralize)", file: file, line: line)
+        } else if result == PollResult.Timeout {
+            fail("Stall on main thread - too much enqueued on main run loop before waitUntil executes.", file: file, line: line)
+        }
+    }
+
+    public class func until(action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
+        until(timeout: 1, action: action, file: file, line: line)
+    }
+}
+
+/// Wait asynchronously until the done closure is called.
+///
+/// This will advance the run loop.
+public func waitUntil(#timeout: NSTimeInterval, action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
+    NMBWait.until(timeout: timeout, action: action, file: file, line: line)
+}
+
+/// Wait asynchronously until the done closure is called.
+///
+/// This will advance the run loop.
+public func waitUntil(action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
+    NMBWait.until(action, file: file, line: line)
+}

--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
 public func expect<T>(expression: @autoclosure () -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
@@ -14,35 +12,6 @@ public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression
         expression: Expression(
             expression: expression,
             location: SourceLocation(file: file, line: line)))
-}
-
-/// Wait asynchronously until the done closure is called.
-///
-/// This will advance the run loop.
-public func waitUntil(#timeout: NSTimeInterval, action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
-    var completed = false
-    var token: dispatch_once_t = 0
-    let result = pollBlock(pollInterval: 0.01, timeoutInterval: timeout) {
-        dispatch_once(&token) {
-            dispatch_async(dispatch_get_main_queue()) {
-                action() { completed = true }
-            }
-        }
-        return completed
-    }
-    if result == PollResult.Failure {
-        let pluralize = (timeout == 1 ? "" : "s")
-        fail("Waited more than \(timeout) second\(pluralize)", file: file, line: line)
-    } else if result == PollResult.Timeout {
-        fail("Stall on main thread - too much enqueued on main run loop before waitUntil executes.", file: file, line: line)
-    }
-}
-
-/// Wait asynchronously until the done closure is called.
-///
-/// This will advance the run loop.
-public func waitUntil(action: (() -> Void) -> Void, file: String = __FILE__, line: UInt = __LINE__) -> Void {
-    waitUntil(timeout: 1, action, file: file, line: line)
 }
 
 /// Always fails the test with a message and a specified location.

--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -92,8 +92,21 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_match(id expectedValue);
 NIMBLE_SHORT(id<NMBMatcher> match(id expectedValue),
              NMB_match(expectedValue));
 
+// In order to preserve breakpoint behavior despite using macros to fill in __FILE__ and __LINE__,
+// define a builder that populates __FILE__ and __LINE__, and returns a block that takes timeout
+// and action arguments. See https://github.com/Quick/Quick/pull/185 for details.
+typedef void (^NMBWaitUntilTimeoutBlock)(NSTimeInterval timeout, void (^action)(void (^)(void)));
+typedef void (^NMBWaitUntilBlock)(void (^action)(void (^)(void)));
+
+NIMBLE_EXPORT NMBWaitUntilTimeoutBlock nmb_wait_until_timeout_builder(NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBWaitUntilBlock nmb_wait_until_builder(NSString *file, NSUInteger line);
+
+#define NMB_waitUntilTimeout nmb_wait_until_timeout_builder(@(__FILE__), __LINE__)
+#define NMB_waitUntil nmb_wait_until_builder(@(__FILE__), __LINE__)
 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(EXPR) NMB_expect(^id{ return (EXPR); }, __FILE__, __LINE__)
 #define expectAction(EXPR) NMB_expect(^id{ (EXPR); return nil; }, __FILE__, __LINE__)
+#define waitUntilTimeout NMB_waitUntilTimeout
+#define waitUntil NMB_waitUntil
 #endif

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -84,3 +84,14 @@ NIMBLE_EXPORT NMBObjCRaiseExceptionMatcher *NMB_raiseException() {
     return [NMBObjCMatcher raiseExceptionMatcher];
 }
 
+NIMBLE_EXPORT NMBWaitUntilTimeoutBlock nmb_wait_until_timeout_builder(NSString *file, NSUInteger line) {
+    return ^(NSTimeInterval timeout, void (^action)(void (^)(void))) {
+        [NMBWait untilTimeout:timeout action:action file:file line:line];
+    };
+}
+
+NIMBLE_EXPORT NMBWaitUntilBlock nmb_wait_until_builder(NSString *file, NSUInteger line) {
+  return ^(void (^action)(void (^)(void))) {
+    [NMBWait until:action file:file line:line];
+  };
+}

--- a/NimbleTests/objc/ObjCAsyncTest.m
+++ b/NimbleTests/objc/ObjCAsyncTest.m
@@ -25,4 +25,29 @@
     expect(obj).withTimeout(5).toEventuallyNot(beNil());
 }
 
+- (void)testAsyncCallback {
+    waitUntil(^(void (^done)(void)){
+        done();
+    });
+
+    expectFailureMessage(@"Waited more than 1.0 second", ^{
+        waitUntil(^(void (^done)(void)){ /* ... */ });
+    });
+
+    expectFailureMessage(@"Waited more than 0.01 seconds", ^{
+        waitUntilTimeout(0.01, ^(void (^done)(void)){
+            [NSThread sleepForTimeInterval:0.1];
+            done();
+        });
+    });
+
+    expectFailureMessage(@"expected to equal <goodbye>, got <hello>", ^{
+        waitUntil(^(void (^done)(void)){
+            [NSThread sleepForTimeInterval:0.1];
+            expect(@"hello").to(equal(@"goodbye"));
+            done();
+        });
+    });
+}
+
 @end

--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@ waitUntil { done in
 }
 ```
 
+```objc
+// Objective-C
+
+waitUntil(^(void (^done)(void)){
+  // do some stuff that takes a while...
+  [NSThread sleepForTimeInterval:0.5];
+  done();
+});
+```
+
 `waitUntil` also optionally takes a timeout parameter:
 
 ```swift
@@ -312,7 +322,15 @@ waitUntil(timeout: 10) { done in
 }
 ```
 
-> Sorry, Nimble doesn't support waitUntil in Objective-C.
+```objc
+// Objective-C
+
+waitUntilTimeout(10, ^(void (^done)(void)){
+  // do some stuff that takes a while...
+  [NSThread sleepForTimeInterval:1];
+  done();
+});
+```
 
 ## Objective-C Support
 


### PR DESCRIPTION
Support waitUntil in Objective-C.
- Split waitUntil DSL into its own Swift file.
- Convert original waitUntil functions into class methods in order to
  bridge them to Objective-C using the `@objc` keyword.
- Define Objective-C DSLs to call the newly created class methods.
- Add objc tests for the new DSL.
- Update README.

Fixes #71.
