### PR TITLE
expect(...) uses a lazy autoclosure again.

### DIFF
--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -1,18 +1,10 @@
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(expression: () -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
             location: SourceLocation(file: file, line: line),
             isClosure: true))
-}
-
-public func expect<T>(value: T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
-    return Expectation(
-        expression: Expression(
-            expression: { value },
-            location: SourceLocation(file: file, line: line),
-            isClosure: false))
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -2,13 +2,7 @@ import XCTest
 import Nimble
 
 class AsyncTest: XCTestCase {
-    func testAsyncWithValue() {
-        failsWithErrorMessage("expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function") {
-            expect(0).toEventually(equal(1))
-        }
-    }
-
-    func testAsyncPolling() {
+    func testAsyncTestnigViaEventually() {
         var value = 0
         deferToMainQueue { value = 1 }
         expect { value }.toEventually(equal(1))
@@ -24,7 +18,7 @@ class AsyncTest: XCTestCase {
         }
     }
 
-    func testAsyncCallback() {
+    func testAsyncTestingViaWaitUntil() {
         waitUntil { done in
             done()
         }

--- a/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -1,17 +1,17 @@
 import XCTest
 import Nimble
 
-class BeIdenticalToObjectTest:XCTestCase {
+class BeIdenticalToObjectTest: XCTestCase {
     private class BeIdenticalToObjectTester {}
     private let testObjectA = BeIdenticalToObjectTester()
     private let testObjectB = BeIdenticalToObjectTester()
 
     func testBeIdenticalToPositive() {
-        expect(testObjectA).to(beIdenticalTo(testObjectA))
+        expect(self.testObjectA).to(beIdenticalTo(testObjectA))
     }
     
     func testBeIdenticalToNegative() {
-        expect(testObjectA).toNot(beIdenticalTo(testObjectB))
+        expect(self.testObjectA).toNot(beIdenticalTo(testObjectB))
     }
     
     func testBeIdenticalToPositiveMessage() {
@@ -45,8 +45,8 @@ class BeIdenticalToObjectTest:XCTestCase {
     }
     
     func testOperators() {
-        expect(testObjectA) === testObjectA
-        expect(testObjectA) !== testObjectB
+        expect(self.testObjectA) === testObjectA
+        expect(self.testObjectA) !== testObjectB
     }
 
 }

--- a/NimbleTests/Matchers/BeNilTest.swift
+++ b/NimbleTests/Matchers/BeNilTest.swift
@@ -9,7 +9,7 @@ class BeNilTest: XCTestCase {
     func testBeNil() {
         expect(nil as Int?).to(beNil())
         expect(1 as Int?).toNot(beNil())
-        expect(producesNil()).to(beNil())
+        expect(self.producesNil()).to(beNil())
 
         failsWithErrorMessage("expected to not be nil, got <nil>") {
             expect(nil as Int?).toNot(beNil())


### PR DESCRIPTION
Xcode 6.3 beta 2 reintroduced this feature with `@autoclosure(escaping)`.

Addresses https://github.com/Quick/Quick/issues/251 after Quick updates Nimble.

Closes #89.