### PR TITLE
Added vargs into waitUntil done

### DIFF
--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -38,13 +38,15 @@ internal class NMBWait: NSObject {
 /// Wait asynchronously until the done closure is called.
 ///
 /// This will advance the run loop.
-public func waitUntil(timeout timeout: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
-    NMBWait.until(timeout: timeout, file: file, line: line, action: action)
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: ((Any?...) -> Void) -> Void) -> Void {
+    NMBWait.until(timeout: timeout, file: file, line: line, action: bridgeToVoidAction(action))
 }
 
-/// Wait asynchronously until the done closure is called.
-///
-/// This will advance the run loop.
-public func waitUntil(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
-    NMBWait.until(timeout: 1, file: file, line: line, action: action)
+/// This bridging function should not be required in Swift 2.1 as it supports function covariance
+private func bridgeToVoidAction(vargAction: ((Any?...) -> Void) -> Void) -> ((() -> Void) -> Void) {
+    return { voidDone in
+        vargAction() { _ in
+            voidDone()
+        }
+    }
 }

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -81,4 +81,10 @@ class AsyncTest: XCTestCase {
         // "clear" runloop to ensure this test doesn't poison other tests
         NSRunLoop.mainRunLoop().runUntilDate(NSDate().dateByAddingTimeInterval(2.0))
     }
+    
+    func testWaitUntilTakesAnyArguments() {
+        waitUntil { done in
+            done(nil, 0, "", NSNumber.self, {})
+        }
+    }
 }


### PR DESCRIPTION
Currently done does not accept any arguments, as result sometimes it require additional boilerplate code. The current pull request solves this problem.

Here is an example what we can do with current waitUntil implementation:
```
func asyncCall(callback:(Void -> Void)) { ... }
func argsAsyncCall(callback:(AnyObject->Void)) { ... }

waitUntil { done in
  asyncCall(done) //Looks nice
  asyncCall { _ in done() } //Looks ugly
}
```

Proposed change allows to write code consistently since introduces variadic arguments for done function. Swift allows zero to any amount of variadic arguments. As result we always getting consistent code: 
```
waitUntil { done in 
  anyAsyncCall(done) // consistency!
}
```