### PR TITLE
expectAction(...) requires a void block argument

### DIFF
--- a/Nimble/ObjCExpectation.swift
+++ b/Nimble/ObjCExpectation.swift
@@ -76,4 +76,8 @@ public class NMBExpectation : NSObject {
             )
         })
     }
+
+    public class func failWithMessage(message: String, file: String, line: UInt) {
+        fail(message, location: SourceLocation(file: file, line: line))
+    }
 }

--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -15,6 +15,7 @@
 #endif
 
 NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, unsigned int line);
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), const char *file, unsigned int line);
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue);
 NIMBLE_SHORT(id<NMBMatcher> equal(id expectedValue),
@@ -114,7 +115,9 @@ NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger 
 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, __FILE__, __LINE__)
-#define expectAction(...) NMB_expect(^id{ (__VA_ARGS__); return nil; }, __FILE__, __LINE__)
+#define expectAction(BLOCK) NMB_expectAction((BLOCK), __FILE__, __LINE__)
+#define fail() NMB_expectAction((BLOCK), __FILE__, __LINE__)
+
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil
 #endif

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -16,6 +16,13 @@ NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, u
                                                   line:line];
 }
 
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), const char *file, unsigned int line) {
+    return NMB_expect(^id{
+        actualBlock();
+        return nil;
+    }, file, line);
+}
+
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass) {
     return [NMBObjCMatcher beAnInstanceOfMatcher:expectedClass];
 }

--- a/NimbleTests/objc/NimbleSpecHelper.h
+++ b/NimbleTests/objc/NimbleSpecHelper.h
@@ -1,4 +1,4 @@
-#import <Nimble/Nimble.h>
+@import Nimble;
 #import "NimbleTests-Swift.h"
 
 // Use this when you want to verify the failure message for when an expectation fails

--- a/NimbleTests/objc/ObjCRaiseExceptionTest.m
+++ b/NimbleTests/objc/ObjCRaiseExceptionTest.m
@@ -11,43 +11,44 @@
     __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
                                                              reason:@"No food"
                                                            userInfo:@{@"key": @"value"}];
-    expectAction([exception raise]).to(raiseException());
-    expectAction([exception raise]).to(raiseException().named(NSInvalidArgumentException));
-    expectAction([exception raise]).to(raiseException().
-                                       named(NSInvalidArgumentException).
-                                       reason(@"No food"));
-    expectAction([exception raise]).to(raiseException().
-                                       named(NSInvalidArgumentException).
-                                       reason(@"No food").
-                                       userInfo(@{@"key": @"value"}));
+    expectAction(^{ @throw exception; }).to(raiseException());
+    expectAction(^{ [exception raise]; }).to(raiseException());
+    expectAction(^{ [exception raise]; }).to(raiseException().named(NSInvalidArgumentException));
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             named(NSInvalidArgumentException).
+                                             reason(@"No food"));
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             named(NSInvalidArgumentException).
+                                             reason(@"No food").
+                                             userInfo(@{@"key": @"value"}));
 
-    expectAction(exception).toNot(raiseException());
+    expectAction(^{ }).toNot(raiseException());
 }
 
 - (void)testPositiveMatchesWithBlocks {
     __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
                                                              reason:@"No food"
                                                            userInfo:@{@"key": @"value"}];
-    expectAction([exception raise]).to(raiseException().
-                                       satisfyingBlock(^(NSException *exception) {
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             satisfyingBlock(^(NSException *exception) {
         expect(exception.name).to(equal(NSInvalidArgumentException));
     }));
-    expectAction([exception raise]).to(raiseException().
-                                       named(NSInvalidArgumentException).
-                                       satisfyingBlock(^(NSException *exception) {
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             named(NSInvalidArgumentException).
+                                             satisfyingBlock(^(NSException *exception) {
         expect(exception.name).to(equal(NSInvalidArgumentException));
     }));
-    expectAction([exception raise]).to(raiseException().
-                                       named(NSInvalidArgumentException).
-                                       reason(@"No food").
-                                       satisfyingBlock(^(NSException *exception) {
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             named(NSInvalidArgumentException).
+                                             reason(@"No food").
+                                             satisfyingBlock(^(NSException *exception) {
         expect(exception.name).to(equal(NSInvalidArgumentException));
     }));
-    expectAction([exception raise]).to(raiseException().
-                                       named(NSInvalidArgumentException).
-                                       reason(@"No food").
-                                       userInfo(@{@"key": @"value"}).
-                                       satisfyingBlock(^(NSException *exception) {
+    expectAction(^{ [exception raise]; }).to(raiseException().
+                                             named(NSInvalidArgumentException).
+                                             reason(@"No food").
+                                             userInfo(@{@"key": @"value"}).
+                                             satisfyingBlock(^(NSException *exception) {
         expect(exception.name).to(equal(NSInvalidArgumentException));
     }));
 }
@@ -56,30 +57,31 @@
     __block NSException *exception = [NSException exceptionWithName:NSInvalidArgumentException
                                                              reason:@"No food"
                                                            userInfo:@{@"key": @"value"}];
+
     expectFailureMessage(@"expected to raise any exception, got no exception", ^{
-        expect([exception reason]).to(raiseException());
+        expectAction(^{ }).to(raiseException());
     });
 
     expectFailureMessage(@"expected to raise exception with name <foo>, got no exception", ^{
-        expect([exception reason]).to(raiseException().
-                                      named(@"foo"));
+        expectAction(^{ }).to(raiseException().
+                              named(@"foo"));
     });
 
     expectFailureMessage(@"expected to raise exception with name <NSInvalidArgumentException> with reason <cakes>, got no exception", ^{
-        expect([exception reason]).to(raiseException().
-                                      named(NSInvalidArgumentException).
-                                      reason(@"cakes"));
+        expectAction(^{ }).to(raiseException().
+                              named(NSInvalidArgumentException).
+                              reason(@"cakes"));
     });
 
     expectFailureMessage(@"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{k = v;}>, got no exception", ^{
-        expect([exception reason]).to(raiseException().
-                                      named(NSInvalidArgumentException).
-                                      reason(@"No food").
-                                      userInfo(@{@"k": @"v"}));
+        expectAction(^{ }).to(raiseException().
+                              named(NSInvalidArgumentException).
+                              reason(@"No food").
+                              userInfo(@{@"k": @"v"}));
     });
 
     expectFailureMessage(@"expected to not raise any exception, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }", ^{
-        expectAction([exception raise]).toNot(raiseException());
+        expectAction(^{ [exception raise]; }).toNot(raiseException());
     });
 }
 
@@ -96,38 +98,38 @@
 
     NSString *outerFailureMessage = @"expected to raise exception that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(NSInvalidArgumentException));
         }));
     });
 
     outerFailureMessage = @"expected to raise exception with name <foo> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(@"foo").
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(@"foo").
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(NSInvalidArgumentException));
         }));
     });
 
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <bar> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(NSInvalidArgumentException).
-                                           reason(@"bar").
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(NSInvalidArgumentException).
+                                                 reason(@"bar").
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(NSInvalidArgumentException));
         }));
     });
 
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{}> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(NSInvalidArgumentException).
-                                           reason(@"No food").
-                                           userInfo(@{}).
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(NSInvalidArgumentException).
+                                                 reason(@"No food").
+                                                 userInfo(@{}).
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(NSInvalidArgumentException));
         }));
     });
@@ -142,9 +144,9 @@
     NSString const *innerFailureMessage = @"expected to equal <foo>, got <NSInvalidArgumentException>";
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(NSInvalidArgumentException).
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(NSInvalidArgumentException).
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(@"foo"));
         }));
     });
@@ -152,10 +154,10 @@
 
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(NSInvalidArgumentException).
-                                           reason(@"No food").
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(NSInvalidArgumentException).
+                                                 reason(@"No food").
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(@"foo"));
         }));
     });
@@ -163,11 +165,11 @@
 
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
-        expectAction([exception raise]).to(raiseException().
-                                           named(NSInvalidArgumentException).
-                                           reason(@"No food").
-                                           userInfo(@{@"key": @"value"}).
-                                           satisfyingBlock(^(NSException *exception) {
+        expectAction(^{ [exception raise]; }).to(raiseException().
+                                                 named(NSInvalidArgumentException).
+                                                 reason(@"No food").
+                                                 userInfo(@{@"key": @"value"}).
+                                                 satisfyingBlock(^(NSException *exception) {
             expect(exception.name).to(equal(@"foo"));
         }));
     });

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ value:
 NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
                                                  reason:@"Not enough fish in the sea."
                                                userInfo:nil];
-expectAction([exception raise]).to(raiseException());
+expectAction(^{ [exception raise]; }).to(raiseException());
 
 // Use the property-block syntax to be more specific.
-expectAction([exception raise]).to(raiseException().named(NSInternalInconsistencyException));
-expectAction([exception raise]).to(raiseException().
+expectAction(^{ [exception raise]; }).to(raiseException().named(NSInternalInconsistencyException));
+expectAction(^{ [exception raise]; }).to(raiseException().
     named(NSInternalInconsistencyException).
     reason("Not enough fish in the sea"));
-expectAction([exception raise]).to(raiseException().
+expectAction(^{ [exception raise]; }).to(raiseException().
     named(NSInternalInconsistencyException).
     reason("Not enough fish in the sea").
     userInfo(@{@"something": @"is fishy"}));
@@ -362,7 +362,7 @@ to keep in mind when using Nimble in Objective-C:
    ```objc
    // Objective-C
 
-   expectAction([exception raise]).to(raiseException());
+   expectAction(^{ [exception raise]; }).to(raiseException());
    ```
 
 ## Disabling Objective-C Shorthand


### PR DESCRIPTION
Breaking change for Objective-C API.

Instead of:

```objc
expectAction([exception raise])
```

Is now:

```objc
expectAction(^{ [expection raise]; })
```

Which is more intuitive for objective-c users. `NMB_expectAction()` is defined to provide a compiler error to users migrating to Nimble 2.

Also converted `#import <Nimble/Nimble.h>` to `@import Nimble;` in tests to avoid clean compile issues (rdar://21376825).

Closes #134.