### PR TITLE
[README] New syntax in Swift Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,19 +652,24 @@ expect(actual).to(beNil());
 
 ## Swift Error Handling
 
-If you're using Swift 2.0+, you can use the `throwAnError` matcher to check if an error is thrown.
+If you're using Swift 2.0+, you can use the `throwError` matcher to check if an error is thrown.
 
 ```swift
 // Swift
 
 // Passes if somethingThatThrows() throws an ErrorType:
-expect{ try somethingThatThrows() }.to(throwAnError())
+expect{ try somethingThatThrows() }.to(throwError())
 
 // Passes if somethingThatThrows() throws an error with a given domain:
-expect{ try somethingThatThrows() }.to(throwAnError { error in
-    let nserror = error as NSError
-    expect(nserror.domain).to(equal(NSInternalInconsistencyException))
+expect{ try somethingThatThrows() }.to(throwError { error in
+    expect(error._domain).to(equal(NSCocoaErrorDomain))
 })
+
+// Passes if somethingThatThrows() throws an error with a given case:
+expect{ try somethingThatThrows() }.to(throwError(NSCocoaError.PropertyListReadCorruptError))
+
+// Passes if somethingThatThrows() throws an error with a given type:
+expect{ try somethingThatThrows() }.to(throwError(errorType: MyError.self))
 ```
 
 Note: This feature is only available in Swift.


### PR DESCRIPTION
In addition to #143.
Sorry @jeffh, I didn't caught earlier as well that we were not using the exact same syntax. Fixed that here now. I provided some further examples and fixed one slightly, because you would need to use a forced- or optional-downcast on the error argument of the closure to check the domain over Foundation's NSError. Accessing `_domain` directly appears unelegant, but should be safer.