### PR TITLE
Updated Install Instructions in the README for CocoaPods Version 0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,4 +1057,4 @@ To use Nimble with Swift 1.2, you'll currently need to use Version 0.4.0 of Nimb
 ```
 
 
-Finally run `bundle exec pod install`. 
+Finally run `pod install`. 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ expect(ocean).toEventually(contain("starfish"), timeout: 3)
 // Waits three seconds for ocean to contain "starfish":
 expect(ocean).withTimeout(3).toEventually(contain(@"starfish"));
 ```
-
+c
 You can also provide a callback by using the `waitUntil` function:
 
 ```swift
@@ -1013,8 +1013,7 @@ extension NMBObjCMatcher {
   Quick and Nimble, follow [the installation instructions in the Quick
   README](https://github.com/Quick/Quick#how-to-install-quick).
 
-Nimble can currently be installed in one of two ways: using a pre-release 
-version of CocoaPods, or with git submodules. The master branch of
+Nimble can currently be installed in one of two ways: using CocoaPods, or with git submodules. The master branch of
 Nimble supports Swift 1.2. For Swift 1.1 support, use the `swift-1.1`
 branch.
 
@@ -1035,9 +1034,8 @@ install just Nimble.
 
 ## Installing Nimble via CocoaPods
 
-To use Nimble in CocoaPods to test your iOS or OS X applications, we'll need to 
-install 0.36 Beta 1 of CocoaPods. Do so using the command `[sudo] gem install cocoapods --pre`. 
-Then just add Nimble to your podfile.
+To use Nimble in CocoaPods to test your iOS or OS X applications, update CocoaPods to Version 0.36.0.
+Then just add Nimble to your podfile and add the ```use_frameworks!``` line to enable Switf support for Cocoapods.
 
 ```ruby
 platform :ios, '8.0'
@@ -1047,8 +1045,16 @@ source 'https://github.com/CocoaPods/Specs.git'
 # Whatever pods you need for your app go here
 
 target 'YOUR_APP_NAME_HERE_Tests', :exclusive => true do
+  use_frameworks!
   pod 'Nimble'
 end
 ```
+
+To use Nimble with Swift 1.2, you'll currently need to use Version 0.4.0 of Nimble. To do so, change extend the line in your Podfile:
+
+```ruby
+  pod 'Nimble', :git => 'git@github.com:Quick/Nimble.git', :tag => 'v0.4.0'
+```
+
 
 Finally run `bundle exec pod install`. 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ expect(ocean).toEventually(contain("starfish"), timeout: 3)
 // Waits three seconds for ocean to contain "starfish":
 expect(ocean).withTimeout(3).toEventually(contain(@"starfish"));
 ```
-c
+
 You can also provide a callback by using the `waitUntil` function:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,7 @@ target 'YOUR_APP_NAME_HERE_Tests', :exclusive => true do
 end
 ```
 
-To use Nimble with Swift 1.2, you'll currently need to use Version 0.4.0 of Nimble. To do so, change extend the line in your Podfile:
+To use Nimble with Swift 1.2, you'll currently need to use Version 0.4.0 of Nimble. To do so, extend the line in your Podfile:
 
 ```ruby
   pod 'Nimble', :git => 'git@github.com:Quick/Nimble.git', :tag => 'v0.4.0'


### PR DESCRIPTION
CocoaPods has been updated to Version 0.36.0, so the install instructions had to be updated.

This fixes #104 

Additionally, I have added a short note about using Nimble with Swift 1.2, since it seems that Nimble v0.4.0 has not yet been published to the central Podspec repo. I'll also add a similar note to the install instructions for Quick as well.

This note can be removed once Nimble v0.4.0 is published there.

Also, I've changed the install command from ```bundle exec pod install``` to only ```pod install``` because in the install instructions for Quick also just has ```pod install```. Or was there any particular reason to use bundle? 