### PR TITLE
[Podspec] Rename Pod to NimbleMatcher

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "Nimble"
+  s.name         = "NimbleMatcher"
   s.version      = "0.2.0"
   s.summary      = "A Matcher Framework for Swift and Objective-C"
   s.description  = <<-DESC


### PR DESCRIPTION
The name [`Nimble`](https://github.com/MarcoSero/Nimble) is already used by another Pod (since early 2013). I think it would be far clearer if this Pod used a different name (NimbleMatcher, or something more suited).

Having two Pods with the same name, means that this Pod cannot be submitted to the [master spec repository](http://github.com/CocoaPods/Specs) and it might be confusing to users when there are two Pods with the same name. It will also prevent being able to use both of these Pods at the same time.

https://github.com/CocoaPods/Specs/blob/master/Specs/Nimble/0.0.1/Nimble.podspec.json