### PR TITLE
[ObjC]Fix fail() and introduce failWithMessage

### DIFF
--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -112,13 +112,17 @@ typedef void (^NMBWaitUntilBlock)(void (^action)(void (^)(void)));
 NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line);
 NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line);
 
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line);
+
 #define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
 #define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, __FILE__, __LINE__)
 #define expectAction(BLOCK) NMB_expectAction((BLOCK), __FILE__, __LINE__)
-#define fail() NMB_expectAction((BLOCK), __FILE__, __LINE__)
+#define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
+#define fail() failWithMessage(@"")
+
 
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -23,6 +23,10 @@ NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), const char 
     }, file, line);
 }
 
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line) {
+    return [NMBExpectation failWithMessage:msg file:file line:line];
+}
+
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass) {
     return [NMBObjCMatcher beAnInstanceOfMatcher:expectedClass];
 }


### PR DESCRIPTION
The old fail() macro used the `NMB_expectAction` method which required a block as a parameter, but the macro had no block argument. 
This commit fixes the behaviour using a new Objective- C macro: `failWithMessage` - it allows the user to provide a failure message. Just like the corresponding Swift method. Calling the fail() macro resolves in a call to failWithMessage() without a message to reuse the macro.

Ref.: #149 #150