### PR TITLE
Refactors

### DIFF
--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Only classes, protocols, methods, properties, and subscript declarations can be
 /// bridges to Objective-C via the @objc keyword. This class encapsulates callback-style
 /// asynchronous waiting logic so that it may be called from Objective-C and Swift.
-@objc public class NMBWait {
-    public class func until(#timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+@objc internal class NMBWait {
+    internal class func until(#timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         var completed = false
         var token: dispatch_once_t = 0
         let result = pollBlock(pollInterval: 0.01, timeoutInterval: timeout) {
@@ -23,7 +23,7 @@ import Foundation
         }
     }
 
-    public class func until(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    internal class func until(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
 }

--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -106,11 +106,11 @@ NIMBLE_SHORT(id<NMBMatcher> allPass(id matcher),
 typedef void (^NMBWaitUntilTimeoutBlock)(NSTimeInterval timeout, void (^action)(void (^)(void)));
 typedef void (^NMBWaitUntilBlock)(void (^action)(void (^)(void)));
 
-NIMBLE_EXPORT NMBWaitUntilTimeoutBlock nmb_wait_until_timeout_builder(NSString *file, NSUInteger line);
-NIMBLE_EXPORT NMBWaitUntilBlock nmb_wait_until_builder(NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line);
 
-#define NMB_waitUntilTimeout nmb_wait_until_timeout_builder(@(__FILE__), __LINE__)
-#define NMB_waitUntil nmb_wait_until_builder(@(__FILE__), __LINE__)
+#define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
+#define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, __FILE__, __LINE__)

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -1,6 +1,14 @@
 #import <Nimble/DSL.h>
 #import <Nimble/Nimble-Swift.h>
 
+SWIFT_CLASS("_TtC6Nimble7NMBWait")
+@interface NMBWait : NSObject
+
++ (void)untilTimeout:(NSTimeInterval)timeout file:(NSString *)file line:(NSUInteger)line action:(void(^)())action;
++ (void)untilFile:(NSString *)file line:(NSUInteger)line action:(void(^)())action;
+
+@end
+
 NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, unsigned int line) {
     return [[NMBExpectation alloc] initWithActualBlock:actualBlock
                                               negative:NO
@@ -92,13 +100,13 @@ NIMBLE_EXPORT NMBObjCRaiseExceptionMatcher *NMB_raiseException() {
     return [NMBObjCMatcher raiseExceptionMatcher];
 }
 
-NIMBLE_EXPORT NMBWaitUntilTimeoutBlock nmb_wait_until_timeout_builder(NSString *file, NSUInteger line) {
+NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line) {
     return ^(NSTimeInterval timeout, void (^action)(void (^)(void))) {
         [NMBWait untilTimeout:timeout file:file line:line action:action];
     };
 }
 
-NIMBLE_EXPORT NMBWaitUntilBlock nmb_wait_until_builder(NSString *file, NSUInteger line) {
+NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line) {
   return ^(void (^action)(void (^)(void))) {
     [NMBWait untilFile:file line:line action:action];
   };

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class AsyncTest: XCTestCase {
-    func testAsyncTestnigViaEventually() {
+    func testAsyncTestingViaEventually() {
         var value = 0
         deferToMainQueue { value = 1 }
         expect { value }.toEventually(equal(1))


### PR DESCRIPTION
For 1.0:

- Privatized NMBWait class
- nmb_wait_until_*_builders are now camel cased
- fixed test name typo