### PR TITLE
Breaking Change: Support for Swift Error Handling

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -66,6 +66,10 @@
 		1F4A569E1A3B3565009E1637 /* ObjCMatchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */; };
 		1F4A56A01A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
 		1F4A56A11A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */; };
+		1F6AACA21B43CD3F00FD81CF /* RaisesErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6AACA11B43CD3F00FD81CF /* RaisesErrorTest.swift */; };
+		1F6AACA31B43CD3F00FD81CF /* RaisesErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6AACA11B43CD3F00FD81CF /* RaisesErrorTest.swift */; };
+		1F7830EC1B43DB4B001225E1 /* ThrowAnError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7830EB1B43DB4B001225E1 /* ThrowAnError.swift */; };
+		1F7830ED1B43DB4B001225E1 /* ThrowAnError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7830EB1B43DB4B001225E1 /* ThrowAnError.swift */; };
 		1F925EB8195C0D6300ED456B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F925EAD195C0D6300ED456B /* Nimble.framework */; };
 		1F925EC7195C0DD100ED456B /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F925EE2195C0DFD00ED456B /* utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14FB63194180C5009F2A08 /* utils.swift */; };
@@ -276,6 +280,8 @@
 		1F4A56991A3B3539009E1637 /* ObjCEqualTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCEqualTest.m; sourceTree = "<group>"; };
 		1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCMatchTest.m; sourceTree = "<group>"; };
 		1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCRaiseExceptionTest.m; sourceTree = "<group>"; };
+		1F6AACA11B43CD3F00FD81CF /* RaisesErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaisesErrorTest.swift; sourceTree = "<group>"; };
+		1F7830EB1B43DB4B001225E1 /* ThrowAnError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAnError.swift; sourceTree = "<group>"; };
 		1F925EAD195C0D6300ED456B /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F925EB7195C0D6300ED456B /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F925EE5195C121200ED456B /* AsynchronousTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsynchronousTest.swift; sourceTree = "<group>"; };
@@ -457,25 +463,26 @@
 		1F925EE3195C11B000ED456B /* Matchers */ = {
 			isa = PBXGroup;
 			children = (
-				1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */,
-				1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */,
-				1F925EEE195C136500ED456B /* BeLogicalTest.swift */,
-				1F925EF5195C147800ED456B /* BeCloseToTest.swift */,
-				1F925EF8195C175000ED456B /* BeNilTest.swift */,
-				1F925EFB195C186800ED456B /* BeginWithTest.swift */,
-				1F925EFE195C187600ED456B /* EndWithTest.swift */,
-				1F925F01195C189500ED456B /* ContainTest.swift */,
-				1F925F04195C18B700ED456B /* EqualTest.swift */,
-				1F925F07195C18CF00ED456B /* BeGreaterThanTest.swift */,
-				1F925F0A195C18E100ED456B /* BeLessThanTest.swift */,
-				1F925F0D195C18F500ED456B /* BeLessThanOrEqualToTest.swift */,
-				1F925F10195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift */,
-				1FB90097195EC4B8001D7FAE /* BeIdenticalToTest.swift */,
-				DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */,
-				1F299EAA19627B2D002641AF /* BeEmptyTest.swift */,
-				1F1B5AD31963E13900CA8BF9 /* BeAKindOfTest.swift */,
-				DDB4D5EF19FE442800E9D9FE /* MatchTest.swift */,
 				DD72EC631A93874A002F7651 /* AllPassTest.swift */,
+				1F1B5AD31963E13900CA8BF9 /* BeAKindOfTest.swift */,
+				1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */,
+				1F925EF5195C147800ED456B /* BeCloseToTest.swift */,
+				1F299EAA19627B2D002641AF /* BeEmptyTest.swift */,
+				1F925EFB195C186800ED456B /* BeginWithTest.swift */,
+				1F925F10195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift */,
+				1F925F07195C18CF00ED456B /* BeGreaterThanTest.swift */,
+				DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */,
+				1FB90097195EC4B8001D7FAE /* BeIdenticalToTest.swift */,
+				1F925F0D195C18F500ED456B /* BeLessThanOrEqualToTest.swift */,
+				1F925F0A195C18E100ED456B /* BeLessThanTest.swift */,
+				1F925EEE195C136500ED456B /* BeLogicalTest.swift */,
+				1F925EF8195C175000ED456B /* BeNilTest.swift */,
+				1F925F01195C189500ED456B /* ContainTest.swift */,
+				1F925EFE195C187600ED456B /* EndWithTest.swift */,
+				1F925F04195C18B700ED456B /* EqualTest.swift */,
+				DDB4D5EF19FE442800E9D9FE /* MatchTest.swift */,
+				1F6AACA11B43CD3F00FD81CF /* RaisesErrorTest.swift */,
+				1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -513,6 +520,7 @@
 				DDB4D5EC19FE43C200E9D9FE /* Match.swift */,
 				1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */,
 				1FD8CD1E1968AB07008ED995 /* RaisesException.swift */,
+				1F7830EB1B43DB4B001225E1 /* ThrowAnError.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -781,6 +789,7 @@
 				1F0FEA9A1AF32DA4001E554E /* ObjCExpectation.swift in Sources */,
 				1FD8CD661968AB07008ED995 /* NMBExceptionCapture.m in Sources */,
 				DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */,
+				1F7830EC1B43DB4B001225E1 /* ThrowAnError.swift in Sources */,
 				DDB1BC791A92235600F743C3 /* AllPass.swift in Sources */,
 				1FD8CD3E1968AB07008ED995 /* BeAKindOf.swift in Sources */,
 				DDB4D5ED19FE43C200E9D9FE /* Match.swift in Sources */,
@@ -839,6 +848,7 @@
 				1F4A567C1A3B3311009E1637 /* ObjCBeIdenticalToTest.m in Sources */,
 				1F4A56911A3B344A009E1637 /* ObjCBeNilTest.m in Sources */,
 				1F4A56941A3B346F009E1637 /* ObjCContainTest.m in Sources */,
+				1F6AACA21B43CD3F00FD81CF /* RaisesErrorTest.swift in Sources */,
 				1F299EAB19627B2D002641AF /* BeEmptyTest.swift in Sources */,
 				1F925EF6195C147800ED456B /* BeCloseToTest.swift in Sources */,
 				1F4A56791A3B32E3009E1637 /* ObjCBeGreaterThanOrEqualToTest.m in Sources */,
@@ -878,6 +888,7 @@
 				1F0FEA9B1AF32DA4001E554E /* ObjCExpectation.swift in Sources */,
 				1FD8CD671968AB07008ED995 /* NMBExceptionCapture.m in Sources */,
 				DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */,
+				1F7830ED1B43DB4B001225E1 /* ThrowAnError.swift in Sources */,
 				DDB1BC7A1A92235600F743C3 /* AllPass.swift in Sources */,
 				1FD8CD3F1968AB07008ED995 /* BeAKindOf.swift in Sources */,
 				1FD8CD2F1968AB07008ED995 /* AssertionRecorder.swift in Sources */,
@@ -936,6 +947,7 @@
 				1F4A567D1A3B3311009E1637 /* ObjCBeIdenticalToTest.m in Sources */,
 				1F4A56921A3B344A009E1637 /* ObjCBeNilTest.m in Sources */,
 				1F4A56951A3B346F009E1637 /* ObjCContainTest.m in Sources */,
+				1F6AACA31B43CD3F00FD81CF /* RaisesErrorTest.swift in Sources */,
 				1F299EAC19627B2D002641AF /* BeEmptyTest.swift in Sources */,
 				1F925EF7195C147800ED456B /* BeCloseToTest.swift in Sources */,
 				1F4A567A1A3B32E3009E1637 /* ObjCBeGreaterThanOrEqualToTest.m in Sources */,

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -64,7 +64,7 @@ public func withAssertionHandler(tempAssertionHandler: AssertionHandler, closure
 ///                 assertion handler when this is true. Defaults to false.
 ///
 /// @see gatherFailingExpectations
-public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
+public func gatherExpectations(silently silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let previousRecorder = NimbleAssertionHandler
     let recorder = AssertionRecorder()
     let handlers: [AssertionHandler]
@@ -91,8 +91,8 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
 ///
 /// @see gatherExpectations
 /// @see raiseException source for an example use case.
-public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
-    let assertions = gatherExpectations(silently, closure: closure)
+public func gatherFailingExpectations(silently silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
+    let assertions = gatherExpectations(silently: silently, closure: closure)
     return assertions.filter { assertion in
         !assertion.success
     }

--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -15,11 +15,17 @@ import Foundation
             }
             return completed
         }
-        if result == PollResult.Failure {
+        switch (result) {
+        case .Failure:
             let pluralize = (timeout == 1 ? "" : "s")
             fail("Waited more than \(timeout) second\(pluralize)", file: file, line: line)
-        } else if result == PollResult.Timeout {
+        case .Timeout:
             fail("Stall on main thread - too much enqueued on main run loop before waitUntil executes.", file: file, line: line)
+        case let .ErrorThrown(error):
+            // Technically, we can never reach this via a public API call
+            fail("Unexpected error thrown: \(error)", file: file, line: line)
+        case .Success:
+            break
         }
     }
 

--- a/Nimble/DSL.swift
+++ b/Nimble/DSL.swift
@@ -1,5 +1,5 @@
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(@autoclosure(escaping) expression: () -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -8,7 +8,7 @@ public func expect<T>(@autoclosure(escaping) expression: () -> T?, file: String 
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression: () -> T?) -> Expectation<T> {
+public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -3,21 +3,31 @@ import Foundation
 internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, to: String) -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.to = to
-    let pass = matcher.matches(expression, failureMessage: msg)
-    if msg.actualValue == "" {
-        msg.actualValue = "<\(stringify(expression.evaluate()))>"
+    do {
+        let pass = try matcher.matches(expression, failureMessage: msg)
+        if msg.actualValue == "" {
+            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
+        }
+        return (pass, msg)
+    } catch let error {
+        msg.actualValue = "an unexpected error thrown: <\(error)>"
+        return (false, msg)
     }
-    return (pass, msg)
 }
 
 internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, toNot: String) -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.to = toNot
-    let pass = matcher.doesNotMatch(expression, failureMessage: msg)
-    if msg.actualValue == "" {
-        msg.actualValue = "<\(stringify(expression.evaluate()))>"
+    do {
+        let pass = try matcher.doesNotMatch(expression, failureMessage: msg)
+        if msg.actualValue == "" {
+            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
+        }
+        return (pass, msg)
+    } catch let error {
+        msg.actualValue = "an unexpected error thrown: <\(error)>"
+        return (false, msg)
     }
-    return (pass, msg)
 }
 
 public struct Expectation<T> {

--- a/Nimble/Expression.swift
+++ b/Nimble/Expression.swift
@@ -2,11 +2,11 @@ import Foundation
 
 // Memoizes the given closure, only calling the passed
 // closure once; even if repeat calls to the returned closure
-internal func memoizedClosure<T>(closure: () -> T) -> (Bool) -> T {
+internal func memoizedClosure<T>(closure: () throws -> T) -> (Bool) throws -> T {
     var cache: T?
     return ({ withoutCaching in
         if (withoutCaching || cache == nil) {
-            cache = closure()
+            cache = try closure()
         }
         return cache!
     })
@@ -24,7 +24,7 @@ internal func memoizedClosure<T>(closure: () -> T) -> (Bool) -> T {
 /// This provides a common consumable API for matchers to utilize to allow
 /// Nimble to change internals to how the captured closure is managed.
 public struct Expression<T> {
-    internal let _expression: (Bool) -> T?
+    internal let _expression: (Bool) throws -> T?
     internal let _withoutCaching: Bool
     public let location: SourceLocation
     public let isClosure: Bool
@@ -40,7 +40,7 @@ public struct Expression<T> {
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(expression: () -> T?, location: SourceLocation, isClosure: Bool = true) {
+    public init(expression: () throws -> T?, location: SourceLocation, isClosure: Bool = true) {
         self._expression = memoizedClosure(expression)
         self.location = location
         self._withoutCaching = false
@@ -61,7 +61,7 @@ public struct Expression<T> {
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(memoizedExpression: (Bool) -> T?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
+    public init(memoizedExpression: (Bool) throws -> T?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
         self._expression = memoizedExpression
         self.location = location
         self._withoutCaching = withoutCaching
@@ -76,12 +76,12 @@ public struct Expression<T> {
     ///
     /// @param block The block that can cast the current Expression value to a
     ///              new type.
-    public func cast<U>(block: (T?) -> U?) -> Expression<U> {
-        return Expression<U>(expression: ({ block(self.evaluate()) }), location: self.location, isClosure: self.isClosure)
+    public func cast<U>(block: (T?) throws -> U?) -> Expression<U> {
+        return Expression<U>(expression: ({ try block(self.evaluate()) }), location: self.location, isClosure: self.isClosure)
     }
 
-    public func evaluate() -> T? {
-        return self._expression(_withoutCaching)
+    public func evaluate() throws -> T? {
+        return try self._expression(_withoutCaching)
     }
 
     public func withoutCaching() -> Expression<T> {

--- a/Nimble/Matchers/BeAKindOf.swift
+++ b/Nimble/Matchers/BeAKindOf.swift
@@ -14,7 +14,7 @@ public func beAKindOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
 /// @see beAnInstanceOf if you want to match against the exact class
 public func beAKindOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        let instance = actualExpression.evaluate()
+        let instance = try actualExpression.evaluate()
         if let validInstance = instance {
             failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
         } else {
@@ -28,7 +28,7 @@ public func beAKindOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
 extension NMBObjCMatcher {
     public class func beAKindOfMatcher(expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            return beAKindOf(expected).matches(actualExpression, failureMessage: failureMessage)
+            return try! beAKindOf(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Nimble/Matchers/BeAnInstanceOf.swift
@@ -14,7 +14,7 @@ public func beAnInstanceOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
 /// @see beAKindOf if you want to match against subclasses
 public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        let instance = actualExpression.evaluate()
+        let instance = try actualExpression.evaluate()
         if let validInstance = instance {
             failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
         } else {
@@ -28,7 +28,7 @@ public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObjec
 extension NMBObjCMatcher {
     public class func beAnInstanceOfMatcher(expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            return beAnInstanceOf(expected).matches(actualExpression, failureMessage: failureMessage)
+            return try! beAnInstanceOf(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -18,7 +18,7 @@ internal func isCloseTo(actualValue: Double?, expectedValue: Double, delta: Doub
 /// @see equal
 public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta) -> NonNilMatcherFunc<Double> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        return isCloseTo(actualExpression.evaluate(), expectedValue: expectedValue, delta: delta, failureMessage: failureMessage)
+        return isCloseTo(try actualExpression.evaluate(), expectedValue: expectedValue, delta: delta, failureMessage: failureMessage)
     }
 }
 
@@ -28,7 +28,7 @@ public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta
 /// @see equal
 public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double = DefaultDelta) -> NonNilMatcherFunc<NMBDoubleConvertible> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        return isCloseTo(actualExpression.evaluate()?.doubleValue, expectedValue: expectedValue.doubleValue, delta: delta, failureMessage: failureMessage)
+        return isCloseTo(try actualExpression.evaluate()?.doubleValue, expectedValue: expectedValue.doubleValue, delta: delta, failureMessage: failureMessage)
     }
 }
 
@@ -46,7 +46,7 @@ public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double 
         })
         let expr = Expression(expression: actualBlock, location: location)
         let matcher = beCloseTo(self._expected, within: self._delta)
-        return matcher.matches(expr, failureMessage: failureMessage)
+        return try! matcher.matches(expr, failureMessage: failureMessage)
     }
 
     public func doesNotMatch(actualExpression: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
@@ -55,7 +55,7 @@ public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double 
         })
         let expr = Expression(expression: actualBlock, location: location)
         let matcher = beCloseTo(self._expected, within: self._delta)
-        return matcher.doesNotMatch(expr, failureMessage: failureMessage)
+        return try! matcher.doesNotMatch(expr, failureMessage: failureMessage)
     }
 
     public var within: (CDouble) -> NMBObjCBeCloseToMatcher {
@@ -74,7 +74,7 @@ extension NMBObjCMatcher {
 public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDelta) -> NonNilMatcherFunc <[Double]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be close to <\(stringify(expectedValues))> (each within \(stringify(delta)))"
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             if actual.count != expectedValues.count {
                 return false
             } else {

--- a/Nimble/Matchers/BeEmpty.swift
+++ b/Nimble/Matchers/BeEmpty.swift
@@ -6,7 +6,7 @@ import Foundation
 public func beEmpty<S: SequenceType>() -> NonNilMatcherFunc<S> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
-        let actualSeq = actualExpression.evaluate()
+        let actualSeq = try actualExpression.evaluate()
         if actualSeq == nil {
             return true
         }
@@ -20,7 +20,7 @@ public func beEmpty<S: SequenceType>() -> NonNilMatcherFunc<S> {
 public func beEmpty() -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
-        let actualString = actualExpression.evaluate()
+        let actualString = try actualExpression.evaluate()
         return actualString == nil || (actualString! as NSString).length  == 0
     }
 }
@@ -30,7 +30,7 @@ public func beEmpty() -> NonNilMatcherFunc<String> {
 public func beEmpty() -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
-        let actualString = actualExpression.evaluate()
+        let actualString = try actualExpression.evaluate()
         return actualString == nil || actualString!.length == 0
     }
 }
@@ -43,7 +43,7 @@ public func beEmpty() -> NonNilMatcherFunc<NSString> {
 public func beEmpty() -> NonNilMatcherFunc<NSDictionary> {
 	return NonNilMatcherFunc { actualExpression, failureMessage in
 		failureMessage.postfixMessage = "be empty"
-		let actualDictionary = actualExpression.evaluate()
+		let actualDictionary = try actualExpression.evaluate()
 		return actualDictionary == nil || actualDictionary!.count == 0
 	}
 }
@@ -53,7 +53,7 @@ public func beEmpty() -> NonNilMatcherFunc<NSDictionary> {
 public func beEmpty() -> NonNilMatcherFunc<NSArray> {
 	return NonNilMatcherFunc { actualExpression, failureMessage in
 		failureMessage.postfixMessage = "be empty"
-		let actualArray = actualExpression.evaluate()
+		let actualArray = try actualExpression.evaluate()
 		return actualArray == nil || actualArray!.count == 0
 	}
 }
@@ -63,7 +63,7 @@ public func beEmpty() -> NonNilMatcherFunc<NSArray> {
 public func beEmpty() -> NonNilMatcherFunc<NMBCollection> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
-        let actual = actualExpression.evaluate()
+        let actual = try actualExpression.evaluate()
         return actual == nil || actual!.count == 0
     }
 }
@@ -72,14 +72,14 @@ extension NMBObjCMatcher {
     public class func beEmptyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let location = actualExpression.location
-            let actualValue = actualExpression.evaluate()
+            let actualValue = try! actualExpression.evaluate()
             failureMessage.postfixMessage = "be empty"
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value as NMBCollection }), location: location)
-                return beEmpty().matches(expr, failureMessage: failureMessage)
+                return try! beEmpty().matches(expr, failureMessage: failureMessage)
             } else if let value = actualValue as? NSString {
                 let expr = Expression(expression: ({ value as String }), location: location)
-                return beEmpty().matches(expr, failureMessage: failureMessage)
+                return try! beEmpty().matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
                 failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings)"
                 failureMessage.actualValue = "\(NSStringFromClass(actualValue.dynamicType)) type"

--- a/Nimble/Matchers/BeGreaterThan.swift
+++ b/Nimble/Matchers/BeGreaterThan.swift
@@ -5,7 +5,7 @@ import Foundation
 public func beGreaterThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be greater than <\(stringify(expectedValue))>"
-        return actualExpression.evaluate() > expectedValue
+        return try actualExpression.evaluate() > expectedValue
     }
 }
 
@@ -13,7 +13,7 @@ public func beGreaterThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc
 public func beGreaterThan(expectedValue: NMBComparable?) -> NonNilMatcherFunc<NMBComparable> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be greater than <\(stringify(expectedValue))>"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) == NSComparisonResult.OrderedDescending
         return matches
     }
@@ -31,7 +31,7 @@ extension NMBObjCMatcher {
     public class func beGreaterThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return beGreaterThan(expected).matches(expr, failureMessage: failureMessage)
+            return try! beGreaterThan(expected).matches(expr, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -5,7 +5,7 @@ import Foundation
 public func beGreaterThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be greater than or equal to <\(stringify(expectedValue))>"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         return actualValue >= expectedValue
     }
 }
@@ -15,7 +15,7 @@ public func beGreaterThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMa
 public func beGreaterThanOrEqualTo<T: NMBComparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be greater than or equal to <\(stringify(expectedValue))>"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) != NSComparisonResult.OrderedAscending
         return matches
     }
@@ -33,7 +33,7 @@ extension NMBObjCMatcher {
     public class func beGreaterThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return beGreaterThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
+            return try! beGreaterThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Nimble/Matchers/BeIdenticalTo.swift
@@ -5,7 +5,7 @@ import Foundation
 /// as the expected instance.
 public func beIdenticalTo<T: AnyObject>(expected: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        let actual = actualExpression.evaluate()
+        let actual = try actualExpression.evaluate()
         failureMessage.actualValue = "\(identityAsString(actual))"
         failureMessage.postfixMessage = "be identical to \(identityAsString(expected))"
         return actual === expected && actual !== nil
@@ -22,7 +22,7 @@ public func !==<T: AnyObject>(lhs: Expectation<T>, rhs: T?) {
 extension NMBObjCMatcher {
     public class func beIdenticalToMatcher(expected: NSObject?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            return beIdenticalTo(expected).matches(actualExpression, failureMessage: failureMessage)
+            return try! beIdenticalTo(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeLessThan.swift
+++ b/Nimble/Matchers/BeLessThan.swift
@@ -4,7 +4,7 @@ import Foundation
 public func beLessThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be less than <\(stringify(expectedValue))>"
-        return actualExpression.evaluate() < expectedValue
+        return try actualExpression.evaluate() < expectedValue
     }
 }
 
@@ -12,7 +12,7 @@ public func beLessThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T>
 public func beLessThan(expectedValue: NMBComparable?) -> NonNilMatcherFunc<NMBComparable> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be less than <\(stringify(expectedValue))>"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) == NSComparisonResult.OrderedAscending
         return matches
     }
@@ -30,7 +30,7 @@ extension NMBObjCMatcher {
     public class func beLessThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as! NMBComparable? }
-            return beLessThan(expected).matches(expr, failureMessage: failureMessage)
+            return try! beLessThan(expected).matches(expr, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -5,7 +5,7 @@ import Foundation
 public func beLessThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be less than or equal to <\(stringify(expectedValue))>"
-        return actualExpression.evaluate() <= expectedValue
+        return try actualExpression.evaluate() <= expectedValue
     }
 }
 
@@ -14,7 +14,7 @@ public func beLessThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatch
 public func beLessThanOrEqualTo<T: NMBComparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be less than or equal to <\(stringify(expectedValue))>"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         return actualValue != nil && actualValue!.NMB_compare(expectedValue) != NSComparisonResult.OrderedDescending
     }
 }
@@ -31,7 +31,7 @@ extension NMBObjCMatcher {
     public class func beLessThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil:false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
-            return beLessThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
+            return try! beLessThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeLogical.swift
+++ b/Nimble/Matchers/BeLogical.swift
@@ -4,9 +4,9 @@ internal func matcherWithFailureMessage<T, M: Matcher where M.ValueType == T>(ma
     return FullMatcherFunc { actualExpression, failureMessage, isNegation in
         let pass: Bool
         if isNegation {
-            pass = matcher.doesNotMatch(actualExpression, failureMessage: failureMessage)
+            pass = try matcher.doesNotMatch(actualExpression, failureMessage: failureMessage)
         } else {
-            pass = matcher.matches(actualExpression, failureMessage: failureMessage)
+            pass = try matcher.matches(actualExpression, failureMessage: failureMessage)
         }
         postprocessor(failureMessage)
         return pass
@@ -37,7 +37,7 @@ public func beFalse() -> FullMatcherFunc<Bool> {
 public func beTruthy<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be truthy"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         if let actualValue = actualValue {
             if let actualValue = actualValue as? BooleanType {
                 return actualValue.boolValue == true
@@ -52,7 +52,7 @@ public func beTruthy<T>() -> MatcherFunc<T> {
 public func beFalsy<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be falsy"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         if let actualValue = actualValue {
             if let actualValue = actualValue as? BooleanType {
                 return actualValue.boolValue != true
@@ -66,28 +66,28 @@ extension NMBObjCMatcher {
     public class func beTruthyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as BooleanType? }
-            return beTruthy().matches(expr, failureMessage: failureMessage)
+            return try! beTruthy().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beFalsyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as BooleanType? }
-            return beFalsy().matches(expr, failureMessage: failureMessage)
+            return try! beFalsy().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beTrueMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
-            return beTrue().matches(expr, failureMessage: failureMessage)
+            return try! beTrue().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beFalseMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
-            return beFalse().matches(expr, failureMessage: failureMessage)
+            return try! beFalse().matches(expr, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeNil.swift
+++ b/Nimble/Matchers/BeNil.swift
@@ -4,7 +4,7 @@ import Foundation
 public func beNil<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be nil"
-        let actualValue = actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         return actualValue == nil
     }
 }
@@ -12,7 +12,7 @@ public func beNil<T>() -> MatcherFunc<T> {
 extension NMBObjCMatcher {
     public class func beNilMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
-            return beNil().matches(actualExpression, failureMessage: failureMessage)
+            return try! beNil().matches(actualExpression, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/BeginWith.swift
+++ b/Nimble/Matchers/BeginWith.swift
@@ -6,7 +6,7 @@ import Foundation
 public func beginWith<S: SequenceType, T: Equatable where S.Generator.Element == T>(startingElement: T) -> NonNilMatcherFunc<S> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "begin with <\(startingElement)>"
-        if let actualValue = actualExpression.evaluate() {
+        if let actualValue = try actualExpression.evaluate() {
             var actualGenerator = actualValue.generate()
             return actualGenerator.next() == startingElement
         }
@@ -19,7 +19,7 @@ public func beginWith<S: SequenceType, T: Equatable where S.Generator.Element ==
 public func beginWith(startingElement: AnyObject) -> NonNilMatcherFunc<NMBOrderedCollection> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "begin with <\(startingElement)>"
-        let collection = actualExpression.evaluate()
+        let collection = try actualExpression.evaluate()
         return collection != nil && collection!.indexOfObject(startingElement) == 0
     }
 }
@@ -29,7 +29,7 @@ public func beginWith(startingElement: AnyObject) -> NonNilMatcherFunc<NMBOrdere
 public func beginWith(startingSubstring: String) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "begin with <\(startingSubstring)>"
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             let range = actual.rangeOfString(startingSubstring)
             return range != nil && range!.startIndex == actual.startIndex
         }
@@ -40,13 +40,13 @@ public func beginWith(startingSubstring: String) -> NonNilMatcherFunc<String> {
 extension NMBObjCMatcher {
     public class func beginWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let actual = actualExpression.evaluate()
+            let actual = try! actualExpression.evaluate()
             if let _ = actual as? String {
                 let expr = actualExpression.cast { $0 as? String }
-                return beginWith(expected as! String).matches(expr, failureMessage: failureMessage)
+                return try! beginWith(expected as! String).matches(expr, failureMessage: failureMessage)
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
-                return beginWith(expected).matches(expr, failureMessage: failureMessage)
+                return try! beginWith(expected).matches(expr, failureMessage: failureMessage)
             }
         }
     }

--- a/Nimble/Matchers/Contain.swift
+++ b/Nimble/Matchers/Contain.swift
@@ -4,7 +4,7 @@ import Foundation
 public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T>(items: T...) -> NonNilMatcherFunc<S> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             return all(items) {
                 return actual.contains($0)
             }
@@ -17,7 +17,7 @@ public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T
 public func contain(substrings: String...) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             return all(substrings) {
                 let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
                 let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
@@ -32,7 +32,7 @@ public func contain(substrings: String...) -> NonNilMatcherFunc<String> {
 public func contain(substrings: NSString...) -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             return all(substrings) { actual.rangeOfString($0.description).length != 0 }
         }
         return false
@@ -43,7 +43,7 @@ public func contain(substrings: NSString...) -> NonNilMatcherFunc<NSString> {
 public func contain(items: AnyObject?...) -> NonNilMatcherFunc<NMBContainer> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
-        let actual = actualExpression.evaluate()
+        let actual = try actualExpression.evaluate()
         return all(items) { item in
             return actual != nil && actual!.containsObject(item)
         }
@@ -54,13 +54,13 @@ extension NMBObjCMatcher {
     public class func containMatcher(expected: NSObject?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let location = actualExpression.location
-            let actualValue = actualExpression.evaluate()
+            let actualValue = try! actualExpression.evaluate()
             if let value = actualValue as? NMBContainer {
                 let expr = Expression(expression: ({ value as NMBContainer }), location: location)
-                return contain(expected).matches(expr, failureMessage: failureMessage)
+                return try! contain(expected).matches(expr, failureMessage: failureMessage)
             } else if let value = actualValue as? NSString {
                 let expr = Expression(expression: ({ value as String }), location: location)
-                return contain(expected as! String).matches(expr, failureMessage: failureMessage)
+                return try! contain(expected as! String).matches(expr, failureMessage: failureMessage)
             } else if actualValue != nil {
                 failureMessage.postfixMessage = "contain <\(stringify(expected))> (only works for NSArrays, NSSets, NSHashTables, and NSStrings)"
             } else {

--- a/Nimble/Matchers/EndWith.swift
+++ b/Nimble/Matchers/EndWith.swift
@@ -7,7 +7,7 @@ public func endWith<S: SequenceType, T: Equatable where S.Generator.Element == T
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "end with <\(endingElement)>"
 
-        if let actualValue = actualExpression.evaluate() {
+        if let actualValue = try actualExpression.evaluate() {
             var actualGenerator = actualValue.generate()
             var lastItem: T?
             var item: T?
@@ -27,7 +27,7 @@ public func endWith<S: SequenceType, T: Equatable where S.Generator.Element == T
 public func endWith(endingElement: AnyObject) -> NonNilMatcherFunc<NMBOrderedCollection> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "end with <\(endingElement)>"
-        let collection = actualExpression.evaluate()
+        let collection = try actualExpression.evaluate()
         return collection != nil && collection!.indexOfObject(endingElement) == collection!.count - 1
     }
 }
@@ -39,7 +39,7 @@ public func endWith(endingElement: AnyObject) -> NonNilMatcherFunc<NMBOrderedCol
 public func endWith(endingSubstring: String) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "end with <\(endingSubstring)>"
-        if let collection = actualExpression.evaluate() {
+        if let collection = try actualExpression.evaluate() {
             let range = collection.rangeOfString(endingSubstring)
             return range != nil && range!.endIndex == collection.endIndex
         }
@@ -50,13 +50,13 @@ public func endWith(endingSubstring: String) -> NonNilMatcherFunc<String> {
 extension NMBObjCMatcher {
     public class func endWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let actual = actualExpression.evaluate()
+            let actual = try! actualExpression.evaluate()
             if let _ = actual as? String {
                 let expr = actualExpression.cast { $0 as? String }
-                return endWith(expected as! String).matches(expr, failureMessage: failureMessage)
+                return try! endWith(expected as! String).matches(expr, failureMessage: failureMessage)
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
-                return endWith(expected).matches(expr, failureMessage: failureMessage)
+                return try! endWith(expected).matches(expr, failureMessage: failureMessage)
             }
         }
     }

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -7,8 +7,9 @@ import Foundation
 public func equal<T: Equatable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        let matches = actualExpression.evaluate() == expectedValue && expectedValue != nil
-        if expectedValue == nil || actualExpression.evaluate() == nil {
+        let actualValue = try actualExpression.evaluate()
+        let matches = actualValue == expectedValue && expectedValue != nil
+        if expectedValue == nil || actualValue == nil {
             if expectedValue == nil {
                 failureMessage.postfixActual = " (use beNil() to match nils)"
             }
@@ -25,13 +26,14 @@ public func equal<T: Equatable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
 public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]?) -> NonNilMatcherFunc<[T: C]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        if expectedValue == nil || actualExpression.evaluate() == nil {
+        let actualValue = try actualExpression.evaluate()
+        if expectedValue == nil || actualValue == nil {
             if expectedValue == nil {
                 failureMessage.postfixActual = " (use beNil() to match nils)"
             }
             return false
         }
-        return expectedValue! == actualExpression.evaluate()!
+        return expectedValue! == actualValue!
     }
 }
 
@@ -40,13 +42,14 @@ public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]?) -> NonNilM
 public func equal<T: Equatable>(expectedValue: [T]?) -> NonNilMatcherFunc<[T]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        if expectedValue == nil || actualExpression.evaluate() == nil {
+        let actualValue = try actualExpression.evaluate()
+        if expectedValue == nil || actualValue == nil {
             if expectedValue == nil {
                 failureMessage.postfixActual = " (use beNil() to match nils)"
             }
             return false
         }
-        return expectedValue! == actualExpression.evaluate()!
+        return expectedValue! == actualValue!
     }
 }
 
@@ -71,7 +74,7 @@ private func equal<T>(expectedValue: Set<T>?, stringify: Set<T>? -> String) -> N
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
 
         if let expectedValue = expectedValue {
-            if let actualValue = actualExpression.evaluate() {
+            if let actualValue = try actualExpression.evaluate() {
                 failureMessage.actualValue = "<\(stringify(actualValue))>"
 
                 if expectedValue == actualValue {
@@ -139,7 +142,7 @@ public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]
 extension NMBObjCMatcher {
     public class func equalMatcher(expected: NSObject) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            return equal(expected).matches(actualExpression, failureMessage: failureMessage)
+            return try! equal(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/Match.swift
+++ b/Nimble/Matchers/Match.swift
@@ -6,7 +6,7 @@ public func match(expectedValue: String?) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "match <\(stringify(expectedValue))>"
         
-        if let actual = actualExpression.evaluate() {
+        if let actual = try actualExpression.evaluate() {
             if let regexp = expectedValue {
                 return actual.rangeOfString(regexp, options: .RegularExpressionSearch) != nil
             }
@@ -20,7 +20,7 @@ extension NMBObjCMatcher {
     public class func matchMatcher(expected: NSString) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let actual = actualExpression.cast { $0 as? String }
-            return match(expected.description).matches(actual, failureMessage: failureMessage)
+            return try! match(expected.description).matches(actual, failureMessage: failureMessage)
         }
     }
 }

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
     typealias ValueType
-    func matches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) -> Bool
-    func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) -> Bool
+    func matches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
+    func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }
 
 /// Objective-C interface to the Swift variant of Matcher.

--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -22,7 +22,7 @@ public func raiseException(
             }), finally: nil)
 
             capture.tryBlock {
-                actualExpression.evaluate()
+                try! actualExpression.evaluate()
                 return
             }
 
@@ -114,7 +114,7 @@ internal func exceptionMatchesNonNilFieldsOrClosure(
         let block: () -> Any? = ({ actualBlock(); return nil })
         let expr = Expression(expression: block, location: location)
 
-        return raiseException(
+        return try! raiseException(
             named: _name,
             reason: _reason,
             userInfo: _userInfo,

--- a/Nimble/Matchers/ThrowAnError.swift
+++ b/Nimble/Matchers/ThrowAnError.swift
@@ -1,0 +1,48 @@
+public struct ThrowErrorMatcher: Matcher {
+    private let closure: ((ErrorType) -> Void)?
+
+    private init() {
+        closure = nil
+    }
+    private init(_ closure: (ErrorType) -> Void) {
+        self.closure = closure
+    }
+
+    public func matches(actualExpression: Expression<Any>, failureMessage: FailureMessage) throws -> Bool {
+        failureMessage.actualValue = nil
+        failureMessage.postfixMessage = "throw an error"
+
+        do {
+            try actualExpression.evaluate()
+        } catch let error {
+            failureMessage.actualValue = "<\(error)>"
+
+            if let closure = closure {
+                failureMessage.postfixMessage += " that satisfies block"
+                let assertions = gatherFailingExpectations {
+                    closure(error)
+                    return
+                }
+                let messages = assertions.map { $0.message }
+                if messages.count > 0 {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
+
+    }
+
+    public func doesNotMatch(actualExpression: Expression<Any>, failureMessage: FailureMessage) throws -> Bool {
+        return try !matches(actualExpression, failureMessage: failureMessage)
+    }
+}
+
+public func throwAnError(closure: (ErrorType) -> Void) -> ThrowErrorMatcher {
+    return ThrowErrorMatcher(closure)
+}
+
+public func throwAnError() -> ThrowErrorMatcher {
+    return ThrowErrorMatcher()
+}

--- a/Nimble/ObjCExpectation.swift
+++ b/Nimble/ObjCExpectation.swift
@@ -3,14 +3,14 @@ internal struct ObjCMatcherWrapper : Matcher {
 
     func matches(actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool {
         return matcher.matches(
-            ({ actualExpression.evaluate() }),
+            ({ try! actualExpression.evaluate() }),
             failureMessage: failureMessage,
             location: actualExpression.location)
     }
 
     func doesNotMatch(actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool {
         return matcher.doesNotMatch(
-            ({ actualExpression.evaluate() }),
+            ({ try! actualExpression.evaluate() }),
             failureMessage: failureMessage,
             location: actualExpression.location)
     }

--- a/Nimble/Utils/Poll.swift
+++ b/Nimble/Utils/Poll.swift
@@ -2,9 +2,15 @@ import Foundation
 
 internal enum PollResult : BooleanType {
     case Success, Failure, Timeout
+    case ErrorThrown(ErrorType)
 
     var boolValue : Bool {
-        return self == .Success
+        switch (self) {
+        case .Success:
+            return true
+        default:
+            return false
+        }
     }
 }
 
@@ -42,7 +48,7 @@ internal func stopRunLoop(runLoop: NSRunLoop, delay: NSTimeInterval) -> RunPromi
     return promise
 }
 
-internal func pollBlock(pollInterval pollInterval: NSTimeInterval, timeoutInterval: NSTimeInterval, expression: () -> Bool) -> PollResult {
+internal func pollBlock(pollInterval pollInterval: NSTimeInterval, timeoutInterval: NSTimeInterval, expression: () throws -> Bool) -> PollResult {
     let runLoop = NSRunLoop.mainRunLoop()
 
     let promise = stopRunLoop(runLoop, delay: min(timeoutInterval, 0.2))
@@ -59,15 +65,19 @@ internal func pollBlock(pollInterval pollInterval: NSTimeInterval, timeoutInterv
     }
 
     var pass: Bool = false
-    repeat {
-        pass = expression()
-        if pass {
-            break
-        }
+    do {
+        repeat {
+            pass = try expression()
+            if pass {
+                break
+            }
 
-        let runDate = NSDate().dateByAddingTimeInterval(pollInterval) as NSDate
-        runLoop.runUntilDate(runDate)
-    } while(NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
+            let runDate = NSDate().dateByAddingTimeInterval(pollInterval) as NSDate
+            runLoop.runUntilDate(runDate)
+        } while(NSDate().timeIntervalSinceDate(startDate) < timeoutInterval);
+    } catch let error {
+        return .ErrorThrown(error)
+    }
 
     return pass ? .Success : .Failure
 }

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -14,28 +14,34 @@ internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Ma
     func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
         let uncachedExpression = actualExpression.withoutCaching()
         let result = pollBlock(pollInterval: pollInterval, timeoutInterval: timeoutInterval) {
-            self.fullMatcher.matches(uncachedExpression, failureMessage: failureMessage)
+            try self.fullMatcher.matches(uncachedExpression, failureMessage: failureMessage)
         }
         switch (result) {
-            case .Success: return true
-            case .Failure: return false
-            case .Timeout:
-                failureMessage.postfixMessage += " (Stall on main thread)."
-                return false
+        case .Success: return true
+        case .Failure: return false
+        case let .ErrorThrown(error):
+            failureMessage.actualValue = "an unexpected error thrown: <\(error)>"
+            return false
+        case .Timeout:
+            failureMessage.postfixMessage += " (Stall on main thread)."
+            return false
         }
     }
 
     func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool  {
         let uncachedExpression = actualExpression.withoutCaching()
         let result = pollBlock(pollInterval: pollInterval, timeoutInterval: timeoutInterval) {
-            self.fullMatcher.doesNotMatch(uncachedExpression, failureMessage: failureMessage)
+            try self.fullMatcher.doesNotMatch(uncachedExpression, failureMessage: failureMessage)
         }
         switch (result) {
-            case .Success: return true
-            case .Failure: return false
-            case .Timeout:
-                failureMessage.postfixMessage += " (Stall on main thread)."
-                return false
+        case .Success: return true
+        case .Failure: return false
+        case let .ErrorThrown(error):
+            failureMessage.actualValue = "an unexpected error thrown: <\(error)>"
+            return false
+        case .Timeout:
+            failureMessage.postfixMessage += " (Stall on main thread)."
+            return false
         }
     }
 }

--- a/Nimble/Wrappers/MatcherFunc.swift
+++ b/Nimble/Wrappers/MatcherFunc.swift
@@ -9,18 +9,18 @@
 /// input parameters.
 /// @see allPass for an example that uses accepts other matchers as input.
 public struct FullMatcherFunc<T>: Matcher {
-    public let matcher: (Expression<T>, FailureMessage, Bool) -> Bool
+    public let matcher: (Expression<T>, FailureMessage, Bool) throws -> Bool
 
-    public init(_ matcher: (Expression<T>, FailureMessage, Bool) -> Bool) {
+    public init(_ matcher: (Expression<T>, FailureMessage, Bool) throws -> Bool) {
         self.matcher = matcher
     }
 
-    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        return matcher(actualExpression, failureMessage, false)
+    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        return try matcher(actualExpression, failureMessage, false)
     }
 
-    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        return matcher(actualExpression, failureMessage, true)
+    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        return try matcher(actualExpression, failureMessage, true)
     }
 }
 
@@ -36,18 +36,18 @@ public struct FullMatcherFunc<T>: Matcher {
 /// input parameters.
 /// @see allPass for an example that uses accepts other matchers as input.
 public struct MatcherFunc<T>: Matcher {
-    public let matcher: (Expression<T>, FailureMessage) -> Bool
+    public let matcher: (Expression<T>, FailureMessage) throws -> Bool
 
-    public init(_ matcher: (Expression<T>, FailureMessage) -> Bool) {
+    public init(_ matcher: (Expression<T>, FailureMessage) throws -> Bool) {
         self.matcher = matcher
     }
 
-    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        return matcher(actualExpression, failureMessage)
+    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        return try matcher(actualExpression, failureMessage)
     }
 
-    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        return !matcher(actualExpression, failureMessage)
+    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        return try !matcher(actualExpression, failureMessage)
     }
 }
 
@@ -63,30 +63,30 @@ public struct MatcherFunc<T>: Matcher {
 /// input parameters.
 /// @see allPass for an example that uses accepts other matchers as input.
 public struct NonNilMatcherFunc<T>: Matcher {
-    public let matcher: (Expression<T>, FailureMessage) -> Bool
+    public let matcher: (Expression<T>, FailureMessage) throws -> Bool
 
-    public init(_ matcher: (Expression<T>, FailureMessage) -> Bool) {
+    public init(_ matcher: (Expression<T>, FailureMessage) throws -> Bool) {
         self.matcher = matcher
     }
 
-    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        let pass = matcher(actualExpression, failureMessage)
-        if attachNilErrorIfNeeded(actualExpression, failureMessage: failureMessage) {
+    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        let pass = try matcher(actualExpression, failureMessage)
+        if try attachNilErrorIfNeeded(actualExpression, failureMessage: failureMessage) {
             return false
         }
         return pass
     }
 
-    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        let pass = !matcher(actualExpression, failureMessage)
-        if attachNilErrorIfNeeded(actualExpression, failureMessage: failureMessage) {
+    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        let pass = try !matcher(actualExpression, failureMessage)
+        if try attachNilErrorIfNeeded(actualExpression, failureMessage: failureMessage) {
             return false
         }
         return pass
     }
 
-    internal func attachNilErrorIfNeeded(actualExpression: Expression<T>, failureMessage: FailureMessage) -> Bool {
-        if actualExpression.evaluate() == nil {
+    internal func attachNilErrorIfNeeded(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
+        if try actualExpression.evaluate() == nil {
             failureMessage.postfixActual = " (use beNil() to match nils)"
             return true
         }

--- a/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Nimble/Wrappers/ObjCMatcher.swift
@@ -36,8 +36,15 @@ public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, fai
     }
 
     private func canMatch(actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool {
-        if !canMatchNil && actualExpression.evaluate() == nil {
-            failureMessage.postfixActual = " (use beNil() to match nils)"
+        do {
+            if !canMatchNil {
+                if try actualExpression.evaluate() == nil {
+                    failureMessage.postfixActual = " (use beNil() to match nils)"
+                    return false
+                }
+            }
+        } catch let error {
+            failureMessage.actualValue = "an unexpected error thrown: \(error)"
             return false
         }
         return true

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -2,23 +2,38 @@ import XCTest
 import Nimble
 
 class AsyncTest: XCTestCase {
-    func testAsyncTestingViaEventually() {
+    let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
+
+    private func doThrowError() throws -> Int {
+        throw errorToThrow
+    }
+
+    func testAsyncTestingViaEventuallyPositiveMatches() {
         var value = 0
         deferToMainQueue { value = 1 }
         expect { value }.toEventually(equal(1))
 
         deferToMainQueue { value = 0 }
         expect { value }.toEventuallyNot(equal(1))
+    }
 
+    func testAsyncTestingViaEventuallyNegativeMatches() {
+        let value = 0
         failsWithErrorMessage("expected to eventually not equal <0>, got <0>") {
             expect { value }.toEventuallyNot(equal(0))
         }
         failsWithErrorMessage("expected to eventually equal <1>, got <0>") {
             expect { value }.toEventually(equal(1))
         }
+        failsWithErrorMessage("expected to eventually equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toEventually(equal(1))
+        }
+        failsWithErrorMessage("expected to eventually not equal <0>, got an unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toEventuallyNot(equal(0))
+        }
     }
 
-    func testAsyncTestingViaWaitUntil() {
+    func testAsyncTestingViaWaitUntilPositiveMatches() {
         waitUntil { done in
             done()
         }
@@ -27,6 +42,9 @@ class AsyncTest: XCTestCase {
                 done()
             }
         }
+    }
+
+    func testAsyncTestingViaWaitUntilNegativeMatches() {
         failsWithErrorMessage("Waited more than 1.0 second") {
             waitUntil(timeout: 1) { done in return }
         }

--- a/NimbleTests/Matchers/RaisesErrorTest.swift
+++ b/NimbleTests/Matchers/RaisesErrorTest.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Nimble
+
+class RaisesErrorTest: XCTestCase {
+    let errorToThrow = NSError(domain: "foo", code: 2, userInfo: nil)
+
+    private func doThrowError() throws {
+        throw errorToThrow
+    }
+
+    private func doNotThrowError() throws {
+    }
+
+    func testPositiveMatches() {
+        expect(try self.doThrowError()).to(throwAnError())
+        expect(try self.doNotThrowError()).toNot(throwAnError())
+        expect { try self.doThrowError() }.to(throwAnError())
+        expect { try self.doNotThrowError() }.toNot(throwAnError())
+
+        expect { try self.doThrowError() }.to(throwAnError { error in
+            expect(error as NSError).to(equal(self.errorToThrow))
+        })
+
+        expect { try self.doThrowError() }.to(throwAnError { error in
+            expect(error as NSError).to(equal(self.errorToThrow))
+        })
+    }
+
+    func testNegativeMatches() {
+        // does not compile: rdar:///21677942
+        /*
+        failsWithErrorMessage("expected to throw an error") {
+            expect(try self.doNotThrowError()).to(throwAnError())
+        }
+
+        failsWithErrorMessage("expected to not throw an error, got <\(errorToThrow)>") {
+            expect(try self.doThrowError()).toNot(throwAnError())
+        }
+        */
+
+        failsWithErrorMessage("expected to throw an error") {
+            expect { try self.doNotThrowError() }.to(throwAnError())
+        }
+
+        failsWithErrorMessage("expected to not throw an error, got <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toNot(throwAnError())
+        }
+
+        failsWithErrorMessage("expected to throw an error that satisfies block, got <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.to(throwAnError { error in
+                expect(error as NSError?).to(beNil())
+            })
+        }
+
+        failsWithErrorMessage("expected to not throw an error that satisfies block, got <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toNot(throwAnError { error in
+                expect((error as NSError).domain).to(equal("LOL"))
+            })
+        }
+    }
+
+    func testSurprisingNegativeMatches() {
+        // A tradeoff was made here to keep this failing instead possibly a more
+        // intuitive passing expectation because:
+        //
+        // - Negative assertions are generally a poor testing pattern we should
+        //   discourage. It's better to convert this to either an expectation
+        //   that takes no block or one that throws with an expectation checking
+        //   a known property of the error thrown.
+        // - Making this pass will currently prevent the throwAnError closure's
+        //   inner expectation failures from emiting proper line outputs. While
+        //   anything is possible with more code, it's more complexity for
+        //   little benefit (see first point).
+        // - The expectation is confusing to interperate.
+        //
+        failsWithErrorMessage("expected to not throw an error that satisfies block, got <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toNot(throwAnError { error in
+                expect(error as NSError?).to(beNil())
+                })
+        }
+    }
+}

--- a/NimbleTests/SynchronousTests.swift
+++ b/NimbleTests/SynchronousTests.swift
@@ -2,12 +2,26 @@ import XCTest
 import Nimble
 
 class SynchronousTest: XCTestCase {
+    let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
+    private func doThrowError() throws -> Int {
+        throw errorToThrow
+    }
+
     func testFailAlwaysFails() {
         failsWithErrorMessage("My error message") {
             fail("My error message")
         }
         failsWithErrorMessage("fail() always fails") {
             fail()
+        }
+    }
+
+    func testUnexpectedErrorsThrownFails() {
+        failsWithErrorMessage("expected to equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.to(equal(1))
+        }
+        failsWithErrorMessage("expected to not equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toNot(equal(1))
         }
     }
 
@@ -18,15 +32,15 @@ class SynchronousTest: XCTestCase {
 
     func testToProvidesActualValueExpression() {
         var value: Int?
-        expect(1).to(MatcherFunc { expr, failure in value = expr.evaluate(); return true })
+        expect(1).to(MatcherFunc { expr, failure in value = try expr.evaluate(); return true })
         expect(value).to(equal(1))
     }
 
     func testToProvidesAMemoizedActualValueExpression() {
         var callCount = 0
         expect{ callCount++ }.to(MatcherFunc { expr, failure in
-            expr.evaluate()
-            expr.evaluate()
+            try expr.evaluate()
+            try expr.evaluate()
             return true
         })
         expect(callCount).to(equal(1))
@@ -36,7 +50,7 @@ class SynchronousTest: XCTestCase {
         var callCount = 0
         expect{ callCount++ }.to(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
-            expr.evaluate()
+            try expr.evaluate()
             return true
         })
         expect(callCount).to(equal(1))
@@ -57,15 +71,15 @@ class SynchronousTest: XCTestCase {
 
     func testToNotProvidesActualValueExpression() {
         var value: Int?
-        expect(1).toNot(MatcherFunc { expr, failure in value = expr.evaluate(); return false })
+        expect(1).toNot(MatcherFunc { expr, failure in value = try expr.evaluate(); return false })
         expect(value).to(equal(1))
     }
 
     func testToNotProvidesAMemoizedActualValueExpression() {
         var callCount = 0
         expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
-            expr.evaluate()
-            expr.evaluate()
+            try expr.evaluate()
+            try expr.evaluate()
             return false
         })
         expect(callCount).to(equal(1))
@@ -75,7 +89,7 @@ class SynchronousTest: XCTestCase {
         var callCount = 0
         expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
-            expr.evaluate()
+            try expr.evaluate()
             return false
         })
         expect(callCount).to(equal(1))

--- a/README.md
+++ b/README.md
@@ -620,6 +620,25 @@ expect(actual).to(beFalse());
 expect(actual).to(beNil());
 ```
 
+## Swift Error Handling
+
+If you're using Swift 2.0+, you can use the `throwAnError` matcher to check if an error is thrown.
+
+```swift
+// Swift
+
+// Passes if somethingThatThrows() throws an ErrorType:
+expect{ try somethingThatThrows() }.to(throwAnError())
+
+// Passes if somethingThatThrows() throws an error with a given domain:
+expect{ try somethingThatThrows() }.to(throwAnError { error in
+    let nserror = error as NSError
+    expect(nserror.domain).to(equal(NSInternalInconsistencyException))
+})
+```
+
+Note: This feature is only available in Swift.
+
 ## Exceptions
 
 ```swift


### PR DESCRIPTION
Implements #136.

- `Expectation` now accepts a throwable closure.
- `Expectation` requires a try to evaluate, since this can now throw.
- Adds `throwAnError()` matcher to match against thrown errors.
    - A general `throwAnError()` for checking if any error was thrown
    - A closure-based `throwAnError()` for checking more details about a thrown error.
- to/toEventually fails (aka, catches) unexpected errors thrown
- gatherExpectations silently parameter is explicitly named
- Currently, ObjC matchers use `try!` (ew). Perhaps a better error reporting mechanism is needed in the future.