### PR TITLE
Add beCloseTo support for NSDate

### DIFF
--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -2,14 +2,14 @@ import Foundation
 
 internal let DefaultDelta = 0.0001
 
-internal func isCloseTo(actualValue: Double?, expectedValue: Double, delta: Double, failureMessage: FailureMessage) -> Bool {
+internal func isCloseTo(actualValue: NMBDoubleConvertible?, expectedValue: NMBDoubleConvertible, delta: Double, failureMessage: FailureMessage) -> Bool {
     failureMessage.postfixMessage = "be close to <\(stringify(expectedValue))> (within \(stringify(delta)))"
     if actualValue != nil {
         failureMessage.actualValue = "<\(stringify(actualValue!))>"
     } else {
         failureMessage.actualValue = "<nil>"
     }
-    return actualValue != nil && abs(actualValue! - expectedValue) < delta
+    return actualValue != nil && abs(actualValue!.doubleValue - expectedValue.doubleValue) < delta
 }
 
 /// A Nimble matcher that succeeds when a value is close to another. This is used for floating
@@ -28,7 +28,7 @@ public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta
 /// @see equal
 public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double = DefaultDelta) -> NonNilMatcherFunc<NMBDoubleConvertible> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
-        return isCloseTo(try actualExpression.evaluate()?.doubleValue, expectedValue: expectedValue.doubleValue, delta: delta, failureMessage: failureMessage)
+        return isCloseTo(try actualExpression.evaluate(), expectedValue: expectedValue, delta: delta, failureMessage: failureMessage)
     }
 }
 

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -38,13 +38,30 @@ extension NSArray : NMBOrderedCollection {}
 /// Protocol for types to support beCloseTo() matcher
 @objc public protocol NMBDoubleConvertible {
     var doubleValue: CDouble { get }
+    var stringRepresentation: String { get }
 }
-extension NSNumber : NMBDoubleConvertible { }
+extension NSNumber : NMBDoubleConvertible {
+    public var stringRepresentation: String {
+        get {
+            return NSString(format: "%.4f", (self)).description
+        }
+    }
+}
+
+private let dateFormatter = NSDateFormatter()
 
 extension NSDate: NMBDoubleConvertible {
     public var doubleValue: CDouble {
         get {
             return self.timeIntervalSinceReferenceDate
+        }
+    }
+    
+    public var stringRepresentation: String {
+        get {
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
+            dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+            return "\(dateFormatter.stringFromDate(self))"
         }
     }
 }

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -41,6 +41,14 @@ extension NSArray : NMBOrderedCollection {}
 }
 extension NSNumber : NMBDoubleConvertible { }
 
+extension NSDate: NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return self.timeIntervalSinceReferenceDate
+        }
+    }
+}
+
 /// Protocol for types to support beLessThan(), beLessThanOrEqualTo(),
 ///  beGreaterThan(), beGreaterThanOrEqualTo(), and equal() matchers.
 ///

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -38,14 +38,8 @@ extension NSArray : NMBOrderedCollection {}
 /// Protocol for types to support beCloseTo() matcher
 @objc public protocol NMBDoubleConvertible {
     var doubleValue: CDouble { get }
-    var stringRepresentation: String { get }
 }
 extension NSNumber : NMBDoubleConvertible {
-    public var stringRepresentation: String {
-        get {
-            return NSString(format: "%.4f", (self)).description
-        }
-    }
 }
 
 private let dateFormatter = NSDateFormatter()
@@ -56,12 +50,27 @@ extension NSDate: NMBDoubleConvertible {
             return self.timeIntervalSinceReferenceDate
         }
     }
-    
+}
+
+
+extension NMBDoubleConvertible {
     public var stringRepresentation: String {
         get {
-            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
-            dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-            return "\(dateFormatter.stringFromDate(self))"
+            if let date = self as? NSDate {
+                dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
+                dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+                return "\(dateFormatter.stringFromDate(date))"
+            }
+            
+            if let debugStringConvertible = self as? CustomDebugStringConvertible {
+                return debugStringConvertible.debugDescription
+            }
+            
+            if let stringConvertible = self as? CustomStringConvertible {
+                return stringConvertible.description
+            }
+            
+            return ""
         }
     }
 }

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -42,7 +42,13 @@ extension NSArray : NMBOrderedCollection {}
 extension NSNumber : NMBDoubleConvertible {
 }
 
-private let dateFormatter = NSDateFormatter()
+private let dateFormatter: NSDateFormatter = {
+    let formatter = NSDateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
+    formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+    
+    return formatter
+    }()
 
 extension NSDate: NMBDoubleConvertible {
     public var doubleValue: CDouble {
@@ -57,9 +63,7 @@ extension NMBDoubleConvertible {
     public var stringRepresentation: String {
         get {
             if let date = self as? NSDate {
-                dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
-                dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-                return "\(dateFormatter.stringFromDate(date))"
+                return dateFormatter.stringFromDate(date)
             }
             
             if let debugStringConvertible = self as? CustomDebugStringConvertible {

--- a/Nimble/Utils/Stringers.swift
+++ b/Nimble/Utils/Stringers.swift
@@ -47,6 +47,13 @@ internal func stringify<T>(value: T) -> String {
     return String(value)
 }
 
+internal func stringify(value: NMBDoubleConvertible) -> String {
+    if let value = value as? Double {
+        return NSString(format: "%.4f", (value)).description
+    }
+    return value.stringRepresentation
+}
+
 internal func stringify<T>(value: T?) -> String {
     if let unboxed = value {
        return stringify(unboxed)

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -78,10 +78,10 @@ public class NimbleHelper : NSObject {
 
 extension NSDate {
     convenience init(dateTimeString:String) {
-        let dateStringFormatter = NSDateFormatter()
-        dateStringFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
-        dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-        let d = dateStringFormatter.dateFromString(dateTimeString)!
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        let d = dateFormatter.dateFromString(dateTimeString)!
         self.init(timeInterval:0, sinceDate:d)
     }
 }

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -75,3 +75,13 @@ public class NimbleHelper : NSObject {
         failsWithErrorMessageForNil(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }
+
+extension NSDate {
+    convenience init(dateTimeString:String) {
+        let dateStringFormatter = NSDateFormatter()
+        dateStringFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
+        dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        let d = dateStringFormatter.dateFromString(dateTimeString)!
+        self.init(timeInterval:0, sinceDate:d)
+    }
+}

--- a/NimbleTests/Helpers/utils.swift
+++ b/NimbleTests/Helpers/utils.swift
@@ -81,7 +81,7 @@ extension NSDate {
         let dateFormatter = NSDateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-        let d = dateFormatter.dateFromString(dateTimeString)!
-        self.init(timeInterval:0, sinceDate:d)
+        let date = dateFormatter.dateFromString(dateTimeString)!
+        self.init(timeInterval:0, sinceDate:date)
     }
 }

--- a/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/NimbleTests/Matchers/BeCloseToTest.swift
@@ -33,8 +33,10 @@ class BeCloseToTest: XCTestCase {
     func testBeCloseToWithNSDate() {
         expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
         
-        failsWithErrorMessage("expected to not be close to <462296591.0000> (within 10.0000), got <462296580.0000>") {
-            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:11"), within: 10))
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.0040), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
         }
     }
     

--- a/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/NimbleTests/Matchers/BeCloseToTest.swift
@@ -30,6 +30,14 @@ class BeCloseToTest: XCTestCase {
         }
     }
     
+    func testBeCloseToWithNSDate() {
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
+        
+        failsWithErrorMessage("expected to not be close to <462296591.0000> (within 10.0000), got <462296580.0000>") {
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:11"), within: 10))
+        }
+    }
+    
     func testBeCloseToOperator() {
         expect(1.2) ≈ 1.2001
         expect(1.2 as CDouble) ≈ 1.2001


### PR DESCRIPTION
Fixed issue #171. Added `NMBDoubleConvertible` support for NSDate, and updated the matcher and that protocol to support friendly printing of dates when they don't match.