### PR TITLE
raiseException() matchers for name, reason and userInfo

### DIFF
--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -1,81 +1,187 @@
 import Foundation
 
-internal func raiseExceptionMatcher<T>(message: String, matches: (NSException?) -> Bool) -> MatcherFunc<T> {
+internal struct RaiseExceptionMatchResult {
+    var success:Bool
+    var nameFailureMessage:FailureMessage?
+    var reasonFailureMessage:FailureMessage?
+    var userInfoFailureMessage:FailureMessage?
+}
+
+internal func raiseExceptionMatcher(matches: (NSException?, SourceLocation) -> RaiseExceptionMatchResult) -> MatcherFunc<Any> {
     return MatcherFunc { actualExpression, failureMessage in
         failureMessage.actualValue = nil
-        failureMessage.postfixMessage = message
-
-        // It would be better if this was part of Expression, but
-        // Swift compiler crashes when expect() is inside a closure.
+        
         var exception: NSException?
-        var result: T?
         var capture = NMBExceptionCapture(handler: ({ e in
             exception = e
-            }), finally: nil)
-
+        }), finally: nil)
+        
         capture.tryBlock {
             actualExpression.evaluate()
             return
         }
-        return matches(exception)
+        
+        let result = matches(exception, actualExpression.location)
+        
+        
+        failureMessage.postfixMessage = "raise exception"
+        
+        if let nameFailureMessage = result.nameFailureMessage {
+            failureMessage.postfixMessage += " named \(nameFailureMessage.postfixMessage)"
+        }
+        if let reasonFailureMessage = result.reasonFailureMessage {
+            failureMessage.postfixMessage += " with reason \(reasonFailureMessage.postfixMessage)"
+        }
+        if let userInfoFailureMessage = result.userInfoFailureMessage {
+            failureMessage.postfixMessage += " with userInfo \(userInfoFailureMessage.postfixMessage)"
+        }
+        if result.nameFailureMessage == nil && result.reasonFailureMessage == nil
+            && result.userInfoFailureMessage == nil {
+                failureMessage.postfixMessage = "raise any exception"
+        }
+        
+        return result.success
     }
+    
+}
+
+// A Nimble matcher that succeeds when the actual expression raises an exception, which name,
+// reason and userInfo match successfully with the provided matchers
+public func raiseException(
+    named: NonNilMatcherFunc<String>? = nil,
+    reason: NonNilMatcherFunc<String>? = nil,
+    userInfo: NonNilMatcherFunc<NSDictionary>? = nil) -> MatcherFunc<Any> {
+        return raiseExceptionMatcher() {
+            exception, location in
+            
+            var matches = exception != nil
+            
+            var nameFailureMessage:FailureMessage?
+            if let nameMatcher = named {
+                let wrapper = NonNilMatcherWrapper(NonNilBasicMatcherWrapper(nameMatcher))
+                nameFailureMessage = FailureMessage()
+                matches = wrapper.matches(
+                    Expression(expression: {exception?.name},
+                        location: location,
+                        isClosure: false),
+                    failureMessage: nameFailureMessage!) && matches
+            }
+            
+            var reasonFailureMessage:FailureMessage?
+            if let reasonMatcher = reason {
+                let wrapper = NonNilMatcherWrapper(NonNilBasicMatcherWrapper(reasonMatcher))
+                reasonFailureMessage = FailureMessage()
+                matches = wrapper.matches(
+                    Expression(expression: {exception?.reason},
+                        location: location,
+                        isClosure: false),
+                    failureMessage: reasonFailureMessage!) && matches
+            }
+            
+            var userInfoFailureMessage:FailureMessage?
+            if let userInfoMatcher = userInfo {
+                let wrapper = NonNilMatcherWrapper(NonNilBasicMatcherWrapper(userInfoMatcher))
+                userInfoFailureMessage = FailureMessage()
+                matches = wrapper.matches(
+                    Expression(expression: {exception?.userInfo},
+                        location: location,
+                        isClosure: false),
+                    failureMessage: userInfoFailureMessage!) && matches
+            }
+            
+            return RaiseExceptionMatchResult(
+                success: matches,
+                nameFailureMessage: nameFailureMessage,
+                reasonFailureMessage: reasonFailureMessage,
+                userInfoFailureMessage: userInfoFailureMessage)
+        }
 }
 
 /// A Nimble matcher that succeeds when the actual expression raises an exception with
 /// the specified name, reason, and userInfo.
 public func raiseException(#named: String, #reason: String, #userInfo: NSDictionary) -> MatcherFunc<Any> {
-    return raiseExceptionMatcher("raise exception named <\(named)> with reason <\(reason)> and userInfo <\(userInfo)>") {
-        exception in
-        return exception?.name == named
-            && exception?.reason == reason
-            && exception?.userInfo == userInfo
-    }
+    return raiseException(named: equal(named), reason: equal(reason), userInfo:equal(userInfo))
 }
 
 /// A Nimble matcher that succeeds when the actual expression raises an exception with
 /// the specified name and reason.
 public func raiseException(#named: String, #reason: String) -> MatcherFunc<Any> {
-    return raiseExceptionMatcher("raise exception named <\(named)> with reason <\(reason)>") {
-        exception in return exception?.name == named && exception?.reason == reason
-    }
+    return raiseException(named: equal(named), reason: equal(reason))
 }
 
 
 /// A Nimble matcher that succeeds when the actual expression raises an exception with
 /// the specified name.
 public func raiseException(#named: String) -> MatcherFunc<Any> {
-    return raiseExceptionMatcher("raise exception named <\(named)>") {
-        exception in return exception?.name == named
-    }
-}
-
-/// A Nimble matcher that succeeds when the actual expression raises any exception.
-/// Please use a more specific raiseException() matcher when possible.
-public func raiseException() -> MatcherFunc<Any> {
-    return raiseExceptionMatcher("raise any exception") {
-        exception in return exception != nil
-    }
+    return raiseException(named: equal(named))
 }
 
 @objc public class NMBObjCRaiseExceptionMatcher : NMBMatcher {
     var _name: String?
     var _reason: String?
     var _userInfo: NSDictionary?
+    var _nameMatcher:NMBMatcher?
+    var _reasonMatcher:NMBMatcher?
+    var _userInfoMatcher:NMBMatcher?
+    
     init(name: String?, reason: String?, userInfo: NSDictionary?) {
         _name = name
         _reason = reason
         _userInfo = userInfo
     }
+    
+    init(nameMatcher:NMBMatcher?, reasonMatcher:NMBMatcher?, userInfoMatcher:NMBMatcher?) {
+        _nameMatcher = nameMatcher
+        _reasonMatcher = reasonMatcher
+        _userInfoMatcher = userInfoMatcher
+    }
 
     public func matches(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let block: () -> Any? = ({ actualBlock(); return nil })
         let expr = Expression(expression: block, location: location)
-        if _name != nil && _reason != nil && _userInfo != nil {
-            return raiseException(named: _name!, reason: _reason!, userInfo: _userInfo!).matches(expr, failureMessage: failureMessage)
-        } else if _name != nil && _reason != nil {
-            return raiseException(named: _name!, reason: _reason!).matches(expr, failureMessage: failureMessage)
-        } else if _name != nil {
-            return raiseException(named: _name!).matches(expr, failureMessage: failureMessage)
+        if _nameMatcher != nil || _reasonMatcher != nil || _userInfoMatcher != nil {
+            return raiseExceptionMatcher() {
+                exception, location in
+                
+                var matches = exception != nil
+                
+                var nameFailureMessage: FailureMessage?
+                if let nameMatcher = self._nameMatcher {
+                    nameFailureMessage = FailureMessage()
+                    matches = nameMatcher.matches({exception?.name},
+                        failureMessage: nameFailureMessage!,
+                        location: location) && matches
+                }
+                
+                var reasonFailureMessage: FailureMessage?
+                if let reasonMatcher = self._reasonMatcher {
+                    reasonFailureMessage = FailureMessage()
+                    matches = reasonMatcher.matches({exception?.reason},
+                        failureMessage: reasonFailureMessage!,
+                        location: location) && matches
+                }
+                
+                var userInfoFailureMessage: FailureMessage?
+                if let userInfoMatcher = self._userInfoMatcher {
+                    userInfoFailureMessage = FailureMessage()
+                    matches = userInfoMatcher.matches({exception?.userInfo},
+                        failureMessage: userInfoFailureMessage!,
+                        location: location) && matches
+                }
+                
+                return RaiseExceptionMatchResult(
+                    success: matches,
+                    nameFailureMessage: nameFailureMessage,
+                    reasonFailureMessage: reasonFailureMessage,
+                    userInfoFailureMessage: userInfoFailureMessage)
+                
+            }.matches(expr, failureMessage: failureMessage)
+        } else if let name = _name, reason = _reason, userInfo = _userInfo {
+            return raiseException(named: name, reason: reason, userInfo: userInfo).matches(expr, failureMessage: failureMessage)
+        } else if let name = _name, reason = _reason {
+            return raiseException(named: name, reason: reason).matches(expr, failureMessage: failureMessage)
+        } else if let name = _name {
+            return raiseException(named: name).matches(expr, failureMessage: failureMessage)
         } else {
             return raiseException().matches(expr, failureMessage: failureMessage)
         }
@@ -100,6 +206,27 @@ public func raiseException() -> MatcherFunc<Any> {
     public var userInfo: (userInfo: NSDictionary?) -> NMBObjCRaiseExceptionMatcher {
         return ({ userInfo in
             return NMBObjCRaiseExceptionMatcher(name: self._name, reason: self._reason, userInfo: userInfo)
+        })
+    }
+    
+    public var withName: (nameMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
+        return ({ nameMatcher in
+            return NMBObjCRaiseExceptionMatcher(nameMatcher: nameMatcher,
+                reasonMatcher: self._reasonMatcher, userInfoMatcher: self._userInfoMatcher)
+        })
+    }
+    
+    public var withReason: (reasonMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
+        return ({ reasonMatcher in
+            return NMBObjCRaiseExceptionMatcher(nameMatcher: self._nameMatcher,
+                reasonMatcher: reasonMatcher, userInfoMatcher: self._userInfoMatcher)
+        })
+    }
+    
+    public var withUserInfo: (userInfoMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
+        return ({ userInfoMatcher in
+            return NMBObjCRaiseExceptionMatcher(nameMatcher: self._nameMatcher,
+                reasonMatcher: self._reasonMatcher, userInfoMatcher: userInfoMatcher)
         })
     }
 }

--- a/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -9,36 +9,33 @@ class RaisesExceptionTest: XCTestCase {
         expect { self.exception.raise() }.to(raiseException(named: "laugh"))
         expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz"))
         expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
-
-        expect {
-            self.exception.raise()
-        }.to(raiseException())
-
-        expect {
-            self.exception.raise()
-        }.to(raiseException(named: "laugh"))
-
-
-        expect {
-            self.exception.raise()
-        }.to(raiseException(named: "laugh", reason: "Lulz"))
-
-
-        expect {
-            self.exception.raise()
-        }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
+    }
+    
+    func testPositiveMatchesWithSubMatchers() {
+        expect { self.exception.raise() }.to(raiseException(named: equal("laugh")))
+        expect { self.exception.raise() }.to(raiseException(reason: beginWith("Lu")))
+        expect { self.exception.raise() }.to(raiseException(userInfo:equal(["key": "value"])))
+        expect { self.exception.raise() }.to(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+        expect { self.exception.raise() }.to(
+            raiseException(named: equal("laugh"), reason: beginWith("Lu"), userInfo:equal(["key": "value"])))
+        expect { self.exception.raise() }.toNot(raiseException(named: equal("smile")))
+        expect { self.exception.raise() }.toNot(raiseException(reason: beginWith("Lut")))
+        expect { self.exception.raise() }.toNot(raiseException(userInfo:equal(["key": "no value"])))
+        expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lut")))
+        expect { self.exception }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected to raise exception named <foo>") {
+        failsWithErrorMessage("expected to raise exception named equal <foo>") {
             expect { self.exception.raise() }.to(raiseException(named: "foo"))
         }
 
-        failsWithErrorMessage("expected to raise exception named <laugh> with reason <bar>") {
+        failsWithErrorMessage("expected to raise exception named equal <laugh> with reason equal <bar>") {
             expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "bar"))
         }
 
-        failsWithErrorMessage("expected to raise exception named <laugh> with reason <Lulz> and userInfo <{k = v;}>") {
+        failsWithErrorMessage(
+            "expected to raise exception named equal <laugh> with reason equal <Lulz> with userInfo equal <{k = v;}>") {
             expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["k": "v"]))
         }
 
@@ -48,21 +45,58 @@ class RaisesExceptionTest: XCTestCase {
         failsWithErrorMessage("expected to not raise any exception") {
             expect { self.exception.raise() }.toNot(raiseException())
         }
-        failsWithErrorMessage("expected to raise exception named <laugh> with reason <Lulz>") {
+        failsWithErrorMessage("expected to raise exception named equal <laugh> with reason equal <Lulz>") {
             expect { self.exception }.to(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to raise exception named <bar> with reason <Lulz>") {
+        failsWithErrorMessage("expected to raise exception named equal <bar> with reason equal <Lulz>") {
             expect { self.exception.raise() }.to(raiseException(named: "bar", reason: "Lulz"))
         }
-        failsWithErrorMessage("expected to not raise exception named <laugh>") {
+        failsWithErrorMessage("expected to not raise exception named equal <laugh>") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh"))
         }
-        failsWithErrorMessage("expected to not raise exception named <laugh> with reason <Lulz>") {
+        failsWithErrorMessage("expected to not raise exception named equal <laugh> with reason equal <Lulz>") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz"))
         }
-        failsWithErrorMessage("expected to not raise exception named <laugh> with reason <Lulz> and userInfo <{key = value;}>") {
+        
+        failsWithErrorMessage("expected to not raise exception named equal <laugh> with reason equal <Lulz> with userInfo equal <{key = value;}>") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
         }
     }
+    
+    func testNegativeMatchesWithSubMatchers() {
+        failsWithErrorMessage("expected to raise exception named equal <foo> with reason begin with <bar>") {
+            expect { self.exception.raise() }.to(raiseException(named: equal("foo"), reason: beginWith("bar")))
+        }
+
+        failsWithErrorMessage("expected to raise exception named equal <foo>") {
+            expect { self.exception.raise() }.to(raiseException(named: equal("foo")))
+        }
+        
+        failsWithErrorMessage("expected to raise exception with reason begin with <bar>") {
+            expect { self.exception.raise() }.to(raiseException(reason: beginWith("bar")))
+        }
+        
+        failsWithErrorMessage("expected to raise exception with userInfo equal <{k = v;}>") {
+            expect { self.exception.raise() }.to(raiseException(userInfo: equal(["k": "v"])))
+        }
+        
+        failsWithErrorMessage("expected to not raise exception named equal <laugh> with reason begin with <Lu>") {
+            expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+        }
+
+        failsWithErrorMessage("expected to not raise exception named equal <laugh>") {
+            expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh")))
+        }
+        
+        failsWithErrorMessage("expected to not raise exception with reason begin with <Lu>") {
+            expect { self.exception.raise() }.toNot(raiseException(reason: beginWith("Lu")))
+        }
+        
+        failsWithErrorMessage("expected to raise exception named equal <laugh> with reason begin with <Lu>") {
+            expect { self.exception }.to(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+        }
+    }
+    
+
 }

--- a/NimbleTests/objc/ObjCRaiseExceptionTest.m
+++ b/NimbleTests/objc/ObjCRaiseExceptionTest.m
@@ -24,6 +24,18 @@
     expectAction(exception).toNot(raiseException());
 }
 
+- (void)testPositiveMatchesWithSubMatchers {
+    __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
+                                                             reason:@"No food"
+                                                           userInfo:@{@"key": @"value"}];
+    expectAction([exception raise]).to(raiseException().
+                                       withName(equal(NSInvalidArgumentException)).
+                                       withReason(beginWith(@"No")));
+    expectAction([exception raise]).to(raiseException().
+                                       withName(equal(NSInvalidArgumentException)));
+    expectAction([exception raise]).toNot(raiseException().withReason(beginWith(@"Much")));
+}
+
 - (void)testNegativeMatches {
     __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
                                                              reason:@"No food"
@@ -32,18 +44,18 @@
         expectAction([exception reason]).to(raiseException());
     });
 
-    expectFailureMessage(@"expected to raise exception named <foo>", ^{
+    expectFailureMessage(@"expected to raise exception named equal <foo>", ^{
         expectAction([exception reason]).to(raiseException().
                                             named(@"foo"));
     });
 
-    expectFailureMessage(@"expected to raise exception named <NSInvalidArgumentException> with reason <cakes>", ^{
+    expectFailureMessage(@"expected to raise exception named equal <NSInvalidArgumentException> with reason equal <cakes>", ^{
         expectAction([exception reason]).to(raiseException().
                                             named(NSInvalidArgumentException).
                                             reason(@"cakes"));
     });
 
-    expectFailureMessage(@"expected to raise exception named <NSInvalidArgumentException> with reason <No food> and userInfo <{k = v;}>", ^{
+    expectFailureMessage(@"expected to raise exception named equal <NSInvalidArgumentException> with reason equal <No food> with userInfo equal <{k = v;}>", ^{
         expectAction([exception reason]).to(raiseException().
                                             named(NSInvalidArgumentException).
                                             reason(@"No food").
@@ -53,6 +65,36 @@
 
     expectFailureMessage(@"expected to not raise any exception", ^{
         expectAction([exception raise]).toNot(raiseException());
+    });
+}
+
+- (void)testNegativeMatchesWithSubMatchers {
+    __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
+                                                             reason:@"No food"
+                                                           userInfo:@{@"key": @"value"}];
+    
+    expectFailureMessage(@"expected to raise exception named equal <NSInvalidArgumentException> with reason begin with <Much>", ^{
+        expectAction([exception raise]).to(raiseException().
+                                              withName(equal(NSInvalidArgumentException)).
+                                              withReason(beginWith(@"Much")));
+    });
+    expectFailureMessage(@"expected to raise exception with reason begin with <Much>", ^{
+        expectAction([exception raise]).to(raiseException().
+                                           withReason(beginWith(@"Much")));
+    });
+    
+    expectFailureMessage(@"expected to not raise exception named equal <NSInvalidArgumentException> with reason begin with <No>", ^{
+        expectAction([exception raise]).toNot(raiseException().
+                                           withName(equal(NSInvalidArgumentException)).
+                                           withReason(beginWith(@"No")));
+    });
+    expectFailureMessage(@"expected to not raise exception named equal <NSInvalidArgumentException>", ^{
+        expectAction([exception raise]).toNot(raiseException().
+                                              withName(equal(NSInvalidArgumentException)));
+    });
+    expectFailureMessage(@"expected to not raise exception with userInfo equal <{key = value;}>", ^{
+        expectAction([exception raise]).toNot(raiseException().
+                                              withUserInfo(equal(@{@"key": @"value"})));
     });
 }
 

--- a/README.md
+++ b/README.md
@@ -629,6 +629,16 @@ expect(actual).to(raiseException(named: name))
 
 // Passes if actual raises an exception with the given name and reason:
 expect(actual).to(raiseException(named: name, reason: reason))
+
+// Passes if actual raises an exception with a name equal "a name" 
+expect(actual).to(raiseException(named: equal("a name")))
+
+// Passes if actual raises an exception with a reason that begins with "a r"
+expect(actual).to(raiseException(reason: beginWith("a r")))
+
+// Passes if actual raises an exception with a name equal "a name" 
+// and a reason that begins with "a r"
+expect(actual).to(raiseException(named: equal("a name"), reason: beginWith("a r")))
 ```
 
 ```objc
@@ -636,12 +646,26 @@ expect(actual).to(raiseException(named: name, reason: reason))
 
 // Passes if actual, when evaluated, raises an exception:
 expect(actual).to(raiseException())
+
+// Passes if actual raises an exception with the given name
+expect(actual).to(raiseException().named(name))
+
+// Passes if actual raises an exception with the given name and reason:
+expect(actual).to(raiseException().named(name).reason(reason))
+
+// Passes if actual raises an exception with a name equal "a name" 
+expect(actual).to(raiseException().withName(equal("a name")))
+
+// Passes if actual raises an exception with a reason that begins with "a r"
+expect(actual).to(raiseException().withName(withReason(beginWith(@"a r")))
+
+// Passes if actual raises an exception with a name equal "a name" 
+// and a reason that begins with "a r"
+expect(actual).to(raiseException().withName(equal("a name")).withReason(beginWith(@"a r")))
 ```
 
 Note: Swift currently doesn't have exceptions. Only Objective-C code can raise
 exceptions that Nimble will catch.
-
-> Sorry, [Nimble doesn't support matching on exception `name`, `reason`, or `userInfo` yet](https://github.com/Quick/Nimble/issues/26).
 
 ## Collection Membership
 


### PR DESCRIPTION
This implements https://github.com/Quick/Nimble/issues/96 .

All other raiseException() matcher functions are still available, but as they also use the variant using matchers for name, reason and userInfo, the failure messages look a bit different.

There's currently no way to test that the reason is nil as only NonNilMatcherFuncs are accepted.