### PR TITLE
Changed wording of HaveCount failure message

### DIFF
--- a/Nimble/Matchers/HaveCount.swift
+++ b/Nimble/Matchers/HaveCount.swift
@@ -5,9 +5,9 @@ import Foundation
 public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false
@@ -20,9 +20,9 @@ public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> Non
 public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     return MatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(actualValue.count)"
+            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
             let result = expectedValue == actualValue.count
-            failureMessage.actualValue = "\(expectedValue)"
+            failureMessage.actualValue = "\(actualValue.count)"
             return result
         } else {
             return false

--- a/NimbleTests/Matchers/HaveCountTest.swift
+++ b/NimbleTests/Matchers/HaveCountTest.swift
@@ -6,7 +6,7 @@ class HaveCountTest: XCTestCase {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [1, 2, 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [1, 2, 3] with count 1, got 3") {
             expect([1, 2, 3]).to(haveCount(1))
         }
 
@@ -19,7 +19,7 @@ class HaveCountTest: XCTestCase {
         expect(["1":1, "2":2, "3":3]).to(haveCount(3))
         expect(["1":1, "2":2, "3":3]).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 1, got 3") {
             expect(["1":1, "2":2, "3":3]).to(haveCount(1))
         }
 
@@ -32,7 +32,7 @@ class HaveCountTest: XCTestCase {
         expect(Set([1, 2, 3])).to(haveCount(3))
         expect(Set([1, 2, 3])).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have [2, 3, 1] with count 3, got 1") {
+        failsWithErrorMessage("expected to have [2, 3, 1] with count 1, got 3") {
             expect(Set([1, 2, 3])).to(haveCount(1))
         }
 

--- a/NimbleTests/objc/ObjCHaveCount.m
+++ b/NimbleTests/objc/ObjCHaveCount.m
@@ -14,7 +14,7 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
-    expectFailureMessage(@"expected to have (1,2,3) with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have (1,2,3) with count 1, got 3", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
 
@@ -28,7 +28,7 @@
     expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@3));
     expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {1 = 1;2 = 2;3 = 3;} with count 1, got 3", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@1));
     });
 
@@ -46,7 +46,7 @@
     expect(table).to(haveCount(@3));
     expect(table).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3", ^{
         expect(table).to(haveCount(@1));
     });
 
@@ -61,7 +61,7 @@
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
 
-    expectFailureMessage(@"expected to have {(3,1,2)} with count 3, got 1", ^{
+    expectFailureMessage(@"expected to have {(3,1,2)} with count 1, got 3", ^{
         expect(set).to(haveCount(@1));
     });
 


### PR DESCRIPTION
Changed wording of HaveCount failure message to match the order of other matchers.

For example:
`expect([1, 2, 3]).to(haveCount(1))`

Failure message before change:
`expected to have [1, 2, 3] with count 3, got 1`

Failure message after change:
`expected to have [1, 2, 3] with count 1, got 3`

I looked at [CONTRIBUTING.md](https://github.com/Quick/Nimble/blob/master/CONTRIBUTING.md) but it wasn't clear whether or not an issue has to be created prior to a PR. Please let me know if I should create an issue to associate this PR with.