### PR TITLE
remove 'import Foundation' from Swift sources

### DIFF
--- a/Nimble/Adapters/AdapterProtocols.swift
+++ b/Nimble/Adapters/AdapterProtocols.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Protocol for the assertion handler that Nimble uses for all expectations.
 public protocol AssertionHandler {
     func assert(assertion: Bool, message: FailureMessage, location: SourceLocation)

--- a/Nimble/Adapters/AssertionRecorder.swift
+++ b/Nimble/Adapters/AssertionRecorder.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A data structure that stores information about an assertion when
 /// AssertionRecorder is set as the Nimble assertion handler.
 ///

--- a/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -1,4 +1,3 @@
-import Foundation
 import XCTest
 
 /// Default handler for Nimble. This assertion handler passes failures along to

--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Only classes, protocols, methods, properties, and subscript declarations can be
 /// bridges to Objective-C via the @objc keyword. This class encapsulates callback-style
 /// asynchronous waiting logic so that it may be called from Objective-C and Swift.

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, to: String) -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.to = to

--- a/Nimble/Expression.swift
+++ b/Nimble/Expression.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // Memoizes the given closure, only calling the passed
 // closure once; even if repeat calls to the returned closure
 internal func memoizedClosure<T>(closure: () -> T) -> (Bool) -> T {

--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Encapsulates the failure message that matchers can report to the end user.
 ///
 /// This is shared state between Nimble and matchers that mutate this value.

--- a/Nimble/Matchers/AllPass.swift
+++ b/Nimble/Matchers/AllPass.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public func allPass<T,U where U: SequenceType, U.Generator.Element == T>
     (passFunc: (T?) -> Bool) -> NonNilMatcherFunc<U> {
         return allPass("pass a condition", passFunc)

--- a/Nimble/Matchers/BeAKindOf.swift
+++ b/Nimble/Matchers/BeAKindOf.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // A Nimble matcher that catches attempts to use beAKindOf with non Objective-C types
 public func beAKindOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in

--- a/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Nimble/Matchers/BeAnInstanceOf.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // A Nimble matcher that catches attempts to use beAnInstanceOf with non Objective-C types
 public func beAnInstanceOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in

--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal let DefaultDelta = 0.0001
 
 internal func isCloseTo(actualValue: Double?, expectedValue: Double, delta: Double, failureMessage: FailureMessage) -> Bool {

--- a/Nimble/Matchers/BeEmpty.swift
+++ b/Nimble/Matchers/BeEmpty.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 /// A Nimble matcher that succeeds when a value is "empty". For collections, this
 /// means the are no items in that collection. For strings, it is an empty string.
 public func beEmpty<S: SequenceType>() -> NonNilMatcherFunc<S> {

--- a/Nimble/Matchers/BeGreaterThan.swift
+++ b/Nimble/Matchers/BeGreaterThan.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 public func beGreaterThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Nimble/Matchers/BeIdenticalTo.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 /// A Nimble matcher that succeeds when the actual value is the same instance
 /// as the expected instance.
 public func beIdenticalTo<T: AnyObject>(expected: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeLessThan.swift
+++ b/Nimble/Matchers/BeLessThan.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual value is less than the expected value.
 public func beLessThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 public func beLessThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeLogical.swift
+++ b/Nimble/Matchers/BeLogical.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal func matcherWithFailureMessage<T, M: Matcher where M.ValueType == T>(matcher: M, postprocessor: (FailureMessage) -> Void) -> FullMatcherFunc<T> {
     return FullMatcherFunc { actualExpression, failureMessage, isNegation in
         let pass: Bool

--- a/Nimble/Matchers/BeNil.swift
+++ b/Nimble/Matchers/BeNil.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual value is nil.
 public func beNil<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/BeginWith.swift
+++ b/Nimble/Matchers/BeginWith.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 /// A Nimble matcher that succeeds when the actual sequence's first element
 /// is equal to the expected value.
 public func beginWith<S: SequenceType, T: Equatable where S.Generator.Element == T>(startingElement: T) -> NonNilMatcherFunc<S> {

--- a/Nimble/Matchers/Contain.swift
+++ b/Nimble/Matchers/Contain.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual sequence contains the expected value.
 public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T>(items: T...) -> NonNilMatcherFunc<S> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/EndWith.swift
+++ b/Nimble/Matchers/EndWith.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 /// A Nimble matcher that succeeds when the actual sequence's last element
 /// is equal to the expected value.
 public func endWith<S: SequenceType, T: Equatable where S.Generator.Element == T>(endingElement: T) -> NonNilMatcherFunc<S> {

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
 /// Values can support equal by supporting the Equatable protocol.
 ///

--- a/Nimble/Matchers/Match.swift
+++ b/Nimble/Matchers/Match.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
 /// described by the expected string.
 public func match(expectedValue: String?) -> NonNilMatcherFunc<String> {

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
     typealias ValueType

--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Nimble matcher that succeeds when the actual expression raises an
 /// exception with the specified name, reason, and/or userInfo.
 ///

--- a/Nimble/Utils/Functional.swift
+++ b/Nimble/Utils/Functional.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal func all<T>(array: [T], fn: (T) -> Bool) -> Bool {
     for item in array {
         if !fn(item) {

--- a/Nimble/Utils/Poll.swift
+++ b/Nimble/Utils/Poll.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal enum PollResult : BooleanType {
     case Success, Failure, Timeout
 

--- a/Nimble/Utils/SourceLocation.swift
+++ b/Nimble/Utils/SourceLocation.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 @objc public class SourceLocation : CustomStringConvertible {
     public let file: String
     public let line: UInt

--- a/Nimble/Utils/Stringers.swift
+++ b/Nimble/Utils/Stringers.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 internal func identityAsString(value: AnyObject?) -> String {
     if value == nil {
         return "nil"

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Matcher {
     let fullMatcher: U
     let timeoutInterval: NSTimeInterval

--- a/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Nimble/Wrappers/ObjCMatcher.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
 public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
 @objc public class NMBObjCMatcher : NMBMatcher {


### PR DESCRIPTION
Reasons:

1.  This statement has no actual effect. All tests pass after its removal.
2.  It seems to have been arbitrarily included/ignored among Swift source files
    anyways.
3.  Most of Nimble does NOT actually depend on Foundation. One could build a
    custom target (with only `swiftc`, for example) that ignores the
    Foundation-dependent parts. Such target could then be linked in
    environments where Foundation is not available.