### PR TITLE
Fix compile issue on Xcode 7b6

### DIFF
--- a/Nimble/FailureMessage.swift
+++ b/Nimble/FailureMessage.swift
@@ -37,7 +37,7 @@ public class FailureMessage: NSObject {
         var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as [String]
         let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
         lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
-        return "".join(lines)
+        return lines.joinWithSeparator("")
     }
 
     internal func computeStringValue() -> String {

--- a/Nimble/Utils/Stringers.swift
+++ b/Nimble/Utils/Stringers.swift
@@ -29,7 +29,7 @@ internal func stringify<S: SequenceType>(value: S) -> String {
             strings.append(stringify(value))
         }
     } while value != nil
-    let str = ", ".join(strings)
+    let str = strings.joinWithSeparator(", ")
     return "[\(str)]"
 }
 


### PR DESCRIPTION
Tried building with the new shiny and got this error in a couple places:

```
error: 'join' is unavailable: call the 'joinWithSeparator()' method on the sequence of elements
        return "".join(lines)
                  ^~~~
Swift.String:3:8: note: 'join' has been explicitly marked unavailable here
  func join<S : SequenceType where S.Generator.Element == String>(elements: S) -> String
```

I *think* this is the right fix but am having trouble getting the tests to run.