### PR TITLE
Add a variadic version of the `contain` matcher for Objective-C

### DIFF
--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -81,9 +81,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beEmpty(void);
 NIMBLE_SHORT(id<NMBMatcher> beEmpty(void),
              NMB_beEmpty());
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_contain(id itemOrSubstring);
-NIMBLE_SHORT(id<NMBMatcher> contain(id itemOrSubstring),
-             NMB_contain(itemOrSubstring));
+NIMBLE_EXPORT id<NMBMatcher> NMB_containWithNilTermination(id itemOrSubstring, ...) NS_REQUIRES_NIL_TERMINATION;
+#define NMB_contain(...) NMB_containWithNilTermination(__VA_ARGS__, nil)
+#ifndef NIMBLE_DISABLE_SHORT_SYNTAX
+#define contain(...) NMB_contain(__VA_ARGS__)
+#endif
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring);
 NIMBLE_SHORT(id<NMBMatcher> endWith(id itemElementOrSubstring),

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -83,8 +83,22 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beEmpty() {
     return [NMBObjCMatcher beEmptyMatcher];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_contain(id itemOrSubstring) {
-    return [NMBObjCMatcher containMatcher:itemOrSubstring];
+NIMBLE_EXPORT id<NMBMatcher> NMB_containWithNilTermination(id itemOrSubstring, ...) {
+    NSMutableArray *itemOrSubstringArray = [NSMutableArray array];
+
+    if (itemOrSubstring) {
+        [itemOrSubstringArray addObject:itemOrSubstring];
+
+        va_list args;
+        va_start(args, itemOrSubstring);
+        id next;
+        while ((next = va_arg(args, id))) {
+            [itemOrSubstringArray addObject:next];
+        }
+        va_end(args);
+    }
+
+    return [NMBObjCMatcher containMatcher:itemOrSubstringArray];
 }
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring) {

--- a/NimbleTests/objc/ObjCContainTest.m
+++ b/NimbleTests/objc/ObjCContainTest.m
@@ -47,4 +47,21 @@
     });
 }
 
+- (void)testVariadicArguments {
+    NSArray *array = @[@1, @2];
+    expect(array).to(contain(@1, @2));
+    expect(array).toNot(contain(@"HI", @"whale"));
+    expect(@"String").to(contain(@"Str", @"ng"));
+    expect(@"Other").toNot(contain(@"Str", @"Oth"));
+
+
+    expectFailureMessage(@"expected to contain <Optional(a), Optional(bar)>, got <(a,b,c)>", ^{
+        expect(@[@"a", @"b", @"c"]).to(contain(@"a", @"bar"));
+    });
+
+    expectFailureMessage(@"expected to not contain <Optional(bar), Optional(b)>, got <(a,b,c)>", ^{
+        expect(@[@"a", @"b", @"c"]).toNot(contain(@"bar", @"b"));
+    });
+}
+
 @end


### PR DESCRIPTION
A macro is used to hide the required nil-termination of the argument list.

This addresses #27 