### PR TITLE
AssertionHandler receives FailureMessage instead of String

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		1FD8CD751968AB07008ED995 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */; };
 		1FD8CD761968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
 		1FD8CD771968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
+		1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
+		1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
 		DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DD72EC641A93874A002F7651 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
@@ -327,6 +329,7 @@
 		1FD8CD2A1968AB07008ED995 /* AsyncMatcherWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncMatcherWrapper.swift; sourceTree = "<group>"; };
 		1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatcherFunc.swift; sourceTree = "<group>"; };
 		1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCMatcher.swift; sourceTree = "<group>"; };
+		1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionDispatcher.swift; sourceTree = "<group>"; };
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1FFD729C1963FCAB00CD29A2 /* Nimble-OSXTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Nimble-OSXTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DSL+Wait.swift"; sourceTree = "<group>"; };
@@ -483,6 +486,7 @@
 				1FD8CD051968AB07008ED995 /* AssertionRecorder.swift */,
 				1FD8CD061968AB07008ED995 /* AdapterProtocols.swift */,
 				1FD8CD071968AB07008ED995 /* NimbleXCTestHandler.swift */,
+				1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */,
 			);
 			path = Adapters;
 			sourceTree = "<group>";
@@ -769,6 +773,7 @@
 				1F43728F1A1B344000EB80F8 /* Stringers.swift in Sources */,
 				1F43728D1A1B343D00EB80F8 /* SourceLocation.swift in Sources */,
 				1FD8CD4E1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
+				1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728A1A1B343800EB80F8 /* Functional.swift in Sources */,
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -865,6 +870,7 @@
 				1F43728E1A1B343F00EB80F8 /* Stringers.swift in Sources */,
 				1F43728C1A1B343C00EB80F8 /* SourceLocation.swift in Sources */,
 				1FD8CD4F1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
+				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728B1A1B343900EB80F8 /* Functional.swift in Sources */,
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,

--- a/Nimble.xcodeproj/project.xcworkspace/xcshareddata/Nimble.xccheckout
+++ b/Nimble.xcodeproj/project.xcworkspace/xcshareddata/Nimble.xccheckout
@@ -7,21 +7,21 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>3C7A95C5-450E-4971-8DC4-2613B2BA4376</string>
 	<key>IDESourceControlProjectName</key>
-	<string>Nimble</string>
+	<string>project</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>95438028B10BBB846574013D29F154A00556A9D1</key>
-		<string>github.com:quick/Nimble.git</string>
+		<string>github.com:Quick/Nimble</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Nimble.xcodeproj</string>
+	<string>Nimble.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>95438028B10BBB846574013D29F154A00556A9D1</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>github.com:quick/Nimble.git</string>
+	<string>github.com:Quick/Nimble</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>

--- a/Nimble/Adapters/AdapterProtocols.swift
+++ b/Nimble/Adapters/AdapterProtocols.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Protocol for the assertion handler that Nimble uses for all expectations.
 public protocol AssertionHandler {
-    func assert(assertion: Bool, message: String, location: SourceLocation)
+    func assert(assertion: Bool, message: FailureMessage, location: SourceLocation)
 }
 
 /// Global backing interface for assertions that Nimble creates.

--- a/Nimble/Adapters/AssertionDispatcher.swift
+++ b/Nimble/Adapters/AssertionDispatcher.swift
@@ -1,0 +1,20 @@
+
+/// AssertionDispatcher allows multiple AssertionHandlers to receive
+/// assertion messages.
+///
+/// @warning Does not fully dispatch if one of the handlers raises an exception.
+///          This is possible with XCTest-based assertion handlers.
+///
+public class AssertionDispatcher: AssertionHandler {
+    let handlers: [AssertionHandler]
+
+    public init(handlers: [AssertionHandler]) {
+        self.handlers = handlers
+    }
+
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        for handler in handlers {
+            handler.assert(assertion, message: message, location: location)
+        }
+    }
+}

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -5,13 +5,17 @@ import Foundation
 ///
 /// @see AssertionRecorder
 /// @see AssertionHandler
-public struct AssertionRecord {
+public struct AssertionRecord: Printable {
     /// Whether the assertion succeeded or failed
     public let success: Bool
     /// The failure message the assertion would display on failure.
-    public let message: String
+    public let message: FailureMessage
     /// The source location the expectation occurred on.
     public let location: SourceLocation
+
+    public var description: String {
+        return "AssertionRecord { success=\(success), message='\(message.stringValue)', location=\(location) }"
+    }
 }
 
 /// An AssertionHandler that silently records assertions that Nimble makes.
@@ -24,7 +28,7 @@ public class AssertionRecorder : AssertionHandler {
 
     public init() {}
 
-    public func assert(assertion: Bool, message: String, location: SourceLocation) {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
         assertions.append(
             AssertionRecord(
                 success: assertion,

--- a/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -4,9 +4,25 @@ import XCTest
 /// Default handler for Nimble. This assertion handler passes failures along to
 /// XCTest.
 public class NimbleXCTestHandler : AssertionHandler {
-    public func assert(assertion: Bool, message: String, location: SourceLocation) {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
         if !assertion {
-            XCTFail(message, file: location.file, line: location.line)
+            XCTFail("\(message.stringValue)\n", file: location.file, line: location.line)
+        }
+    }
+}
+
+/// Alternative handler for Nimble. This assertion handler passes failures along
+/// to XCTest by attempting to reduce the failure message size.
+public class NimbleShortXCTestHandler: AssertionHandler {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        if !assertion {
+            let msg: String
+            if let actual = message.actualValue {
+                msg = "got: \(actual) \(message.postfixActual)"
+            } else {
+                msg = "expected \(message.to) \(message.postfixMessage)"
+            }
+            XCTFail("\(msg)\n", file: location.file, line: location.line)
         }
     }
 }

--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -18,7 +18,7 @@ public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression
 
 /// Always fails the test with a message and a specified location.
 public func fail(message: String, #location: SourceLocation) {
-    NimbleAssertionHandler.assert(false, message: message, location: location)
+    NimbleAssertionHandler.assert(false, message: FailureMessage(stringValue: message), location: location)
 }
 
 /// Always fails the test with a message.

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -23,20 +23,25 @@ internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(ex
 public struct Expectation<T> {
     let expression: Expression<T>
 
-    public func verify(pass: Bool, _ message: String) {
+    public func verify(pass: Bool, _ message: FailureMessage) {
         NimbleAssertionHandler.assert(pass, message: message, location: expression.location)
     }
 
+    /// Tests the actual value using a matcher to match.
     public func to<U where U: Matcher, U.ValueType == T>(matcher: U) {
         let (pass, msg) = expressionMatches(expression, matcher, to: "to")
-        verify(pass, msg.stringValue)
+        verify(pass, msg)
     }
 
+    /// Tests the actual value using a matcher to not match.
     public func toNot<U where U: Matcher, U.ValueType == T>(matcher: U) {
         let (pass, msg) = expressionDoesNotMatch(expression, matcher, toNot: "to not")
-        verify(pass, msg.stringValue)
+        verify(pass, msg)
     }
 
+    /// Tests the actual value using a matcher to not match.
+    ///
+    /// Alias to toNot().
     public func notTo<U where U: Matcher, U.ValueType == T>(matcher: U) {
         toNot(matcher)
     }

--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -1,28 +1,14 @@
 import Foundation
 
-@objc
-public class FailureMessage {
+/// Encapsulates the failure message that matchers can report to the end user.
+///
+/// This is shared state between Nimble and matchers that mutate this value.
+@objc public class FailureMessage {
     public var expected: String = "expected"
     public var actualValue: String? = "" // empty string -> use default; nil -> exclude
     public var to: String = "to"
     public var postfixMessage: String = "match"
     public var postfixActual: String = ""
-
-    internal var _stringValueOverride: String?
-
-    public init() {
-    }
-
-    internal func computeStringValue() -> String {
-        var value = "\(expected) \(to) \(postfixMessage)"
-        if let actualValue = actualValue {
-            value = "\(expected) \(to) \(postfixMessage), got \(actualValue)\(postfixActual)"
-        }
-        var lines: [String] = (value as NSString).componentsSeparatedByString("\n") as! [String]
-        let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
-        return "".join(lines)
-    }
 
     public var stringValue: String {
         get {
@@ -35,5 +21,29 @@ public class FailureMessage {
         set {
             _stringValueOverride = newValue
         }
+    }
+
+    internal var _stringValueOverride: String?
+
+    public init() {
+    }
+
+    public init(stringValue: String) {
+        _stringValueOverride = stringValue
+    }
+
+    internal func stripNewlines(str: String) -> String {
+        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as! [String]
+        let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
+        return "".join(lines)
+    }
+
+    internal func computeStringValue() -> String {
+        var value = "\(expected) \(to) \(postfixMessage)"
+        if let actualValue = actualValue {
+            value = "\(expected) \(to) \(postfixMessage), got \(actualValue)\(postfixActual)"
+        }
+        return stripNewlines(value)
     }
 }

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -40,10 +40,12 @@ internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Ma
     }
 }
 
-private let toEventuallyRequiresClosureError = "expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function"
+private let toEventuallyRequiresClosureError = FailureMessage(stringValue: "expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function")
 
 
 extension Expectation {
+    /// Tests the actual value using a matcher to match by checking continuously
+    /// at each pollInterval until the timeout is reached.
     public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         if expression.isClosure {
             let (pass, msg) = expressionMatches(
@@ -54,12 +56,14 @@ extension Expectation {
                     pollInterval: pollInterval),
                 to: "to eventually"
             )
-            verify(pass, msg.stringValue)
+            verify(pass, msg)
         } else {
             verify(false, toEventuallyRequiresClosureError)
         }
     }
 
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
     public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         if expression.isClosure {
             let (pass, msg) = expressionDoesNotMatch(
@@ -70,12 +74,16 @@ extension Expectation {
                     pollInterval: pollInterval),
                 toNot: "to eventually not"
             )
-            verify(pass, msg.stringValue)
+            verify(pass, msg)
         } else {
             verify(false, toEventuallyRequiresClosureError)
         }
     }
 
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toEventuallyNot()
     public func toNotEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         return toEventuallyNot(matcher, timeout: timeout, pollInterval: pollInterval)
     }

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -12,7 +12,7 @@ func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt 
     var lastFailure: AssertionRecord?
     if recorder.assertions.count > 0 {
         lastFailure = recorder.assertions[recorder.assertions.endIndex - 1]
-        if lastFailure!.message == message {
+        if lastFailure!.message.stringValue == message {
             return
         }
     }


### PR DESCRIPTION
Breaking Change.

This allows the assertion handlers some customization of the failure message.
- Expectation.verify() now requires a FailureMessage, instead of a String.
- Added documentation comments.
- Added NimbleShortXCTestHandler which provides shorter failure messages (to drive out some of this change)
- Added AssertionDispatch (useful for another PR)
- AssertionRecord is Printable
- Letting Xcode muck with checkout file.