### PR TITLE
Make NMBObjCMatcher initializers public

### DIFF
--- a/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Nimble/Wrappers/ObjCMatcher.swift
@@ -1,33 +1,33 @@
 import Foundation
 
-typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
-typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
+public typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
+public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
 @objc public class NMBObjCMatcher : NMBMatcher {
     let _match: MatcherBlock
     let _doesNotMatch: MatcherBlock
     let canMatchNil: Bool
 
-    init(canMatchNil: Bool, matcher: MatcherBlock, notMatcher: MatcherBlock) {
+    public init(canMatchNil: Bool, matcher: MatcherBlock, notMatcher: MatcherBlock) {
         self.canMatchNil = canMatchNil
         self._match = matcher
         self._doesNotMatch = notMatcher
     }
 
-    convenience init(matcher: MatcherBlock) {
+    public convenience init(matcher: MatcherBlock) {
         self.init(canMatchNil: true, matcher: matcher)
     }
 
-    convenience init(canMatchNil: Bool, matcher: MatcherBlock) {
+    public convenience init(canMatchNil: Bool, matcher: MatcherBlock) {
         self.init(canMatchNil: canMatchNil, matcher: matcher, notMatcher: ({ actualExpression, failureMessage in
             return !matcher(actualExpression: actualExpression, failureMessage: failureMessage)
         }))
     }
 
-    convenience init(matcher: FullMatcherBlock) {
+    public convenience init(matcher: FullMatcherBlock) {
         self.init(canMatchNil: true, matcher: matcher)
     }
 
-    convenience init(canMatchNil: Bool, matcher: FullMatcherBlock) {
+    public convenience init(canMatchNil: Bool, matcher: FullMatcherBlock) {
         self.init(canMatchNil: canMatchNil, matcher: ({ actualExpression, failureMessage in
             return matcher(actualExpression: actualExpression, failureMessage: failureMessage, shouldNotMatch: false)
         }), notMatcher: ({ actualExpression, failureMessage in


### PR DESCRIPTION
I don't think it's possible to have Objective-C compatible third party matchers without this.