### PR TITLE
Weaken the dependency on XCTest

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v#{s.version}" }
 
   s.source_files = "Nimble", "Nimble/**/*.{swift,h,m}"
-  s.framework    = "XCTest"
+  s.weak_framework = "XCTest"
+  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-weak-lswiftXCTest', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
   s.requires_arc = true
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end

--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "Nimble", "Nimble/**/*.{swift,h,m}"
   s.weak_framework = "XCTest"
-  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-weak-lswiftXCTest', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
   s.requires_arc = true
-  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'OTHER_LDFLAGS' => '-weak-lswiftXCTest', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
 end

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1041,6 +1041,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1088,6 +1089,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1140,8 +1142,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
-					"-framework",
+					"-weak_framework",
 					XCTest,
+					"-weak-lswiftXCTest",
 				);
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
@@ -1170,8 +1173,9 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
-					"-framework",
+					"-weak_framework",
 					XCTest,
+					"-weak-lswiftXCTest",
 				);
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
@@ -1241,8 +1245,9 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = (
-					"-framework",
+					"-weak_framework",
 					XCTest,
+					"-weak-lswiftXCTest",
 				);
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;
@@ -1274,8 +1279,9 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
-					"-framework",
+					"-weak_framework",
 					XCTest,
+					"-weak-lswiftXCTest",
 				);
 				PRODUCT_MODULE_NAME = Nimble;
 				PRODUCT_NAME = Nimble;

--- a/Nimble/Adapters/AdapterProtocols.swift
+++ b/Nimble/Adapters/AdapterProtocols.swift
@@ -8,5 +8,10 @@ public protocol AssertionHandler {
 /// Global backing interface for assertions that Nimble creates.
 /// Defaults to a private test handler that passes through to XCTest.
 ///
+/// If XCTest is not available, you must assign your own assertion handler
+/// before using any matchers, otherwise Nimble will abort the program.
+///
 /// @see AssertionHandler
-public var NimbleAssertionHandler: AssertionHandler = NimbleXCTestHandler()
+public var NimbleAssertionHandler: AssertionHandler = { () -> AssertionHandler in
+    return isXCTestAvailable() ? NimbleXCTestHandler() : NimbleXCTestUnavailableHandler()
+}()

--- a/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -26,3 +26,15 @@ public class NimbleShortXCTestHandler: AssertionHandler {
         }
     }
 }
+
+/// Fallback handler in case XCTest is unavailable. This assertion handler will abort
+/// the program if it is invoked.
+class NimbleXCTestUnavailableHandler : AssertionHandler {
+    func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        fatalError("XCTest is not available and no custom assertion handler was configured. Aborting.")
+    }
+}
+
+func isXCTestAvailable() -> Bool {
+    return NSClassFromString("XCTestCase") != nil
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ expect(ocean.isClean).toEventually(beTruthy())
 - [Installing Nimble](#installing-nimble)
   - [Installing Nimble as a Submodule](#installing-nimble-as-a-submodule)
   - [Installing Nimble via CocoaPods](#installing-nimble-via-cocoapods)
+  - [Using Nimble without XCTest](#using-nimble-without-xctest)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1109,3 +1110,40 @@ end
 ```
 
 Finally run `pod install`.
+
+## Using Nimble without XCTest
+
+Nimble is integrated with XCTest to allow it work well when used in Xcode test
+bundles, however it can also be used in a standalone app. After installing
+Nimble using one of the above methods, there are two additional steps required
+to make this work.
+
+1. Create a custom assertion handler and assign an instance of it to the
+   global `NimbleAssertionHandler` variable. For example:
+
+```swift
+class MyAssertionHandler : AssertionHandler {
+    func assert(assertion: Bool, message: FailureMessage, location: SourceLocation) {
+        if (!assertion) {
+            print("Expectation failed: \(message.stringValue)")
+        }
+    }
+}
+```
+```swift
+// Somewhere before you use any assertions
+NimbleAssertionHandler = MyAssertionHandler()
+```
+
+2. Add a post-build action to fix an issue with the Swift XCTest support
+   library being unnecessarily copied into your app
+  * Edit your scheme in Xcode, and navigate to Build -> Post-actions
+  * Click the "+" icon and select "New Run Script Action"
+  * Open the "Provide build settings from" dropdown and select your target
+  * Enter the following script contents:
+```
+rm "${SWIFT_STDLIB_TOOL_DESTINATION_DIR}/libswiftXCTest.dylib"
+```
+
+You can now use Nimble assertions in your code and handle failures as you see
+fit.


### PR DESCRIPTION
I had some good success working on what seems like a great solution to #144. The weak linking seems to be working successfully. The process dies with a dylib error the instant that you try to instantiate `NimbleXCTestHandler ` without the XCTest framework+lib around, so I added some code to prevent that form happening. We could potentially try to add a non-crashing fallback assertion handler for this situation as well.

Thoughts? @jeffh @tjarratt