### PR TITLE
`equal` for `Set`s

### DIFF
--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -50,6 +50,35 @@ public func equal<T: Equatable>(expectedValue: [T]?) -> NonNilMatcherFunc<[T]> {
     }
 }
 
+/// A Nimble matcher that succeeds when the actual set is equal to the expected set.
+public func equal<T>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+
+        if let expectedValue = expectedValue {
+            if let actualValue = actualExpression.evaluate() {
+                if expectedValue == actualValue {
+                    return true
+                }
+
+                let missing = expectedValue.subtract(actualValue)
+                if missing.count > 0 {
+                    failureMessage.postfixActual += ", missing <\(stringify(missing))>"
+                }
+
+                let extra = actualValue.subtract(expectedValue)
+                if extra.count > 0 {
+                    failureMessage.postfixActual += ", extra <\(stringify(extra))>"
+                }
+            }
+        } else {
+            failureMessage.postfixActual = " (use beNil() to match nils)"
+        }
+
+        return false
+    }
+}
+
 public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
     lhs.to(equal(rhs))
 }

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -52,11 +52,28 @@ public func equal<T: Equatable>(expectedValue: [T]?) -> NonNilMatcherFunc<[T]> {
 
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.
 public func equal<T>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
+    return equal(expectedValue, stringify: stringify)
+}
+
+/// A Nimble matcher that succeeds when the actual set is equal to the expected set.
+public func equal<T: Comparable>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
+    return equal(expectedValue, stringify: {
+        if let set = $0 {
+            return stringify(Array(set).sorted { $0 < $1 })
+        } else {
+            return "nil"
+        }
+    })
+}
+
+private func equal<T>(expectedValue: Set<T>?, #stringify: Set<T>? -> String) -> NonNilMatcherFunc<Set<T>> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
 
         if let expectedValue = expectedValue {
             if let actualValue = actualExpression.evaluate() {
+                failureMessage.actualValue = "<\(stringify(actualValue))>"
+
                 if expectedValue == actualValue {
                     return true
                 }

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -112,6 +112,22 @@ public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
     lhs.toNot(equal(rhs))
 }
 
+public func ==<T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+    lhs.toNot(equal(rhs))
+}
+
 public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.to(equal(rhs))
 }

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -51,6 +51,14 @@ class EqualTest: XCTestCase {
         failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>") {
             expect(Set([2, 3, 4])).to(equal(Set([1, 2, 3])))
         }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>") {
+            expect(Set([2, 3, 4])) == Set([1, 2, 3])
+        }
+
+        failsWithErrorMessage("expected to not equal <[1, 2, 3]>, got <[1, 2, 3]>") {
+            expect(Set([1, 2, 3])) != Set([1, 2, 3])
+        }
     }
 
     func testDoesNotMatchNils() {

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -39,6 +39,20 @@ class EqualTest: XCTestCase {
         }
     }
 
+    func testSetEquality() {
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3]>, missing <[1]>") {
+            expect(Set([2, 3])).to(equal(Set([1, 2, 3])))
+        }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[1, 2, 3, 4]>, extra <[4]>") {
+            expect(Set([1, 2, 3, 4])).to(equal(Set([1, 2, 3])))
+        }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>") {
+            expect(Set([2, 3, 4])).to(equal(Set([1, 2, 3])))
+        }
+    }
+
     func testDoesNotMatchNils() {
         failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
             expect(nil as String?).to(equal(nil as String?))


### PR DESCRIPTION
Hello, :wave:

I'm comparing `Set`s in my tests.  When there are more than 5 elements, it is hard to read failure messages, because order of elements in the message is non-deterministic.

I wrote a version of `equal` that tells which elements are missing and which are extra.  It also sorts elements if they are `Comparable`.

Example:

    expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>
