### PR TITLE
Remove default interval values for Swift 1.2 beta 3 compatibility

### DIFF
--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -2,8 +2,8 @@ import Foundation
 
 struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Matcher {
     let fullMatcher: U
-    let timeoutInterval: NSTimeInterval = 1
-    let pollInterval: NSTimeInterval = 0.01
+    let timeoutInterval: NSTimeInterval
+    let pollInterval: NSTimeInterval
 
     func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
         let uncachedExpression = actualExpression.withoutCaching()


### PR DESCRIPTION
Xcode 6.3 beta 3 with Swift 1.2 has a stricter policy on default property values and does not allow their redefinition during initialization.