### PR TITLE
beAKindOf and beAnInstanceOf catch wrong usages

### DIFF
--- a/Nimble/Matchers/BeAKindOf.swift
+++ b/Nimble/Matchers/BeAKindOf.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+// A Nimble matcher that catches attempts to use beAKindOf with non Objective-C types
+public func beAKindOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
+    return NonNilMatcherFunc {actualExpression, failureMessage in
+        failureMessage.stringValue = "beAKindOf only works on Objective-C types since"
+            + " the Swift compiler will automatically type check Swift-only types."
+            + " This expectation is redundant."
+        return false
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
 /// @see beAnInstanceOf if you want to match against the exact class
 public func beAKindOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {

--- a/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Nimble/Matchers/BeAnInstanceOf.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+// A Nimble matcher that catches attempts to use beAnInstanceOf with non Objective-C types
+public func beAnInstanceOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
+    return NonNilMatcherFunc {actualExpression, failureMessage in
+        failureMessage.stringValue = "beAnInstanceOf only works on Objective-C types since"
+            + " the Swift compiler will automatically type check Swift-only types."
+            + " This expectation is redundant."
+        return false
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
 /// @see beAKindOf if you want to match against subclasses
 public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {

--- a/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -24,4 +24,22 @@ class BeAKindOfTest: XCTestCase {
             expect(NSNumber(integer:1)).toNot(beAKindOf(NSNumber))
         }
     }
+    
+    func testSwiftTypesFailureMessages() {
+        enum TestEnum {
+            case One, Two
+        }
+        failsWithErrorMessage("beAKindOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect(1).to(beAKindOf(Int))
+        }
+        failsWithErrorMessage("beAKindOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect("test").to(beAKindOf(String))
+        }
+        failsWithErrorMessage("beAKindOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect(TestEnum.One).to(beAKindOf(TestEnum))
+        }
+    }
 }

--- a/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -21,4 +21,24 @@ class BeAnInstanceOfTest: XCTestCase {
             expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSNumber))
         }
     }
+    
+    func testSwiftTypesFailureMessages() {
+        enum TestEnum {
+            case One, Two
+        }
+
+        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect(1).to(beAnInstanceOf(Int))
+        }
+        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect("test").to(beAnInstanceOf(String))
+        }
+        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
+            + " will automatically type check Swift-only types. This expectation is redundant.") {
+            expect(TestEnum.One).to(beAnInstanceOf(TestEnum))
+        }
+    }
+    
 }


### PR DESCRIPTION
beAKindOf and beAnInstanceOf now catch attempts to use them with pure Swift types and create failure messages which tell why they cannot be used in such situations.

This implements https://github.com/Quick/Nimble/issues/123