### PR TITLE
Embarrassing revert of changes for accepting any values in done callback of waitUntil.

### DIFF
--- a/Nimble/DSL+Wait.swift
+++ b/Nimble/DSL+Wait.swift
@@ -38,15 +38,6 @@ internal class NMBWait: NSObject {
 /// Wait asynchronously until the done closure is called.
 ///
 /// This will advance the run loop.
-public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: ((Any?...) -> Void) -> Void) -> Void {
-    NMBWait.until(timeout: timeout, file: file, line: line, action: bridgeToVoidAction(action))
-}
-
-/// This bridging function should not be required in Swift 2.1 as it supports function covariance
-private func bridgeToVoidAction(vargAction: ((Any?...) -> Void) -> Void) -> ((() -> Void) -> Void) {
-    return { voidDone in
-        vargAction() { _ in
-            voidDone()
-        }
-    }
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/NimbleTests/AsynchronousTest.swift
+++ b/NimbleTests/AsynchronousTest.swift
@@ -81,10 +81,4 @@ class AsyncTest: XCTestCase {
         // "clear" runloop to ensure this test doesn't poison other tests
         NSRunLoop.mainRunLoop().runUntilDate(NSDate().dateByAddingTimeInterval(2.0))
     }
-    
-    func testWaitUntilTakesAnyArguments() {
-        waitUntil { done in
-            done(nil, 0, "", NSNumber.self, {})
-        }
-    }
 }


### PR DESCRIPTION
As explained in #199 current implementation of function covariance support does not allow to implement callback that is acceptable as any callback. I decided to unroll it till better support from Swift.

I have a plan for a Swift 2.1 I will provide later functions without variadic argument with a 1 to 5 arguments. This will be a good solution for most of the cases.