### PR TITLE
Fix ≈ operator precedence

### DIFF
--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -92,7 +92,10 @@ public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDe
 
 // MARK: - Operators
 
-infix operator ≈ {}
+infix operator ≈ {
+    associativity none
+    precedence 130
+}
 
 public func ≈(lhs: Expectation<[Double]>, rhs: [Double]) {
     lhs.to(beCloseTo(rhs))


### PR DESCRIPTION
We shouldn't use the default precedence, which is the same as assignment. Instead we should use 130, which is the same as equality operators.

This could be fixed on master as well, but I'm just using the Swift 2.0 version right now.