### PR TITLE
Simplier API for raiseException

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		1FD8CD751968AB07008ED995 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */; };
 		1FD8CD761968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
 		1FD8CD771968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
+		1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
+		1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
 		DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DD72EC641A93874A002F7651 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
@@ -327,6 +329,7 @@
 		1FD8CD2A1968AB07008ED995 /* AsyncMatcherWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncMatcherWrapper.swift; sourceTree = "<group>"; };
 		1FD8CD2C1968AB07008ED995 /* MatcherFunc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatcherFunc.swift; sourceTree = "<group>"; };
 		1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCMatcher.swift; sourceTree = "<group>"; };
+		1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionDispatcher.swift; sourceTree = "<group>"; };
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1FFD729C1963FCAB00CD29A2 /* Nimble-OSXTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Nimble-OSXTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DSL+Wait.swift"; sourceTree = "<group>"; };
@@ -483,6 +486,7 @@
 				1FD8CD051968AB07008ED995 /* AssertionRecorder.swift */,
 				1FD8CD061968AB07008ED995 /* AdapterProtocols.swift */,
 				1FD8CD071968AB07008ED995 /* NimbleXCTestHandler.swift */,
+				1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */,
 			);
 			path = Adapters;
 			sourceTree = "<group>";
@@ -769,6 +773,7 @@
 				1F43728F1A1B344000EB80F8 /* Stringers.swift in Sources */,
 				1F43728D1A1B343D00EB80F8 /* SourceLocation.swift in Sources */,
 				1FD8CD4E1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
+				1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728A1A1B343800EB80F8 /* Functional.swift in Sources */,
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -865,6 +870,7 @@
 				1F43728E1A1B343F00EB80F8 /* Stringers.swift in Sources */,
 				1F43728C1A1B343C00EB80F8 /* SourceLocation.swift in Sources */,
 				1FD8CD4F1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
+				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728B1A1B343900EB80F8 /* Functional.swift in Sources */,
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,

--- a/Nimble.xcodeproj/project.xcworkspace/xcshareddata/Nimble.xccheckout
+++ b/Nimble.xcodeproj/project.xcworkspace/xcshareddata/Nimble.xccheckout
@@ -7,21 +7,21 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>3C7A95C5-450E-4971-8DC4-2613B2BA4376</string>
 	<key>IDESourceControlProjectName</key>
-	<string>Nimble</string>
+	<string>project</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>95438028B10BBB846574013D29F154A00556A9D1</key>
-		<string>github.com:quick/Nimble.git</string>
+		<string>github.com:Quick/Nimble</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Nimble.xcodeproj</string>
+	<string>Nimble.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>95438028B10BBB846574013D29F154A00556A9D1</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>github.com:quick/Nimble.git</string>
+	<string>github.com:Quick/Nimble</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>

--- a/Nimble/Adapters/AdapterProtocols.swift
+++ b/Nimble/Adapters/AdapterProtocols.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Protocol for the assertion handler that Nimble uses for all expectations.
 public protocol AssertionHandler {
-    func assert(assertion: Bool, message: String, location: SourceLocation)
+    func assert(assertion: Bool, message: FailureMessage, location: SourceLocation)
 }
 
 /// Global backing interface for assertions that Nimble creates.

--- a/Nimble/Adapters/AssertionDispatcher.swift
+++ b/Nimble/Adapters/AssertionDispatcher.swift
@@ -1,0 +1,20 @@
+
+/// AssertionDispatcher allows multiple AssertionHandlers to receive
+/// assertion messages.
+///
+/// @warning Does not fully dispatch if one of the handlers raises an exception.
+///          This is possible with XCTest-based assertion handlers.
+///
+public class AssertionDispatcher: AssertionHandler {
+    let handlers: [AssertionHandler]
+
+    public init(handlers: [AssertionHandler]) {
+        self.handlers = handlers
+    }
+
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        for handler in handlers {
+            handler.assert(assertion, message: message, location: location)
+        }
+    }
+}

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -5,13 +5,17 @@ import Foundation
 ///
 /// @see AssertionRecorder
 /// @see AssertionHandler
-public struct AssertionRecord {
+public struct AssertionRecord: Printable {
     /// Whether the assertion succeeded or failed
     public let success: Bool
     /// The failure message the assertion would display on failure.
-    public let message: String
+    public let message: FailureMessage
     /// The source location the expectation occurred on.
     public let location: SourceLocation
+
+    public var description: String {
+        return "AssertionRecord { success=\(success), message='\(message.stringValue)', location=\(location) }"
+    }
 }
 
 /// An AssertionHandler that silently records assertions that Nimble makes.
@@ -24,7 +28,7 @@ public class AssertionRecorder : AssertionHandler {
 
     public init() {}
 
-    public func assert(assertion: Bool, message: String, location: SourceLocation) {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
         assertions.append(
             AssertionRecord(
                 success: assertion,

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -53,3 +53,47 @@ public func withAssertionHandler(tempAssertionHandler: AssertionHandler, closure
         closure()
     }
 }
+
+/// Captures expectations that occur in the given closure. Note that all
+/// expectations will still go through to the default Nimble handler.
+///
+/// This can be useful if you want to gather information about expectations
+/// that occur within a closure.
+///
+/// @param silently expectations are no longer send to the default Nimble 
+///                 assertion handler when this is true. Defaults to false.
+///
+/// @see gatherFailingExpectations
+public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
+    let previousRecorder = NimbleAssertionHandler
+    var recorder = AssertionRecorder()
+    let handlers: [AssertionHandler]
+
+    if silently {
+        handlers = [recorder]
+    } else {
+        handlers = [recorder, previousRecorder]
+    }
+
+    var dispatcher = AssertionDispatcher(handlers: handlers)
+    withAssertionHandler(dispatcher, closure)
+    return recorder.assertions
+}
+
+/// Captures failed expectations that occur in the given closure. Note that all
+/// expectations will still go through to the default Nimble handler.
+///
+/// This can be useful if you want to gather information about failed
+/// expectations that occur within a closure.
+///
+/// @param silently expectations are no longer send to the default Nimble
+///                 assertion handler when this is true. Defaults to false.
+///
+/// @see gatherExpectations
+/// @see raiseException source for an example use case.
+public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
+    let assertions = gatherExpectations(silently: silently, closure)
+    return filter(assertions) { assertion in
+        !assertion.success
+    }
+}

--- a/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -4,9 +4,25 @@ import XCTest
 /// Default handler for Nimble. This assertion handler passes failures along to
 /// XCTest.
 public class NimbleXCTestHandler : AssertionHandler {
-    public func assert(assertion: Bool, message: String, location: SourceLocation) {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
         if !assertion {
-            XCTFail(message, file: location.file, line: location.line)
+            XCTFail("\(message.stringValue)\n", file: location.file, line: location.line)
+        }
+    }
+}
+
+/// Alternative handler for Nimble. This assertion handler passes failures along
+/// to XCTest by attempting to reduce the failure message size.
+public class NimbleShortXCTestHandler: AssertionHandler {
+    public func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        if !assertion {
+            let msg: String
+            if let actual = message.actualValue {
+                msg = "got: \(actual) \(message.postfixActual)"
+            } else {
+                msg = "expected \(message.to) \(message.postfixMessage)"
+            }
+            XCTFail("\(msg)\n", file: location.file, line: location.line)
         }
     }
 }

--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -18,7 +18,7 @@ public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression
 
 /// Always fails the test with a message and a specified location.
 public func fail(message: String, #location: SourceLocation) {
-    NimbleAssertionHandler.assert(false, message: message, location: location)
+    NimbleAssertionHandler.assert(false, message: FailureMessage(stringValue: message), location: location)
 }
 
 /// Always fails the test with a message.

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -23,20 +23,25 @@ internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(ex
 public struct Expectation<T> {
     let expression: Expression<T>
 
-    public func verify(pass: Bool, _ message: String) {
+    public func verify(pass: Bool, _ message: FailureMessage) {
         NimbleAssertionHandler.assert(pass, message: message, location: expression.location)
     }
 
+    /// Tests the actual value using a matcher to match.
     public func to<U where U: Matcher, U.ValueType == T>(matcher: U) {
         let (pass, msg) = expressionMatches(expression, matcher, to: "to")
-        verify(pass, msg.stringValue)
+        verify(pass, msg)
     }
 
+    /// Tests the actual value using a matcher to not match.
     public func toNot<U where U: Matcher, U.ValueType == T>(matcher: U) {
         let (pass, msg) = expressionDoesNotMatch(expression, matcher, toNot: "to not")
-        verify(pass, msg.stringValue)
+        verify(pass, msg)
     }
 
+    /// Tests the actual value using a matcher to not match.
+    ///
+    /// Alias to toNot().
     public func notTo<U where U: Matcher, U.ValueType == T>(matcher: U) {
         toNot(matcher)
     }

--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -1,28 +1,14 @@
 import Foundation
 
-@objc
-public class FailureMessage {
+/// Encapsulates the failure message that matchers can report to the end user.
+///
+/// This is shared state between Nimble and matchers that mutate this value.
+@objc public class FailureMessage {
     public var expected: String = "expected"
     public var actualValue: String? = "" // empty string -> use default; nil -> exclude
     public var to: String = "to"
     public var postfixMessage: String = "match"
     public var postfixActual: String = ""
-
-    internal var _stringValueOverride: String?
-
-    public init() {
-    }
-
-    internal func computeStringValue() -> String {
-        var value = "\(expected) \(to) \(postfixMessage)"
-        if let actualValue = actualValue {
-            value = "\(expected) \(to) \(postfixMessage), got \(actualValue)\(postfixActual)"
-        }
-        var lines: [String] = (value as NSString).componentsSeparatedByString("\n") as! [String]
-        let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
-        return "".join(lines)
-    }
 
     public var stringValue: String {
         get {
@@ -35,5 +21,29 @@ public class FailureMessage {
         set {
             _stringValueOverride = newValue
         }
+    }
+
+    internal var _stringValueOverride: String?
+
+    public init() {
+    }
+
+    public init(stringValue: String) {
+        _stringValueOverride = stringValue
+    }
+
+    internal func stripNewlines(str: String) -> String {
+        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as! [String]
+        let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
+        return "".join(lines)
+    }
+
+    internal func computeStringValue() -> String {
+        var value = "\(expected) \(to) \(postfixMessage)"
+        if let actualValue = actualValue {
+            value = "\(expected) \(to) \(postfixMessage), got \(actualValue)\(postfixActual)"
+        }
+        return stripNewlines(value)
     }
 }

--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -1,185 +1,125 @@
 import Foundation
 
-internal struct RaiseExceptionMatchResult {
-    var success: Bool
-    var nameFailureMessage: FailureMessage?
-    var reasonFailureMessage: FailureMessage?
-    var userInfoFailureMessage: FailureMessage?
+/// A Nimble matcher that succeeds when the actual expression raises an
+/// exception with the specified name, reason, and/or userInfo.
+///
+/// Alternatively, you can pass a closure to do any arbitrary custom matching
+/// to the raised exception. The closure only gets called when an exception
+/// is raised.
+///
+/// nil arguments indicates that the matcher should not attempt to match against
+/// that parameter.
+public func raiseException(
+    named: String? = nil,
+    reason: String? = nil,
+    userInfo: NSDictionary? = nil,
+    closure: ((NSException) -> Void)? = nil) -> MatcherFunc<Any> {
+        return MatcherFunc { actualExpression, failureMessage in
+
+            var exception: NSException?
+            var capture = NMBExceptionCapture(handler: ({ e in
+                exception = e
+            }), finally: nil)
+
+            capture.tryBlock {
+                actualExpression.evaluate()
+                return
+            }
+
+            setFailureMessageForException(failureMessage, exception, named, reason, userInfo, closure)
+            return exceptionMatchesNonNilFieldsOrClosure(exception, named, reason, userInfo, closure)
+        }
 }
 
-internal func raiseExceptionMatcher(matches: (NSException?, SourceLocation) -> RaiseExceptionMatchResult) -> MatcherFunc<Any> {
-    return MatcherFunc { actualExpression, failureMessage in
-        failureMessage.actualValue = nil
-
-        var exception: NSException?
-        var capture = NMBExceptionCapture(handler: ({ e in
-            exception = e
-        }), finally: nil)
-
-        capture.tryBlock {
-            actualExpression.evaluate()
-            return
-        }
-
-        let result = matches(exception, actualExpression.location)
-
+internal func setFailureMessageForException(
+    failureMessage: FailureMessage,
+    exception: NSException?,
+    named: String?,
+    reason: String?,
+    userInfo: NSDictionary?,
+    closure: ((NSException) -> Void)?) {
         failureMessage.postfixMessage = "raise exception"
 
-        if let nameFailureMessage = result.nameFailureMessage {
-            failureMessage.postfixMessage += " with name \(nameFailureMessage.postfixMessage)"
+        if let named = named {
+            failureMessage.postfixMessage += " with name <\(named)>"
         }
-        if let reasonFailureMessage = result.reasonFailureMessage {
-            failureMessage.postfixMessage += " with reason \(reasonFailureMessage.postfixMessage)"
+        if let reason = reason {
+            failureMessage.postfixMessage += " with reason <\(reason)>"
         }
-        if let userInfoFailureMessage = result.userInfoFailureMessage {
-            failureMessage.postfixMessage += " with userInfo \(userInfoFailureMessage.postfixMessage)"
+        if let userInfo = userInfo {
+            failureMessage.postfixMessage += " with userInfo <\(userInfo)>"
         }
-        if result.nameFailureMessage == nil && result.reasonFailureMessage == nil
-            && result.userInfoFailureMessage == nil {
-                failureMessage.postfixMessage = "raise any exception"
+        if let closure = closure {
+            failureMessage.postfixMessage += " that satisfies block"
+        }
+        if named == nil && reason == nil && userInfo == nil && closure == nil {
+            failureMessage.postfixMessage = "raise any exception"
         }
 
-        return result.success
-    }
-
+        if let exception = exception {
+            failureMessage.actualValue = "\(NSStringFromClass(exception.dynamicType)) { name=\(exception.name), reason='\(stringify(exception.reason))', userInfo=\(stringify(exception.userInfo)) }"
+        } else {
+            failureMessage.actualValue = "no exception"
+        }
 }
 
-// A Nimble matcher that succeeds when the actual expression raises an exception, which name,
-// reason and userInfo match successfully with the provided matchers
-public func raiseException(
-    named: NonNilMatcherFunc<String>? = nil,
-    reason: NonNilMatcherFunc<String>? = nil,
-    userInfo: NonNilMatcherFunc<NSDictionary>? = nil) -> MatcherFunc<Any> {
-        return raiseExceptionMatcher() { exception, location in
+internal func exceptionMatchesNonNilFieldsOrClosure(
+    exception: NSException?,
+    named: String?,
+    reason: String?,
+    userInfo: NSDictionary?,
+    closure: ((NSException) -> Void)?) -> Bool {
+        var matches = false
 
-            var matches = exception != nil
+        if let exception = exception {
+            matches = true
 
-            var nameFailureMessage: FailureMessage?
-            if let nameMatcher = named {
-                nameFailureMessage = FailureMessage()
-                matches = nameMatcher.matches(
-                    Expression(expression: { exception?.name },
-                        location: location,
-                        isClosure: false),
-                    failureMessage: nameFailureMessage!) && matches
+            if named != nil && exception.name != named {
+                matches = false
             }
-
-            var reasonFailureMessage: FailureMessage?
-            if let reasonMatcher = reason {
-                reasonFailureMessage = FailureMessage()
-                matches = reasonMatcher.matches(
-                    Expression(expression: { exception?.reason },
-                        location: location,
-                        isClosure: false),
-                    failureMessage: reasonFailureMessage!) && matches
+            if reason != nil && exception.reason != reason {
+                matches = false
             }
-
-            var userInfoFailureMessage: FailureMessage?
-            if let userInfoMatcher = userInfo {
-                userInfoFailureMessage = FailureMessage()
-                matches = userInfoMatcher.matches(
-                    Expression(expression: { exception?.userInfo },
-                        location: location,
-                        isClosure: false),
-                    failureMessage: userInfoFailureMessage!) && matches
+            if userInfo != nil && exception.userInfo != userInfo {
+                matches = false
             }
-
-            return RaiseExceptionMatchResult(
-                success: matches,
-                nameFailureMessage: nameFailureMessage,
-                reasonFailureMessage: reasonFailureMessage,
-                userInfoFailureMessage: userInfoFailureMessage)
+            if let closure = closure {
+                let assertions = gatherFailingExpectations {
+                    closure(exception)
+                }
+                let messages = map(assertions) { $0.message }
+                if messages.count > 0 {
+                    matches = false
+                }
+            }
         }
-}
-
-/// A Nimble matcher that succeeds when the actual expression raises an exception with
-/// the specified name, reason, and userInfo.
-public func raiseException(#named: String, #reason: String, #userInfo: NSDictionary) -> MatcherFunc<Any> {
-    return raiseException(named: equal(named), reason: equal(reason), userInfo: equal(userInfo))
-}
-
-/// A Nimble matcher that succeeds when the actual expression raises an exception with
-/// the specified name and reason.
-public func raiseException(#named: String, #reason: String) -> MatcherFunc<Any> {
-    return raiseException(named: equal(named), reason: equal(reason))
-}
-
-
-/// A Nimble matcher that succeeds when the actual expression raises an exception with
-/// the specified name.
-public func raiseException(#named: String) -> MatcherFunc<Any> {
-    return raiseException(named: equal(named))
+        
+        return matches
 }
 
 @objc public class NMBObjCRaiseExceptionMatcher : NMBMatcher {
-    var _name: String?
-    var _reason: String?
-    var _userInfo: NSDictionary?
-    var _nameMatcher: NMBMatcher?
-    var _reasonMatcher: NMBMatcher?
-    var _userInfoMatcher: NMBMatcher?
+    internal var _name: String?
+    internal var _reason: String?
+    internal var _userInfo: NSDictionary?
+    internal var _block: ((NSException) -> Void)?
 
-    init(name: String?, reason: String?, userInfo: NSDictionary?) {
+    internal init(name: String?, reason: String?, userInfo: NSDictionary?, block: ((NSException) -> Void)?) {
         _name = name
         _reason = reason
         _userInfo = userInfo
-    }
-
-    init(nameMatcher: NMBMatcher?, reasonMatcher: NMBMatcher?, userInfoMatcher: NMBMatcher?) {
-        _nameMatcher = nameMatcher
-        _reasonMatcher = reasonMatcher
-        _userInfoMatcher = userInfoMatcher
+        _block = block
     }
 
     public func matches(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let block: () -> Any? = ({ actualBlock(); return nil })
         let expr = Expression(expression: block, location: location)
-        if _nameMatcher != nil || _reasonMatcher != nil || _userInfoMatcher != nil {
-            return raiseExceptionMatcher() {
-                exception, location in
 
-                var matches = exception != nil
-
-                var nameFailureMessage: FailureMessage?
-                if let nameMatcher = self._nameMatcher {
-                    nameFailureMessage = FailureMessage()
-                    matches = nameMatcher.matches({ exception?.name },
-                        failureMessage: nameFailureMessage!,
-                        location: location) && matches
-                }
-
-                var reasonFailureMessage: FailureMessage?
-                if let reasonMatcher = self._reasonMatcher {
-                    reasonFailureMessage = FailureMessage()
-                    matches = reasonMatcher.matches({ exception?.reason },
-                        failureMessage: reasonFailureMessage!,
-                        location: location) && matches
-                }
-
-                var userInfoFailureMessage: FailureMessage?
-                if let userInfoMatcher = self._userInfoMatcher {
-                    userInfoFailureMessage = FailureMessage()
-                    matches = userInfoMatcher.matches({ exception?.userInfo },
-                        failureMessage: userInfoFailureMessage!,
-                        location: location) && matches
-                }
-
-                return RaiseExceptionMatchResult(
-                    success: matches,
-                    nameFailureMessage: nameFailureMessage,
-                    reasonFailureMessage: reasonFailureMessage,
-                    userInfoFailureMessage: userInfoFailureMessage)
-
-            }.matches(expr, failureMessage: failureMessage)
-        } else if let name = _name, reason = _reason, userInfo = _userInfo {
-            return raiseException(named: name, reason: reason, userInfo: userInfo).matches(expr, failureMessage: failureMessage)
-        } else if let name = _name, reason = _reason {
-            return raiseException(named: name, reason: reason).matches(expr, failureMessage: failureMessage)
-        } else if let name = _name {
-            return raiseException(named: name).matches(expr, failureMessage: failureMessage)
-        } else {
-            return raiseException().matches(expr, failureMessage: failureMessage)
-        }
+        return raiseException(
+            named: _name,
+            reason: _reason,
+            userInfo: _userInfo,
+            closure: _block
+        ).matches(expr, failureMessage: failureMessage)
     }
 
     public func doesNotMatch(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
@@ -188,46 +128,51 @@ public func raiseException(#named: String) -> MatcherFunc<Any> {
 
     public var named: (name: String) -> NMBObjCRaiseExceptionMatcher {
         return ({ name in
-            return NMBObjCRaiseExceptionMatcher(name: name, reason: self._reason, userInfo: self._userInfo)
+            return NMBObjCRaiseExceptionMatcher(
+                name: name,
+                reason: self._reason,
+                userInfo: self._userInfo,
+                block: self._block
+            )
         })
     }
 
     public var reason: (reason: String?) -> NMBObjCRaiseExceptionMatcher {
         return ({ reason in
-            return NMBObjCRaiseExceptionMatcher(name: self._name, reason: reason, userInfo: self._userInfo)
+            return NMBObjCRaiseExceptionMatcher(
+                name: self._name,
+                reason: reason,
+                userInfo: self._userInfo,
+                block: self._block
+            )
         })
     }
 
     public var userInfo: (userInfo: NSDictionary?) -> NMBObjCRaiseExceptionMatcher {
         return ({ userInfo in
-            return NMBObjCRaiseExceptionMatcher(name: self._name, reason: self._reason, userInfo: userInfo)
+            return NMBObjCRaiseExceptionMatcher(
+                name: self._name,
+                reason: self._reason,
+                userInfo: userInfo,
+                block: self._block
+            )
         })
     }
 
-    public var withName: (nameMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
-        return ({ nameMatcher in
-            return NMBObjCRaiseExceptionMatcher(nameMatcher: nameMatcher,
-                reasonMatcher: self._reasonMatcher, userInfoMatcher: self._userInfoMatcher)
-        })
-    }
-
-    public var withReason: (reasonMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
-        return ({ reasonMatcher in
-            return NMBObjCRaiseExceptionMatcher(nameMatcher: self._nameMatcher,
-                reasonMatcher: reasonMatcher, userInfoMatcher: self._userInfoMatcher)
-        })
-    }
-
-    public var withUserInfo: (userInfoMatcher: NMBMatcher) -> NMBObjCRaiseExceptionMatcher {
-        return ({ userInfoMatcher in
-            return NMBObjCRaiseExceptionMatcher(nameMatcher: self._nameMatcher,
-                reasonMatcher: self._reasonMatcher, userInfoMatcher: userInfoMatcher)
+    public var satisfyingBlock: (block: ((NSException) -> Void)?) -> NMBObjCRaiseExceptionMatcher {
+        return ({ block in
+            return NMBObjCRaiseExceptionMatcher(
+                name: self._name,
+                reason: self._reason,
+                userInfo: self._userInfo,
+                block: block
+            )
         })
     }
 }
 
 extension NMBObjCMatcher {
     public class func raiseExceptionMatcher() -> NMBObjCRaiseExceptionMatcher {
-        return NMBObjCRaiseExceptionMatcher(name: nil, reason: nil, userInfo: nil)
+        return NMBObjCRaiseExceptionMatcher(name: nil, reason: nil, userInfo: nil, block: nil)
     }
 }

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -40,10 +40,12 @@ internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Ma
     }
 }
 
-private let toEventuallyRequiresClosureError = "expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function"
+private let toEventuallyRequiresClosureError = FailureMessage(stringValue: "expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function")
 
 
 extension Expectation {
+    /// Tests the actual value using a matcher to match by checking continuously
+    /// at each pollInterval until the timeout is reached.
     public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         if expression.isClosure {
             let (pass, msg) = expressionMatches(
@@ -54,12 +56,14 @@ extension Expectation {
                     pollInterval: pollInterval),
                 to: "to eventually"
             )
-            verify(pass, msg.stringValue)
+            verify(pass, msg)
         } else {
             verify(false, toEventuallyRequiresClosureError)
         }
     }
 
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
     public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         if expression.isClosure {
             let (pass, msg) = expressionDoesNotMatch(
@@ -70,12 +74,16 @@ extension Expectation {
                     pollInterval: pollInterval),
                 toNot: "to eventually not"
             )
-            verify(pass, msg.stringValue)
+            verify(pass, msg)
         } else {
             verify(false, toEventuallyRequiresClosureError)
         }
     }
 
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toEventuallyNot()
     public func toNotEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
         return toEventuallyNot(matcher, timeout: timeout, pollInterval: pollInterval)
     }

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -12,7 +12,7 @@ func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt 
     var lastFailure: AssertionRecord?
     if recorder.assertions.count > 0 {
         lastFailure = recorder.assertions[recorder.assertions.endIndex - 1]
-        if lastFailure!.message == message {
+        if lastFailure!.message.stringValue == message {
             return
         }
     }

--- a/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -11,90 +11,143 @@ class RaisesExceptionTest: XCTestCase {
         expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
     }
 
-    func testPositiveMatchesWithSubMatchers() {
-        expect { self.exception.raise() }.to(raiseException(named: equal("laugh")))
-        expect { self.exception.raise() }.to(raiseException(reason: beginWith("Lu")))
-        expect { self.exception.raise() }.to(raiseException(userInfo:equal(["key": "value"])))
-        expect { self.exception.raise() }.to(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
-        expect { self.exception.raise() }.to(
-            raiseException(named: equal("laugh"), reason: beginWith("Lu"), userInfo:equal(["key": "value"])))
-        expect { self.exception.raise() }.toNot(raiseException(named: equal("smile")))
-        expect { self.exception.raise() }.toNot(raiseException(reason: beginWith("Lut")))
-        expect { self.exception.raise() }.toNot(raiseException(userInfo:equal(["key": "no value"])))
-        expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lut")))
-        expect { self.exception }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+    func testPositiveMatchesWithClosures() {
+        expect { self.exception.raise() }.to(raiseException { exception in
+            expect(exception.name).to(equal("laugh"))
+        })
+        expect { self.exception.raise() }.to(raiseException(named: "laugh") { exception in
+            expect(exception.name).to(beginWith("lau"))
+        })
+        expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { exception in
+            expect(exception.name).to(beginWith("lau"))
+        })
+        expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { exception in
+            expect(exception.name).to(beginWith("lau"))
+        })
+
+        expect { self.exception.raise() }.to(raiseException(named: "laugh") { exception in
+            expect(exception.name).toNot(beginWith("as"))
+        })
+        expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { exception in
+            expect(exception.name).toNot(beginWith("df"))
+        })
+        expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { exception in
+            expect(exception.name).toNot(beginWith("as"))
+        })
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected to raise exception with name equal <foo>") {
+        failsWithErrorMessage("expected to raise exception with name <foo>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.to(raiseException(named: "foo"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name equal <laugh> with reason equal <bar>") {
+        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <bar>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "bar"))
         }
 
         failsWithErrorMessage(
-            "expected to raise exception with name equal <laugh> with reason equal <Lulz> with userInfo equal <{k = v;}>") {
+            "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{k = v;}>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["k": "v"]))
         }
 
-        failsWithErrorMessage("expected to raise any exception") {
+        failsWithErrorMessage("expected to raise any exception, got no exception") {
             expect { self.exception }.to(raiseException())
         }
-        failsWithErrorMessage("expected to not raise any exception") {
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.toNot(raiseException())
         }
-        failsWithErrorMessage("expected to raise exception with name equal <laugh> with reason equal <Lulz>") {
+        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <Lulz>, got no exception") {
             expect { self.exception }.to(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name equal <bar> with reason equal <Lulz>") {
+        failsWithErrorMessage("expected to raise exception with name <bar> with reason <Lulz>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.to(raiseException(named: "bar", reason: "Lulz"))
         }
-        failsWithErrorMessage("expected to not raise exception with name equal <laugh>") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh"))
         }
-        failsWithErrorMessage("expected to not raise exception with name equal <laugh> with reason equal <Lulz>") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to not raise exception with name equal <laugh> with reason equal <Lulz> with userInfo equal <{key = value;}>") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
             expect { self.exception.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
         }
     }
 
-    func testNegativeMatchesWithSubMatchers() {
-        failsWithErrorMessage("expected to raise exception with name equal <foo> with reason begin with <bar>") {
-            expect { self.exception.raise() }.to(raiseException(named: equal("foo"), reason: beginWith("bar")))
+    func testNegativeMatchesDoNotCallClosureWithoutException() {
+        failsWithErrorMessage("expected to raise exception that satisfies block, got no exception") {
+            expect { self.exception }.to(raiseException { exception in
+                expect(exception.name).to(equal("foo"))
+            })
+        }
+        
+        failsWithErrorMessage("expected to raise exception with name <foo> that satisfies block, got no exception") {
+            expect { self.exception }.to(raiseException(named: "foo") { exception in
+                expect(exception.name).to(equal("foo"))
+            })
         }
 
-        failsWithErrorMessage("expected to raise exception with name equal <foo>") {
-            expect { self.exception.raise() }.to(raiseException(named: equal("foo")))
+        failsWithErrorMessage("expected to raise exception with name <foo> with reason <ha> that satisfies block, got no exception") {
+            expect { self.exception }.to(raiseException(named: "foo", reason: "ha") { exception in
+                expect(exception.name).to(equal("foo"))
+            })
         }
 
-        failsWithErrorMessage("expected to raise exception with reason begin with <bar>") {
-            expect { self.exception.raise() }.to(raiseException(reason: beginWith("bar")))
+        failsWithErrorMessage("expected to raise exception with name <foo> with reason <Lulz> with userInfo <{}> that satisfies block, got no exception") {
+            expect { self.exception }.to(raiseException(named: "foo", reason: "Lulz", userInfo: [:]) { exception in
+                expect(exception.name).to(equal("foo"))
+                })
         }
 
-        failsWithErrorMessage("expected to raise exception with userInfo equal <{k = v;}>") {
-            expect { self.exception.raise() }.to(raiseException(userInfo: equal(["k": "v"])))
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+            expect { self.exception.raise() }.toNot(raiseException())
+        }
+    }
+
+    func testNegativeMatchesWithClosure() {
+        failsWithErrorMessage("expected to raise exception that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+            expect { self.exception.raise() }.to(raiseException { exception in
+                expect(exception.name).to(equal("foo"))
+            })
         }
 
-        failsWithErrorMessage("expected to not raise exception with name equal <laugh> with reason begin with <Lu>") {
-            expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+        let innerFailureMessage = "expected to begin with <fo>, got <laugh>"
+
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "laugh") { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
         }
 
-        failsWithErrorMessage("expected to not raise exception with name equal <laugh>") {
-            expect { self.exception.raise() }.toNot(raiseException(named: equal("laugh")))
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "lol") { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
         }
 
-        failsWithErrorMessage("expected to not raise exception with reason begin with <Lu>") {
-            expect { self.exception.raise() }.toNot(raiseException(reason: beginWith("Lu")))
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
         }
 
-        failsWithErrorMessage("expected to raise exception with name equal <laugh> with reason begin with <Lu>") {
-            expect { self.exception }.to(raiseException(named: equal("laugh"), reason: beginWith("Lu")))
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <wrong> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "lol", reason: "wrong") { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
+        }
+
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
+        }
+
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <Lulz> with userInfo <{}> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+            expect { self.exception.raise() }.to(raiseException(named: "lol", reason: "Lulz", userInfo: [:]) { exception in
+                expect(exception.name).to(beginWith("fo"))
+            })
         }
     }
 }

--- a/NimbleTests/objc/NimbleSpecHelper.h
+++ b/NimbleTests/objc/NimbleSpecHelper.h
@@ -5,6 +5,10 @@
 #define expectFailureMessage(MSG, BLOCK) \
 [NimbleHelper expectFailureMessage:(MSG) block:(BLOCK) file:@(__FILE__) line:__LINE__];
 
+#define expectFailureMessages(MSGS, BLOCK) \
+[NimbleHelper expectFailureMessages:(MSGS) block:(BLOCK) file:@(__FILE__) line:__LINE__];
+
+
 // Use this when you want to verify the failure message with the nil message postfixed
 // to it: " (use beNil() to match nils)"
 #define expectNilFailureMessage(MSG, BLOCK) \

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ expectAction([exception raise]).to(raiseException().
     named(NSInternalInconsistencyException).
     reason("Not enough fish in the sea").
     userInfo(@{@"something": @"is fishy"}));
+
+// You can also pass a block for custom matching of the raised exception
+expectAction(exception.raise()).to(raiseException().satisfyingBlock(^(NSException *exception) {
+    expect(exception.name).to(beginWith(NSInternalInconsistencyException));
+}));
 ```
 
 ## C Primitives
@@ -631,15 +636,11 @@ expect(actual).to(raiseException(named: name))
 // Passes if actual raises an exception with the given name and reason:
 expect(actual).to(raiseException(named: name, reason: reason))
 
-// Passes if actual raises an exception with a name equal "a name"
-expect(actual).to(raiseException(named: equal("a name")))
-
-// Passes if actual raises an exception with a reason that begins with "a r"
-expect(actual).to(raiseException(reason: beginWith("a r")))
-
-// Passes if actual raises an exception with a name equal "a name"
-// and a reason that begins with "a r"
-expect(actual).to(raiseException(named: equal("a name"), reason: beginWith("a r")))
+// Passes if actual raises an exception and it passes expectations in the block
+// (in this case, if name begins with 'a r')
+expect { exception.raise() }.to(raiseException { exception in
+    expect(exception.name).to(beginWith("a r"))
+})
 ```
 
 ```objc
@@ -654,15 +655,11 @@ expect(actual).to(raiseException().named(name))
 // Passes if actual raises an exception with the given name and reason:
 expect(actual).to(raiseException().named(name).reason(reason))
 
-// Passes if actual raises an exception with a name equal "a name"
-expect(actual).to(raiseException().withName(equal("a name")))
-
-// Passes if actual raises an exception with a reason that begins with "a r"
-expect(actual).to(raiseException().withName(withReason(beginWith(@"a r")))
-
-// Passes if actual raises an exception with a name equal "a name"
-// and a reason that begins with "a r"
-expect(actual).to(raiseException().withName(equal("a name")).withReason(beginWith(@"a r")))
+// Passes if actual raises an exception and it passes expectations in the block
+// (in this case, if name begins with 'a r')
+expect(actual).to(raiseException().satisfyingBlock(^(NSException *exception) {
+    expect(exception.name).to(beginWith(@"a r"));
+}));
 ```
 
 Note: Swift currently doesn't have exceptions. Only Objective-C code can raise


### PR DESCRIPTION
**Breaking Change. Based on PR #126.**

@Quick/contributors, I'd like input about this proposal. This simplification narrows the API at the expense of verbosity for custom matching behavior on top of `raiseException`.

I'm tempted to simplify this slightly more by removing the `userInfo` matching from `raiseException`. I don't think it's practical to use equality matching on `userInfo`. Technically, it can be useful if you fully control the exception raised (aka - only your own APIs) for a small userInfo field, but that's pretty limited - at least in my limited personal experience. This PR still keeps equality matching of `userInfo`.

-------------------------

**Matchers are no longer accepted** for `raiseException`. Instead, use the closure/block accepting form:

```swift
// Swift
expect(doSomething()).to(raiseException { exception in
    expect(exception.name).to(beginWith("Foo"))
})
```

```objc
// Objective-C
expect(doSomething()).to(raiseException().satisfyingBlock(^(NSException *exception){
    expect(exception.name).to(beginWith(@"Foo"));
}));
```

The closure is called when an exception is raised.

Removed variants of the `raiseException` matchers. Also, raiseException prints an exception in the failure message if one was raised. Expectations inside the closure will still emit correct line numbers to XCTest.

Other changes:

- Adds `gatherFailingExpectations` and `gatherExpectations` to capture
  expectations that occur within a block/closure.
- Updated documentation comment for `raiseException`.
- Added many newlines to raiseException.swift.
- Added some explicit `internal` keywords.

Closes #100.