### PR TITLE
[ObjC]replace C types with Objective-C types

### DIFF
--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -14,8 +14,8 @@
 #define NIMBLE_SHORT(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE PROTO { return (ORIGINAL); }
 #endif
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, unsigned int line);
-NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), const char *file, unsigned int line);
+NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line);
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue);
 NIMBLE_SHORT(id<NMBMatcher> equal(id expectedValue),
@@ -118,8 +118,8 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 #define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
-#define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, __FILE__, __LINE__)
-#define expectAction(BLOCK) NMB_expectAction((BLOCK), __FILE__, __LINE__)
+#define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
+#define expectAction(BLOCK) NMB_expectAction((BLOCK), @(__FILE__), __LINE__)
 #define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
 #define fail() failWithMessage(@"fail() always fails")
 

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -9,14 +9,14 @@ SWIFT_CLASS("_TtC6Nimble7NMBWait")
 
 @end
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, unsigned int line) {
+NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line) {
     return [[NMBExpectation alloc] initWithActualBlock:actualBlock
                                               negative:NO
-                                                  file:[[NSString alloc] initWithFormat:@"%s", file]
+                                                  file:file
                                                   line:line];
 }
 
-NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), const char *file, unsigned int line) {
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line) {
     return NMB_expect(^id{
         actualBlock();
         return nil;


### PR DESCRIPTION
`NMB_expect` and `NMB_expectAction` used C types like `char*` and a normal `unsigned int` in their method definition and not a Objective- C type like `NSString`. This commit replaces them with the corresponding Objective- C type in their method declaration and also in the used macros. Other macros and methods already use types like `NSString` in the definition.