### PR TITLE
Add to Cocoapods Trunk

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author             = "Quick Contributors"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
-  s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v0.2.0" }
+  s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v#{s.version}" }
 
   s.source_files  = "Nimble", "Nimble/**/*.{swift,h,m}"
   s.framework = "XCTest"

--- a/README.md
+++ b/README.md
@@ -971,24 +971,9 @@ install just Nimble.
 
 ## Installing Nimble via CocoaPods
 
-To use Nimble in CocoaPods to test your iOS or OS X applications, we'll need a 
-*Gemfile* that will specify unreleased versions of CocoaPods. Create an empty 
-file called "Gemfile" in your project's directory and add the following lines. 
-
-```ruby
-source 'https://rubygems.org'
-
-gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :branch => 'swift'
-gem 'cocoapods-core', :git => 'https://github.com/CocoaPods/Core.git', :branch => 'swift'
-gem 'xcodeproj',  :git => "https://github.com/CocoaPods/Xcodeproj.git", :branch => 'ext_build_settings'
-```
-
-Now that you have these specified, run `bundle install` from the command line in
-that directory. This will install the prerelease version of CocoaPods. To run
-this version, you'll need to type `bundle exec` in front of your pod commands. 
-
-In that directory, run `bundle exec pod init` to create a blank podfile. iIt 
-will look something like the following (add the line for Nimble).
+To use Nimble in CocoaPods to test your iOS or OS X applications, we'll need to 
+install 0.36 Beta 1 of CocoaPods. Do so using the command `[sudo] gem install cocoapods --pre`. 
+Then just add Nimble to your podfile.
 
 ```ruby
 platform :ios, '8.0'
@@ -997,8 +982,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 # Whatever pods you need for your app go here
 
-target 'YOUR_APP_NAME_HERE_Tests' do
-  pod 'Nimble', :git => "https://github.com/Quick/Nimble"
+target 'YOUR_APP_NAME_HERE_Tests', :exclusive => true do
+  pod 'Nimble'
 end
 ```
 


### PR DESCRIPTION
This is very similar to the [Quick issue](https://github.com/Quick/Quick/pull/239). I'd like to add Nimble to [CocoaPods Trunk](http://guides.cocoapods.org/making/getting-setup-with-trunk.html) so that others may use it more easily and may also write pods using [quick as a dependency](https://github.com/ashfurrow/Nimble-Snapshots/issues/19). This pull requests contains updates to the README, as well as minor edit to the podspec. 

Once this is merged, someone will need to push this to CocoaPods Trunk. As before, I'm happy to do it, happy to add others as owners, and happy to allow someone else to do it altogether. Just let me know, @Quick/owners .