### PR TITLE
Swift and Xcode 7 beta 4 compatibility fix

### DIFF
--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Only classes, protocols, methods, properties, and subscript declarations can be
 /// bridges to Objective-C via the @objc keyword. This class encapsulates callback-style
 /// asynchronous waiting logic so that it may be called from Objective-C and Swift.
-@objc internal class NMBWait {
+internal class NMBWait: NSObject {
     internal class func until(timeout timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         var completed = false
         var token: dispatch_once_t = 0

--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Encapsulates the failure message that matchers can report to the end user.
 ///
 /// This is shared state between Nimble and matchers that mutate this value.
-@objc public class FailureMessage {
+public class FailureMessage: NSObject {
     public var expected: String = "expected"
     public var actualValue: String? = "" // empty string -> use default; nil -> exclude
     public var to: String = "to"
@@ -25,7 +25,7 @@ import Foundation
 
     internal var _stringValueOverride: String?
 
-    public init() {
+    public override init() {
     }
 
     public init(stringValue: String) {

--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -32,7 +32,7 @@ public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double 
     }
 }
 
-@objc public class NMBObjCBeCloseToMatcher : NMBMatcher {
+public class NMBObjCBeCloseToMatcher : NSObject, NMBMatcher {
     var _expected: NSNumber
     var _delta: CDouble
     init(expected: NSNumber, within: CDouble) {

--- a/Nimble/Matchers/RaisesException.swift
+++ b/Nimble/Matchers/RaisesException.swift
@@ -97,7 +97,7 @@ internal func exceptionMatchesNonNilFieldsOrClosure(
         return matches
 }
 
-@objc public class NMBObjCRaiseExceptionMatcher : NMBMatcher {
+public class NMBObjCRaiseExceptionMatcher : NSObject, NMBMatcher {
     internal var _name: String?
     internal var _reason: String?
     internal var _userInfo: NSDictionary?

--- a/Nimble/Utils/SourceLocation.swift
+++ b/Nimble/Utils/SourceLocation.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 
-@objc public class SourceLocation : CustomStringConvertible {
+public class SourceLocation : NSObject {
     public let file: String
     public let line: UInt
 
-    init() {
+    override init() {
         file = "Unknown File"
         line = 0
     }
@@ -15,7 +15,7 @@ import Foundation
         self.line = line
     }
 
-    public var description: String {
+    override public var description: String {
         return "\(file):\(line)"
     }
 }

--- a/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Nimble/Wrappers/ObjCMatcher.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
 public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
-@objc public class NMBObjCMatcher : NMBMatcher {
+public class NMBObjCMatcher : NSObject, NMBMatcher {
     let _match: MatcherBlock
     let _doesNotMatch: MatcherBlock
     let canMatchNil: Bool


### PR DESCRIPTION
the new Beta doesn't like having a class marked `@objc` that isn't a subclass of `NSObject`