### PR TITLE
[ObjC]Backport of fail macros

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		1FD8CD771968AB07008ED995 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD2D1968AB07008ED995 /* ObjCMatcher.swift */; };
 		1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
 		1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
+		30FC9B091B7E48670097E2D6 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */; };
+		30FC9B0A1B7E48670097E2D6 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */; };
 		DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DD72EC641A93874A002F7651 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
@@ -332,6 +334,7 @@
 		1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionDispatcher.swift; sourceTree = "<group>"; };
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1FFD729C1963FCAB00CD29A2 /* Nimble-OSXTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Nimble-OSXTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSyncTest.m; sourceTree = "<group>"; };
 		DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DSL+Wait.swift"; sourceTree = "<group>"; };
 		DD72EC631A93874A002F7651 /* AllPassTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllPassTest.swift; sourceTree = "<group>"; };
 		DD9A9A8D19CF413800706F49 /* BeIdenticalToObjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeIdenticalToObjectTest.swift; sourceTree = "<group>"; };
@@ -577,6 +580,7 @@
 				1F4A569C1A3B3565009E1637 /* ObjCMatchTest.m */,
 				1F4A569F1A3B359E009E1637 /* ObjCRaiseExceptionTest.m */,
 				DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */,
+				30FC9B081B7E48670097E2D6 /* ObjCSyncTest.m */,
 			);
 			path = objc;
 			sourceTree = "<group>";
@@ -831,6 +835,7 @@
 				1F925F0B195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FB1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90098195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
+				30FC9B091B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56761A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EF9195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56701A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,
@@ -928,6 +933,7 @@
 				1F925F0C195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FC1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
 				1FB90099195EC4B8001D7FAE /* BeIdenticalToTest.swift in Sources */,
+				30FC9B0A1B7E48670097E2D6 /* ObjCSyncTest.m in Sources */,
 				1F4A56771A3B3253009E1637 /* ObjCBeGreaterThanTest.m in Sources */,
 				1F925EFA195C175000ED456B /* BeNilTest.swift in Sources */,
 				1F4A56711A3B319F009E1637 /* ObjCBeCloseToTest.m in Sources */,

--- a/Nimble/ObjCExpectation.swift
+++ b/Nimble/ObjCExpectation.swift
@@ -76,4 +76,8 @@ public class NMBExpectation : NSObject {
             )
         })
     }
+
+    public class func failWithMessage(message: String, file: String, line: UInt) {
+        fail(message, location: SourceLocation(file: file, line: line))
+    }
 }

--- a/Nimble/objc/DSL.h
+++ b/Nimble/objc/DSL.h
@@ -106,6 +106,8 @@ NIMBLE_SHORT(id<NMBMatcher> allPass(id matcher),
 typedef void (^NMBWaitUntilTimeoutBlock)(NSTimeInterval timeout, void (^action)(void (^)(void)));
 typedef void (^NMBWaitUntilBlock)(void (^action)(void (^)(void)));
 
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line);
+
 NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line);
 NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line);
 
@@ -115,6 +117,10 @@ NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger 
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, __FILE__, __LINE__)
 #define expectAction(...) NMB_expect(^id{ (__VA_ARGS__); return nil; }, __FILE__, __LINE__)
+#define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
+#define fail() failWithMessage(@"fail() always fails")
+
+
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil
 #endif

--- a/Nimble/objc/DSL.m
+++ b/Nimble/objc/DSL.m
@@ -16,6 +16,10 @@ NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), const char *file, u
                                                   line:line];
 }
 
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line) {
+    return [NMBExpectation failWithMessage:msg file:file line:line];
+}
+
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass) {
     return [NMBObjCMatcher beAnInstanceOfMatcher:expectedClass];
 }

--- a/NimbleTests/objc/ObjCSyncTest.m
+++ b/NimbleTests/objc/ObjCSyncTest.m
@@ -1,0 +1,21 @@
+#import <XCTest/XCTest.h>
+#import <Nimble/Nimble.h>
+#import "NimbleSpecHelper.h"
+
+@interface ObjCSyncTest : XCTestCase
+
+@end
+
+@implementation ObjCSyncTest
+
+- (void)testFailureExpectation {
+    expectFailureMessage(@"fail() always fails", ^{
+        fail();
+    });
+
+    expectFailureMessage(@"This always fails", ^{
+        failWithMessage(@"This always fails");
+    });
+}
+
+@end


### PR DESCRIPTION
This commit ports the Objective- C macro `failWithMessage` and `fail` back to Swift 1.2.

Ref.-Issue: #149 #150
Ref.-PR: #163