### PR TITLE
Support Swift 2.0

### DIFF
--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = ""
@@ -49,6 +51,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugXPCServices = "NO"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = ""
@@ -49,6 +51,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugXPCServices = "NO"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 /// @see AssertionRecorder
 /// @see AssertionHandler
-public struct AssertionRecord: Printable {
+public struct AssertionRecord: CustomStringConvertible {
     /// Whether the assertion succeeded or failed
     public let success: Bool
     /// The failure message the assertion would display on failure.
@@ -66,7 +66,7 @@ public func withAssertionHandler(tempAssertionHandler: AssertionHandler, closure
 /// @see gatherFailingExpectations
 public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let previousRecorder = NimbleAssertionHandler
-    var recorder = AssertionRecorder()
+    let recorder = AssertionRecorder()
     let handlers: [AssertionHandler]
 
     if silently {
@@ -75,8 +75,8 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
         handlers = [recorder, previousRecorder]
     }
 
-    var dispatcher = AssertionDispatcher(handlers: handlers)
-    withAssertionHandler(dispatcher, closure)
+    let dispatcher = AssertionDispatcher(handlers: handlers)
+    withAssertionHandler(dispatcher, closure: closure)
     return recorder.assertions
 }
 
@@ -92,8 +92,8 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
 /// @see gatherExpectations
 /// @see raiseException source for an example use case.
 public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
-    let assertions = gatherExpectations(silently: silently, closure)
-    return filter(assertions) { assertion in
+    let assertions = gatherExpectations(silently, closure: closure)
+    return assertions.filter { assertion in
         !assertion.success
     }
 }

--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -4,7 +4,7 @@ import Foundation
 /// bridges to Objective-C via the @objc keyword. This class encapsulates callback-style
 /// asynchronous waiting logic so that it may be called from Objective-C and Swift.
 @objc internal class NMBWait {
-    internal class func until(#timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    internal class func until(timeout timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         var completed = false
         var token: dispatch_once_t = 0
         let result = pollBlock(pollInterval: 0.01, timeoutInterval: timeout) {
@@ -23,6 +23,7 @@ import Foundation
         }
     }
 
+    @objc(untilFile:line:action:)
     internal class func until(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
@@ -31,7 +32,7 @@ import Foundation
 /// Wait asynchronously until the done closure is called.
 ///
 /// This will advance the run loop.
-public func waitUntil(#timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+public func waitUntil(timeout timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 
@@ -39,5 +40,5 @@ public func waitUntil(#timeout: NSTimeInterval, file: String = __FILE__, line: U
 ///
 /// This will advance the run loop.
 public func waitUntil(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
-    NMBWait.until(file: file, line: line, action: action)
+    NMBWait.until(timeout: 1, file: file, line: line, action: action)
 }

--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -17,7 +17,7 @@ public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression
 }
 
 /// Always fails the test with a message and a specified location.
-public func fail(message: String, #location: SourceLocation) {
+public func fail(message: String, location: SourceLocation) {
     NimbleAssertionHandler.assert(false, message: FailureMessage(stringValue: message), location: location)
 }
 

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, #to: String) -> (Bool, FailureMessage) {
-    var msg = FailureMessage()
+internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, to: String) -> (Bool, FailureMessage) {
+    let msg = FailureMessage()
     msg.to = to
     let pass = matcher.matches(expression, failureMessage: msg)
     if msg.actualValue == "" {
@@ -10,8 +10,8 @@ internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(express
     return (pass, msg)
 }
 
-internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, #toNot: String) -> (Bool, FailureMessage) {
-    var msg = FailureMessage()
+internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, toNot: String) -> (Bool, FailureMessage) {
+    let msg = FailureMessage()
     msg.to = toNot
     let pass = matcher.doesNotMatch(expression, failureMessage: msg)
     if msg.actualValue == "" {
@@ -29,13 +29,13 @@ public struct Expectation<T> {
 
     /// Tests the actual value using a matcher to match.
     public func to<U where U: Matcher, U.ValueType == T>(matcher: U) {
-        let (pass, msg) = expressionMatches(expression, matcher, to: "to")
+        let (pass, msg) = expressionMatches(expression, matcher: matcher, to: "to")
         verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match.
     public func toNot<U where U: Matcher, U.ValueType == T>(matcher: U) {
-        let (pass, msg) = expressionDoesNotMatch(expression, matcher, toNot: "to not")
+        let (pass, msg) = expressionDoesNotMatch(expression, matcher: matcher, toNot: "to not")
         verify(pass, msg)
     }
 

--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -33,7 +33,7 @@ import Foundation
     }
 
     internal func stripNewlines(str: String) -> String {
-        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as! [String]
+        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as [String]
         let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
         lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
         return "".join(lines)

--- a/Nimble/Matchers/AllPass.swift
+++ b/Nimble/Matchers/AllPass.swift
@@ -6,7 +6,7 @@ public func allPass<T,U where U: SequenceType, U.Generator.Element == T>
 }
 
 public func allPass<T,U where U: SequenceType, U.Generator.Element == T>
-    (passName:String, passFunc: (T?) -> Bool) -> NonNilMatcherFunc<U> {
+    (passName: String, _ passFunc: (T?) -> Bool) -> NonNilMatcherFunc<U> {
         return createAllPassMatcher() {
             expression, failureMessage in
             failureMessage.postfixMessage = passName

--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -18,7 +18,7 @@ internal func isCloseTo(actualValue: Double?, expectedValue: Double, delta: Doub
 /// @see equal
 public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta) -> NonNilMatcherFunc<Double> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        return isCloseTo(actualExpression.evaluate(), expectedValue, delta, failureMessage)
+        return isCloseTo(actualExpression.evaluate(), expectedValue: expectedValue, delta: delta, failureMessage: failureMessage)
     }
 }
 
@@ -28,7 +28,7 @@ public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta
 /// @see equal
 public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double = DefaultDelta) -> NonNilMatcherFunc<NMBDoubleConvertible> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        return isCloseTo(actualExpression.evaluate()?.doubleValue, expectedValue.doubleValue, delta, failureMessage)
+        return isCloseTo(actualExpression.evaluate()?.doubleValue, expectedValue: expectedValue.doubleValue, delta: delta, failureMessage: failureMessage)
     }
 }
 
@@ -78,7 +78,7 @@ public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDe
             if actual.count != expectedValues.count {
                 return false
             } else {
-                for (index, actualItem) in enumerate(actual) {
+                for (index, actualItem) in actual.enumerate() {
                     if fabs(actualItem - expectedValues[index]) > delta {
                         return false
                     }

--- a/Nimble/Matchers/BeEmpty.swift
+++ b/Nimble/Matchers/BeEmpty.swift
@@ -17,6 +17,16 @@ public func beEmpty<S: SequenceType>() -> NonNilMatcherFunc<S> {
 
 /// A Nimble matcher that succeeds when a value is "empty". For collections, this
 /// means the are no items in that collection. For strings, it is an empty string.
+public func beEmpty() -> NonNilMatcherFunc<String> {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "be empty"
+        let actualString = actualExpression.evaluate()
+        return actualString == nil || (actualString! as NSString).length  == 0
+    }
+}
+
+/// A Nimble matcher that succeeds when a value is "empty". For collections, this
+/// means the are no items in that collection. For NSString instances, it is an empty string.
 public func beEmpty() -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"

--- a/Nimble/Matchers/BeginWith.swift
+++ b/Nimble/Matchers/BeginWith.swift
@@ -41,7 +41,7 @@ extension NMBObjCMatcher {
     public class func beginWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let actual = actualExpression.evaluate()
-            if let actualString = actual as? String {
+            if let _ = actual as? String {
                 let expr = actualExpression.cast { $0 as? String }
                 return beginWith(expected as! String).matches(expr, failureMessage: failureMessage)
             } else {

--- a/Nimble/Matchers/Contain.swift
+++ b/Nimble/Matchers/Contain.swift
@@ -6,7 +6,7 @@ public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
         if let actual = actualExpression.evaluate() {
             return all(items) {
-                return contains(actual, $0)
+                return actual.contains($0)
             }
         }
         return false
@@ -20,7 +20,7 @@ public func contain(substrings: String...) -> NonNilMatcherFunc<String> {
         if let actual = actualExpression.evaluate() {
             return all(substrings) {
                 let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
-                let range = actual.rangeOfString($0, options: nil, range: scanRange, locale: nil)
+                let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
                 return range != nil && !range!.isEmpty
             }
         }
@@ -33,9 +33,7 @@ public func contain(substrings: NSString...) -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = actualExpression.evaluate() {
-            return all(substrings) {
-                return actual.containsString($0.description)
-            }
+            return all(substrings) { actual.rangeOfString($0.description).length != 0 }
         }
         return false
     }

--- a/Nimble/Matchers/EndWith.swift
+++ b/Nimble/Matchers/EndWith.swift
@@ -11,7 +11,7 @@ public func endWith<S: SequenceType, T: Equatable where S.Generator.Element == T
             var actualGenerator = actualValue.generate()
             var lastItem: T?
             var item: T?
-            do {
+            repeat {
                 lastItem = item
                 item = actualGenerator.next()
             } while(item != nil)
@@ -50,9 +50,8 @@ public func endWith(endingSubstring: String) -> NonNilMatcherFunc<String> {
 extension NMBObjCMatcher {
     public class func endWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let location = actualExpression.location
             let actual = actualExpression.evaluate()
-            if let actualString = actual as? String {
+            if let _ = actual as? String {
                 let expr = actualExpression.cast { $0 as? String }
                 return endWith(expected as! String).matches(expr, failureMessage: failureMessage)
             } else {

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -59,14 +59,14 @@ public func equal<T>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
 public func equal<T: Comparable>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
     return equal(expectedValue, stringify: {
         if let set = $0 {
-            return stringify(Array(set).sorted { $0 < $1 })
+            return stringify(Array(set).sort { $0 < $1 })
         } else {
             return "nil"
         }
     })
 }
 
-private func equal<T>(expectedValue: Set<T>?, #stringify: Set<T>? -> String) -> NonNilMatcherFunc<Set<T>> {
+private func equal<T>(expectedValue: Set<T>?, stringify: Set<T>? -> String) -> NonNilMatcherFunc<Set<T>> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
 

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -40,7 +40,6 @@ extension NSArray : NMBOrderedCollection {}
     var doubleValue: CDouble { get }
 }
 extension NSNumber : NMBDoubleConvertible { }
-extension NSDecimalNumber : NMBDoubleConvertible { } // TODO: not the best to downsize
 
 /// Protocol for types to support beLessThan(), beLessThanOrEqualTo(),
 ///  beGreaterThan(), beGreaterThanOrEqualTo(), and equal() matchers.

--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -10,14 +10,14 @@ import Foundation
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
 public func raiseException(
-    named: String? = nil,
+    named named: String? = nil,
     reason: String? = nil,
     userInfo: NSDictionary? = nil,
     closure: ((NSException) -> Void)? = nil) -> MatcherFunc<Any> {
         return MatcherFunc { actualExpression, failureMessage in
 
             var exception: NSException?
-            var capture = NMBExceptionCapture(handler: ({ e in
+            let capture = NMBExceptionCapture(handler: ({ e in
                 exception = e
             }), finally: nil)
 
@@ -26,8 +26,8 @@ public func raiseException(
                 return
             }
 
-            setFailureMessageForException(failureMessage, exception, named, reason, userInfo, closure)
-            return exceptionMatchesNonNilFieldsOrClosure(exception, named, reason, userInfo, closure)
+            setFailureMessageForException(failureMessage, exception: exception, named: named, reason: reason, userInfo: userInfo, closure: closure)
+            return exceptionMatchesNonNilFieldsOrClosure(exception, named: named, reason: reason, userInfo: userInfo, closure: closure)
         }
 }
 
@@ -49,7 +49,7 @@ internal func setFailureMessageForException(
         if let userInfo = userInfo {
             failureMessage.postfixMessage += " with userInfo <\(userInfo)>"
         }
-        if let closure = closure {
+        if let _ = closure {
             failureMessage.postfixMessage += " that satisfies block"
         }
         if named == nil && reason == nil && userInfo == nil && closure == nil {
@@ -87,7 +87,7 @@ internal func exceptionMatchesNonNilFieldsOrClosure(
                 let assertions = gatherFailingExpectations {
                     closure(exception)
                 }
-                let messages = map(assertions) { $0.message }
+                let messages = assertions.map { $0.message }
                 if messages.count > 0 {
                     matches = false
                 }

--- a/Nimble/ObjCExpectation.swift
+++ b/Nimble/ObjCExpectation.swift
@@ -32,7 +32,7 @@ public class NMBExpectation : NSObject {
     }
 
     private var expectValue: Expectation<NSObject> {
-        return expect(file: _file, line: _line){
+        return expect(_file, line: _line){
             self._actualBlock() as NSObject?
         }
     }

--- a/Nimble/Utils/Poll.swift
+++ b/Nimble/Utils/Poll.swift
@@ -30,8 +30,8 @@ internal class RunPromise {
 }
 
 internal func stopRunLoop(runLoop: NSRunLoop, delay: NSTimeInterval) -> RunPromise {
-    var promise = RunPromise()
-    var killQueue = dispatch_queue_create("nimble.waitUntil.queue", DISPATCH_QUEUE_SERIAL)
+    let promise = RunPromise()
+    let killQueue = dispatch_queue_create("nimble.waitUntil.queue", DISPATCH_QUEUE_SERIAL)
     let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
     let killTime = dispatch_time(DISPATCH_TIME_NOW, killTimeOffset)
     dispatch_after(killTime, killQueue) {
@@ -42,10 +42,10 @@ internal func stopRunLoop(runLoop: NSRunLoop, delay: NSTimeInterval) -> RunPromi
     return promise
 }
 
-internal func pollBlock(#pollInterval: NSTimeInterval, #timeoutInterval: NSTimeInterval, expression: () -> Bool) -> PollResult {
+internal func pollBlock(pollInterval pollInterval: NSTimeInterval, timeoutInterval: NSTimeInterval, expression: () -> Bool) -> PollResult {
     let runLoop = NSRunLoop.mainRunLoop()
 
-    var promise = stopRunLoop(runLoop, min(timeoutInterval, 0.2))
+    let promise = stopRunLoop(runLoop, delay: min(timeoutInterval, 0.2))
 
     let startDate = NSDate()
 
@@ -59,7 +59,7 @@ internal func pollBlock(#pollInterval: NSTimeInterval, #timeoutInterval: NSTimeI
     }
 
     var pass: Bool = false
-    do {
+    repeat {
         pass = expression()
         if pass {
             break

--- a/Nimble/Utils/SourceLocation.swift
+++ b/Nimble/Utils/SourceLocation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-@objc public class SourceLocation : Printable {
+@objc public class SourceLocation : CustomStringConvertible {
     public let file: String
     public let line: UInt
 

--- a/Nimble/Utils/Stringers.swift
+++ b/Nimble/Utils/Stringers.swift
@@ -23,7 +23,7 @@ internal func stringify<S: SequenceType>(value: S) -> String {
     var generator = value.generate()
     var strings = [String]()
     var value: S.Generator.Element?
-    do {
+    repeat {
         value = generator.next()
         if value != nil {
             strings.append(stringify(value))
@@ -44,7 +44,7 @@ internal func stringify<T>(value: T) -> String {
     if let value = value as? Double {
         return NSString(format: "%.4f", (value)).description
     }
-    return toString(value)
+    return String(value)
 }
 
 internal func stringify<T>(value: T?) -> String {

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -50,7 +50,7 @@ extension Expectation {
         if expression.isClosure {
             let (pass, msg) = expressionMatches(
                 expression,
-                AsyncMatcherWrapper(
+                matcher: AsyncMatcherWrapper(
                     fullMatcher: matcher,
                     timeoutInterval: timeout,
                     pollInterval: pollInterval),
@@ -68,7 +68,7 @@ extension Expectation {
         if expression.isClosure {
             let (pass, msg) = expressionDoesNotMatch(
                 expression,
-                AsyncMatcherWrapper(
+                matcher: AsyncMatcherWrapper(
                     fullMatcher: matcher,
                     timeoutInterval: timeout,
                     pollInterval: pollInterval),

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -7,7 +7,7 @@ func failsWithErrorMessage(messages: [String], file: String = __FILE__, line: UI
     var lineNumber = line
 
     let recorder = AssertionRecorder()
-    withAssertionHandler(recorder, closure)
+    withAssertionHandler(recorder, closure: closure)
 
     for msg in messages {
         var lastFailure: AssertionRecord?
@@ -47,12 +47,12 @@ func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt 
         file: file,
         line: line,
         preferOriginalSourceLocation: preferOriginalSourceLocation,
-        closure
+        closure: closure
     )
 }
 
 func failsWithErrorMessageForNil(message: String, file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
-    failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure)
+    failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
 func deferToMainQueue(action: () -> Void) {
@@ -64,14 +64,14 @@ func deferToMainQueue(action: () -> Void) {
 
 public class NimbleHelper : NSObject {
     class func expectFailureMessage(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(message as String, file: file, line: line, preferOriginalSourceLocation: true, block)
+        failsWithErrorMessage(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
     class func expectFailureMessages(messages: [NSString], block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(messages as! [String], file: file, line: line, preferOriginalSourceLocation: true, block)
+        failsWithErrorMessage(messages as! [String], file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
     class func expectFailureMessageForNil(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessageForNil(message as String, file: file, line: line, preferOriginalSourceLocation: true, block)
+        failsWithErrorMessageForNil(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }

--- a/NimbleTests/Matchers/AllPassTest.swift
+++ b/NimbleTests/Matchers/AllPassTest.swift
@@ -5,7 +5,7 @@ class AllPassTest: XCTestCase {
     func testAllPassArray() {
         expect([1,2,3,4]).to(allPass({$0 < 5}))
         expect([1,2,3,4]).toNot(allPass({$0 > 5}))
-        
+
         failsWithErrorMessage(
             "expected to all pass a condition, but failed first at element <3> in <[1, 2, 3, 4]>") {
                 expect([1,2,3,4]).to(allPass({$0 < 3}))
@@ -21,7 +21,7 @@ class AllPassTest: XCTestCase {
             expect([1,2,3,4]).toNot(allPass("be something", {$0 < 5}))
         }
     }
-    
+
     func testAllPassMatcher() {
         expect([1,2,3,4]).to(allPass(beLessThan(5)))
         expect([1,2,3,4]).toNot(allPass(beGreaterThan(5)))
@@ -34,7 +34,7 @@ class AllPassTest: XCTestCase {
             expect([1,2,3,4]).toNot(allPass(beLessThan(5)))
         }
     }
-    
+
     func testAllPassCollectionsWithOptionalsDontWork() {
         failsWithErrorMessage("expected to all be nil, but failed first at element <nil> in <[nil, nil, nil]>") {
             expect([nil, nil, nil] as [Int?]).to(allPass(beNil()))
@@ -43,7 +43,7 @@ class AllPassTest: XCTestCase {
             expect([nil, nil, nil] as [Int?]).to(allPass({$0 == nil}))
         }
     }
-    
+
     func testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer() {
         expect([nil, nil, nil] as [Int?]).to(allPass({$0! == nil}))
         expect([nil, 1, nil] as [Int?]).toNot(allPass({$0! == nil}))
@@ -53,11 +53,11 @@ class AllPassTest: XCTestCase {
         expect([1, 2, 3] as [Int?]).toNot(allPass({$0! < 3}))
         expect([1, 2, nil] as [Int?]).to(allPass({$0! < 3}))
     }
-    
+
     func testAllPassSet() {
         expect(Set([1,2,3,4])).to(allPass({$0 < 5}))
         expect(Set([1,2,3,4])).toNot(allPass({$0 > 5}))
-        
+
         failsWithErrorMessage("expected to not all pass a condition") {
             expect(Set([1,2,3,4])).toNot(allPass({$0 < 5}))
         }
@@ -65,7 +65,7 @@ class AllPassTest: XCTestCase {
             expect(Set([1,2,3,4])).toNot(allPass("be something", {$0 < 5}))
         }
     }
-    
+
     func testAllPassWithNilAsExpectedValue() {
         failsWithErrorMessageForNil("expected to all pass") {
             expect(nil as [Int]?).to(allPass(beLessThan(5)))

--- a/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/NimbleTests/Matchers/BeEmptyTest.swift
@@ -3,22 +3,22 @@ import Nimble
 
 class BeEmptyTest: XCTestCase {
     func testBeEmptyPositive() {
-        expect([]).to(beEmpty())
+        expect([] as [Int]).to(beEmpty())
         expect([1]).toNot(beEmpty())
 
         expect([] as [CInt]).to(beEmpty())
         expect([1] as [CInt]).toNot(beEmpty())
 
-        expect(NSDictionary()).to(beEmpty())
-        expect(NSDictionary(object: 1, forKey: 1)).toNot(beEmpty())
+        expect(NSDictionary() as? [Int:Int]).to(beEmpty())
+        expect(NSDictionary(object: 1, forKey: 1) as? [Int:Int]).toNot(beEmpty())
 
         expect(Dictionary<Int, Int>()).to(beEmpty())
         expect(["hi": 1]).toNot(beEmpty())
 
-        expect(NSArray()).to(beEmpty())
-        expect(NSArray(array: [1])).toNot(beEmpty())
+        expect(NSArray() as? [Int]).to(beEmpty())
+        expect(NSArray(array: [1]) as? [Int]).toNot(beEmpty())
 
-//        expect(NSSet()).to(beEmpty()) // FIXME: ambiguous?
+        expect(NSSet()).to(beEmpty())
         expect(NSSet(array: [1])).toNot(beEmpty())
 
         expect(NSString()).to(beEmpty())

--- a/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/NimbleTests/Matchers/BeLogicalTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 
-enum ConvertsToBool : BooleanType, Printable {
+enum ConvertsToBool : BooleanType, CustomStringConvertible {
     case TrueLike, FalseLike
 
     var boolValue : Bool {


### PR DESCRIPTION
1. Run Edit > Convert > To Latest Swift Syntax.
2. beEmpty() matcher requires an additional definition, not just for
   NSString but for String as well. beEmpty() callsites required casting
   in order to resolve ambiguities around which function was being
   called.