### PR TITLE
Add Carthage/Build to gitignore for better support of Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ build/
 .idea
 DerivedData/
 Nimble.framework.zip
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build


### PR DESCRIPTION
Added `Carthage/Build` to gitignore to solve the following problem with Carthage.

## Problem

After running `carthage update --use-submodules` or `carthage bootstrap --use-submodules`, untracked contents are detected by Git because Nimble does not ignore `Carthage/Build` directory. The directory has to be removed not to be committed.

```
$ git status
On branch master
Changes not staged for commit:

	modified:   Carthage/Checkouts/Nimble (untracked content)
```

## Modification

Added `Carthage/Build` to gitignore. The added part of gitignore was taken from the following example.
https://github.com/github/gitignore/blob/master/Swift.gitignore

This modification has no impact to CocoaPods users. With the gitignore, Carthage users will be more comfortable to use Nimble in their projects.