### PR TITLE
Add support for comparing ErrorTypes with equal function

### DIFF
--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -69,6 +69,26 @@ public func equal<T: Comparable>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Se
     })
 }
 
+/** 
+A Nimble matcher that succeeds when the actual value's domain and code are equal to 
+the expected value's domain and code
+*/
+public func equal(expectedValue: ErrorType?) -> NonNilMatcherFunc<ErrorType> {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+        let actualValue = try actualExpression.evaluate()
+        if expectedValue == nil || actualValue == nil {
+            if expectedValue == nil {
+                failureMessage.postfixActual = " (use beNil() to match nils)"
+            }
+            return false
+        }
+        
+        return (expectedValue!._domain == actualValue!._domain)
+            && (expectedValue!._code == actualValue!._code)
+    }
+}
+
 private func equal<T>(expectedValue: Set<T>?, stringify: Set<T>? -> String) -> NonNilMatcherFunc<Set<T>> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
@@ -137,6 +157,14 @@ public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]
 
 public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
+}
+
+public func ==(lhs: Expectation<ErrorType>, rhs: ErrorType?) {
+    return lhs.to(equal(rhs))
+}
+
+public func !=(lhs: Expectation<ErrorType>, rhs: ErrorType?) {
+    return lhs.toNot(equal(rhs))
 }
 
 extension NMBObjCMatcher {

--- a/Nimble/Utils/Stringers.swift
+++ b/Nimble/Utils/Stringers.swift
@@ -43,6 +43,8 @@ extension NSArray : NMBStringer {
 internal func stringify<T>(value: T) -> String {
     if let value = value as? Double {
         return NSString(format: "%.4f", (value)).description
+    } else if let value = value as? ErrorType {
+        return "\(value._domain).\(value)"
     }
     return String(value)
 }
@@ -50,6 +52,8 @@ internal func stringify<T>(value: T) -> String {
 internal func stringify(value: NMBDoubleConvertible) -> String {
     if let value = value as? Double {
         return NSString(format: "%.4f", (value)).description
+    } else if let value = value as? ErrorType {
+        return "\(value._domain).\(value)"
     }
     return value.stringRepresentation
 }

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -69,6 +69,38 @@ class EqualTest: XCTestCase {
             expect(Set([1, 2, 3])) != Set([1, 2, 3])
         }
     }
+    
+    func testErrorTypeEquality() {
+        enum FakeError : ErrorType {
+            case Error1, Error2
+        }
+        
+        let error1: ErrorType? = FakeError.Error1
+        expect(error1).to(equal(FakeError.Error1))
+        expect(error1).toNot(equal(FakeError.Error2))
+        expect(error1) == FakeError.Error1
+        expect(error1) != FakeError.Error2
+        
+        failsWithErrorMessageForNil("expected to equal <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>, got <nil>") {
+            expect(nil as FakeError?).to(equal(FakeError.Error1))
+        }
+        
+        failsWithErrorMessage("expected to equal <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>, got <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error2>") {
+            expect(FakeError.Error2).to(equal(FakeError.Error1))
+        }
+        
+        failsWithErrorMessage("expected to equal <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>, got <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error2>") {
+            expect(FakeError.Error2) == FakeError.Error1
+        }
+        
+        failsWithErrorMessage("expected to not equal <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>, got <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>") {
+            expect(FakeError.Error1).toNot(equal(FakeError.Error1))
+        }
+        
+        failsWithErrorMessage("expected to not equal <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>, got <NimbleTests.EqualTest.(testErrorTypeEquality (NimbleTests.EqualTest) -> () -> ()).(FakeError #1).Error1>") {
+            expect(FakeError.Error1) != FakeError.Error1
+        }
+    }
 
     func testDoesNotMatchNils() {
         failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {


### PR DESCRIPTION
PR for [this issue](https://github.com/Quick/Nimble/issues/197)

Essentially this has to do with being able to compare two ErrorTypes in which their specific types (name of the enum) is not known at compile time, only at runtime. I found this to be useful when testing the error that was given to a delegate (after, say an asynchronous call) to be a specific error.

### Notes
* Because the FakeEnum I created for the tests is in the test module, in a test case, in a function, it creates a really weird domain. It should look much cleaner in an actual application.
* I'm also not sure if the string representation I made for ErrorTypes is the best choice. If I didn't add anything to stringily it would only display the enum case, and not mention the domain (which I felt was important)