### PR TITLE
Remove public headers from umbrella header

### DIFF
--- a/Nimble/Nimble.h
+++ b/Nimble/Nimble.h
@@ -1,6 +1,4 @@
 #import <Foundation/Foundation.h>
-#import <Nimble/NMBExceptionCapture.h>
-#import <Nimble/DSL.h>
 
 FOUNDATION_EXPORT double NimbleVersionNumber;
 FOUNDATION_EXPORT const unsigned char NimbleVersionString[];


### PR DESCRIPTION
This seems to be the root cause for new projects created in Xcode 7.1
to report "Include of non-modular header inside framework Module
'Nimble'".

Infer: It seems like the swift compiler in Xcode 7.1 now prevents
non-modular includes in umbrella header files. The public headers are
assumed to be imported in modules.

Context: https://github.com/Quick/Quick/issues/395