### PR TITLE
Remove comment about beIdenticalTo to supporting Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,10 +475,6 @@ expect(actual).to(beIdenticalTo(expected));
 expect(actual).toNot(beIdenticalTo(expected));
 ```
 
-> `beIdenticalTo` only supports Objective-C objects: subclasses
-  of `NSObject`, or Swift objects bridged to Objective-C with the
-  `@objc` prefix.
-
 ## Comparisons
 
 ```swift


### PR DESCRIPTION
This closes #204.

Since it works now in Swift 2, the comment has to be removed.

