### PR TITLE
Added vargs into waitUntil done

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,5 +102,6 @@ The process is relatively straight forward, but here's is a useful checklist for
   - `carthage build --no-skip-current`
   - `carthage archive Nimble`
 - Go to [github releases](https://github.com/Quick/Nimble/releases) and mark the tagged commit as a release.
-- Attach the carthage release `Nimble.framework.zip` to the release.
+  - Use the same release notes you created for the tag, but tweak up formatting for github.
+  - Attach the carthage release `Nimble.framework.zip` to the release.
 - Announce!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,5 +98,9 @@ The process is relatively straight forward, but here's is a useful checklist for
 - Tag the version: `git tag -s vA.B.C -F release-notes-file`
 - Push the tag: `git push origin master --tags`
 - Push the podspec file to trunk: `pod trunk push Nimble.podspec`
+- Build the carthage pre-built binary:
+  - `carthage build --no-skip-current`
+  - `carthage archive Nimble`
 - Go to [github releases](https://github.com/Quick/Nimble/releases) and mark the tagged commit as a release.
+- Attach the carthage release `Nimble.framework.zip` to the release.
 - Announce!

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1152,9 +1152,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Nimble/Info.plist;
@@ -1185,9 +1184,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Nimble/Info.plist;
@@ -1212,7 +1210,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1234,7 +1232,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = NimbleTests/Info.plist;

--- a/Nimble/Matchers/MatcherProtocols.swift
+++ b/Nimble/Matchers/MatcherProtocols.swift
@@ -28,6 +28,7 @@ extension NSHashTable : NMBContainer {}
 extension NSSet : NMBCollection {}
 extension NSDictionary : NMBCollection {}
 extension NSHashTable : NMBCollection {}
+extension NSMapTable : NMBCollection {}
 
 /// Protocol for types that support beginWith(), endWith(), beEmpty() matchers
 @objc public protocol NMBOrderedCollection : NMBCollection {

--- a/circle.yml
+++ b/circle.yml
@@ -2,41 +2,7 @@ machine:
   xcode:
     version: "7.0"
 
-general:
-  branches:
-    ignore:
-      - swift-2.0 # Circle CI doesn't support Xcode 7/Swift 2.0 yet.
-
-# despite what circle ci says, xctool 0.2.3 cannot run
-# ios simulator tests on iOS frameworks for whatever reason.
-#
-# See: https://github.com/facebook/xctool/issues/415
 test:
   override:
-    - set -o pipefail &&
-      xcodebuild
-        -scheme "Nimble-iOS"
-        -sdk iphonesimulator
-        -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 6'
-        -project Nimble.xcodeproj
-        -configuration Debug
-        CODE_SIGNING_REQUIRED=NO
-        CODE_SIGN_IDENTITY=
-        PROVISIONING_PROFILE=
-        clean test |
-      tee $CIRCLE_ARTIFACTS/xcode_raw_ios.log |
-      xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/ios-results.xml
-    - set -o pipefail &&
-      xcodebuild
-        -scheme "Nimble-OSX"
-        -sdk macosx
-        -project Nimble.xcodeproj
-        -configuration Debug
-        CODE_SIGNING_REQUIRED=NO
-        CODE_SIGN_IDENTITY=
-        PROVISIONING_PROFILE=
-        clean test |
-      tee $CIRCLE_ARTIFACTS/xcode_raw_osx.log |
-      xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/osx-results.xml
-
-
+    - NIMBLE_RUNTIME_IOS_SDK_VERSION=9.0 ./test ios
+    - NIMBLE_RUNTIME_OSX_SDK_VERSION=10.10 ./test osx

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "6.3.1"
+    version: "7.0"
 
 general:
   branches:


### PR DESCRIPTION
Currently done does not accept any arguments, as result sometimes it require additional boilerplate code. The current pull request solves this problem.

Here is an example what we can do with current waitUntil implementation:
```
func asyncCall(callback:(Void -> Void)) { ... }
func argsAsyncCall(callback:(AnyObject->Void)) { ... }

waitUntil { done in
  asyncCall(done) //Looks nice
  asyncCall { _ in done() } //Looks ugly
}
```

Proposed change allows to write code consistently since introduces variadic arguments for done function. Swift allows zero to any amount of variadic arguments. As result we always getting consistent code: 
```
waitUntil { done in 
  anyAsyncCall(done)
}
```