### PR TITLE
WIP: Protocol extension-based matchers

### DIFF
--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -1,27 +1,12 @@
 import Foundation
 
-internal func expressionMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, to: String, description: String?) -> (Bool, FailureMessage) {
+func expression<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matches: Bool, matcher: U, to: String, description: String?) -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.userDescription = description
-    msg.to = to
+    msg.to = matches ? to : "\(to) not"
     do {
-        let pass = try matcher.matches(expression, failureMessage: msg)
-        if msg.actualValue == "" {
-            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
-        }
-        return (pass, msg)
-    } catch let error {
-        msg.actualValue = "an unexpected error thrown: <\(error)>"
-        return (false, msg)
-    }
-}
-
-internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, toNot: String, description: String?) -> (Bool, FailureMessage) {
-    let msg = FailureMessage()
-    msg.userDescription = description
-    msg.to = toNot
-    do {
-        let pass = try matcher.doesNotMatch(expression, failureMessage: msg)
+        let match = matches ? matcher.matches : matcher.doesNotMatch
+        let pass = try match(expression, failureMessage: msg)
         if msg.actualValue == "" {
             msg.actualValue = "<\(stringify(try expression.evaluate()))>"
         }
@@ -35,20 +20,31 @@ internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(ex
 public struct Expectation<T> {
     let expression: Expression<T>
 
+    var matches = true
+
+    init(expression: Expression<T>) {
+        self.expression = expression
+    }
+
+    public var not: Expectation<T> {
+        var expectation = self
+        expectation.matches = !expectation.matches
+        return expectation
+    }
+
     public func verify(pass: Bool, _ message: FailureMessage) {
         NimbleAssertionHandler.assert(pass, message: message, location: expression.location)
     }
 
     /// Tests the actual value using a matcher to match.
     public func to<U where U: Matcher, U.ValueType == T>(matcher: U, description: String? = nil) {
-        let (pass, msg) = expressionMatches(expression, matcher: matcher, to: "to", description: description)
+        let (pass, msg) = Nimble.expression(expression, matches: matches, matcher: matcher, to: "to", description: description)
         verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match.
     public func toNot<U where U: Matcher, U.ValueType == T>(matcher: U, description: String? = nil) {
-        let (pass, msg) = expressionDoesNotMatch(expression, matcher: matcher, toNot: "to not", description: description)
-        verify(pass, msg)
+        not.to(matcher, description: description)
     }
 
     /// Tests the actual value using a matcher to not match.

--- a/Nimble/Expectation.swift
+++ b/Nimble/Expectation.swift
@@ -17,13 +17,19 @@ func expression<T, U where U: Matcher, U.ValueType == T>(expression: Expression<
     }
 }
 
-public struct Expectation<T> {
+public struct Expectation<T>: _ExpectationType {
+    public typealias Expected = T
+
     let expression: Expression<T>
 
     var matches = true
 
     init(expression: Expression<T>) {
         self.expression = expression
+    }
+
+    public var to: Expectation<T> {
+        return self
     }
 
     public var not: Expectation<T> {
@@ -57,4 +63,14 @@ public struct Expectation<T> {
     // see:
     // - AsyncMatcherWrapper for extension
     // - NMBExpectation for Objective-C interface
+}
+
+public protocol _ExpectationType {
+    typealias Expected
+}
+
+extension _ExpectationType {
+    var expectation: Expectation<Expected> {
+        return self as! Expectation<Expected>
+    }
 }

--- a/Nimble/Matchers/BeCloseTo.swift
+++ b/Nimble/Matchers/BeCloseTo.swift
@@ -12,6 +12,32 @@ internal func isCloseTo(actualValue: NMBDoubleConvertible?, expectedValue: NMBDo
     return actualValue != nil && abs(actualValue!.doubleValue - expectedValue.doubleValue) < delta
 }
 
+extension _ExpectationType where Expected == Double {
+    /// A Nimble matcher that succeeds when a value is close to another. This is used for floating
+    /// point values which can have imprecise results when doing arithmetic on them.
+    ///
+    /// @see equal
+    public func beCloseTo(expectedValue: Double, within delta: Double = DefaultDelta, description: String? = nil) {
+        expectation.to(Nimble.beCloseTo(expectedValue, within: delta), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == [Double] {
+    public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDelta, description: String? = nil) {
+        expectation.to(Nimble.beCloseTo(expectedValues, within: delta), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == NMBDoubleConvertible {
+    /// A Nimble matcher that succeeds when a value is close to another. This is used for floating
+    /// point values which can have imprecise results when doing arithmetic on them.
+    ///
+    /// @see equal
+    public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double = DefaultDelta, description: String? = nil) {
+        expectation.to(Nimble.beCloseTo(expectedValue, within: delta), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when a value is close to another. This is used for floating
 /// point values which can have imprecise results when doing arithmetic on them.
 ///

--- a/Nimble/Matchers/BeEmpty.swift
+++ b/Nimble/Matchers/BeEmpty.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+extension _ExpectationType where Expected: SequenceType {
+    /// A Nimble matcher that succeeds when a value is "empty". For collections, this
+    /// means the are no items in that collection. For strings, it is an empty string.
+    public func beEmpty(description description: String? = nil) {
+        expectation.to(Nimble.beEmpty(), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == String {
+    /// A Nimble matcher that succeeds when a value is "empty". For collections, this
+    /// means the are no items in that collection. For strings, it is an empty string.
+    public func beEmpty(description description: String? = nil) {
+        expectation.to(Nimble.beEmpty(), description: description)
+    }
+}
 
 /// A Nimble matcher that succeeds when a value is "empty". For collections, this
 /// means the are no items in that collection. For strings, it is an empty string.

--- a/Nimble/Matchers/BeGreaterThan.swift
+++ b/Nimble/Matchers/BeGreaterThan.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+extension _ExpectationType where Expected: Comparable {
+    /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
+    public func beGreaterThan(expectedValue: Expected, description: String? = nil) {
+        expectation.to(Nimble.beGreaterThan(expectedValue), description: description)
+    }
+}
 
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 public func beGreaterThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension _ExpectationType where Expected: Comparable {
+    /// A Nimble matcher that succeeds when the actual value is greater than
+    /// or equal to the expected value.
+    public func beGreaterThanOrEqualTo(expectedValue: Expected, description: String? = nil) {
+        expectation.to(Nimble.beGreaterThanOrEqualTo(expectedValue), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeLessThan.swift
+++ b/Nimble/Matchers/BeLessThan.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+extension _ExpectationType where Expected: Comparable {
+    /// A Nimble matcher that succeeds when the actual value is less than the expected value.
+    public func beLessThan(expectedValue: Expected, description: String? = nil) {
+        expectation.to(Nimble.beLessThan(expectedValue), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is less than the expected value.
 public func beLessThan<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension _ExpectationType where Expected: Comparable {
+    /// A Nimble matcher that succeeds when the actual value is less than
+    /// or equal to the expected value.
+    public func beLessThanOrEqualTo(expectedValue: Expected, description: String? = nil) {
+        expectation.to(Nimble.beLessThanOrEqualTo(expectedValue), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 public func beLessThanOrEqualTo<T: Comparable>(expectedValue: T?) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/BeLogical.swift
+++ b/Nimble/Matchers/BeLogical.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+extension _ExpectationType where Expected == Bool {
+    /// A Nimble matcher that succeeds when the actual value is exactly true.
+    /// This matcher will not match against nils.
+    public func beTrue(description description: String? = nil) {
+        expectation.to(Nimble.beTrue(), description: description)
+    }
+
+    /// A Nimble matcher that succeeds when the actual value is exactly false.
+    /// This matcher will not match against nils.
+    public func beFalse(description description: String? = nil) {
+        expectation.to(Nimble.beFalse(), description: description)
+    }
+}
+
+extension _ExpectationType {
+    /// A Nimble matcher that succeeds when the actual value is not logically false.
+    public func beTruthy(description description: String? = nil) {
+        expectation.to(Nimble.beTruthy(), description: description)
+    }
+
+    /// A Nimble matcher that succeeds when the actual value is logically false.
+    /// This matcher will match against nils.
+    public func beFalsy(description description: String? = nil) {
+        expectation.to(Nimble.beFalsy(), description: description)
+    }
+}
+
 internal func matcherWithFailureMessage<T, M: Matcher where M.ValueType == T>(matcher: M, postprocessor: (FailureMessage) -> Void) -> FullMatcherFunc<T> {
     return FullMatcherFunc { actualExpression, failureMessage, isNegation in
         let pass: Bool

--- a/Nimble/Matchers/BeNil.swift
+++ b/Nimble/Matchers/BeNil.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+extension _ExpectationType {
+    /// A Nimble matcher that succeeds when the actual value is nil.
+    public func beNil(description description: String? = nil) {
+        expectation.to(Nimble.beNil(), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is nil.
 public func beNil<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in

--- a/Nimble/Matchers/BeginWith.swift
+++ b/Nimble/Matchers/BeginWith.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+extension _ExpectationType where Expected: SequenceType, Expected.Generator.Element: Equatable {
+    /// A Nimble matcher that succeeds when the actual sequence's first element
+    /// is equal to the expected value.
+    public func beginWith(startingElement: Expected.Generator.Element, description: String? = nil) {
+        expectation.to(Nimble.beginWith(startingElement), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == [AnyObject] {
+    /// A Nimble matcher that succeeds when the actual collection's first element
+    /// is equal to the expected object.
+    public func beginWith(startingElement: AnyObject, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            failureMessage.postfixMessage = "begin with <\(startingElement)>"
+            let collection = try actualExpression.evaluate()
+            return collection != nil && (collection! as NSArray).indexOfObject(startingElement) == 0
+        }, description: description)
+    }
+}
+
+extension _ExpectationType where Expected == String {
+    /// A Nimble matcher that succeeds when the actual string contains expected substring
+    /// where the expected substring's location is zero.
+    public func beginWith(startingSubstring: String, description: String? = nil) {
+        expectation.to(Nimble.beginWith(startingSubstring), description: description)
+    }
+}
 
 /// A Nimble matcher that succeeds when the actual sequence's first element
 /// is equal to the expected value.

--- a/Nimble/Matchers/Contain.swift
+++ b/Nimble/Matchers/Contain.swift
@@ -1,5 +1,30 @@
 import Foundation
 
+extension _ExpectationType where Expected: SequenceType, Expected.Generator.Element: Equatable {
+    /// A Nimble matcher that succeeds when the actual sequence contains the expected value.
+    public func contain(item: Expected.Generator.Element, description: String? = nil) {
+        expectation.to(Nimble.contain(item), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == String {
+    /// A Nimble matcher that succeeds when the actual string contains the expected substring.
+    public func contain(substring: String, description: String? = nil) {
+        expectation.to(Nimble.contain(substring), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == [AnyObject] {
+    /// A Nimble matcher that succeeds when the actual sequence contains the expected value.
+    public func contain(item: AnyObject, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            failureMessage.postfixMessage = "contain <\(item)>"
+            let actual = try actualExpression.evaluate()
+            return actual != nil && (actual! as NSArray).containsObject(item)
+        }, description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual sequence contains the expected value.
 public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T>(items: T...) -> NonNilMatcherFunc<S> {
     return contain(items)

--- a/Nimble/Matchers/EndWith.swift
+++ b/Nimble/Matchers/EndWith.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+extension _ExpectationType where Expected: SequenceType, Expected.Generator.Element: Equatable {
+    /// A Nimble matcher that succeeds when the actual sequence's last element
+    /// is equal to the expected value.
+    public func endWith(endingElement: Expected.Generator.Element, description: String? = nil) {
+        expectation.to(Nimble.endWith(endingElement), description: description)
+    }
+}
+
+extension _ExpectationType where Expected == [AnyObject] {
+    /// A Nimble matcher that succeeds when the actual collection's last element
+    /// is equal to the expected object.
+    public func endWith(endingElement: AnyObject, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            failureMessage.postfixMessage = "end with <\(endingElement)>"
+            let collection = try actualExpression.evaluate()
+            return collection != nil && (collection! as NSArray).indexOfObject(endingElement) == collection!.count - 1
+        }, description: description)
+    }
+}
+
+extension _ExpectationType where Expected == String {
+    /// A Nimble matcher that succeeds when the actual string contains the expected substring
+    /// where the expected substring's location is the actual string's length minus the
+    /// expected substring's length.
+    public func endWith(substring: String, description: String? = nil) {
+        expectation.to(Nimble.endWith(substring), description: description)
+    }
+}
 
 /// A Nimble matcher that succeeds when the actual sequence's last element
 /// is equal to the expected value.

--- a/Nimble/Matchers/Equal.swift
+++ b/Nimble/Matchers/Equal.swift
@@ -1,5 +1,85 @@
 import Foundation
 
+extension _ExpectationType where Expected: Equatable {
+    /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+    /// Values can support equal by supporting the Equatable protocol.
+    ///
+    /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+    public func equal(expectedValue: Expected, description: String? = nil) {
+        expectation.to(Nimble.equal(expectedValue), description: description)
+    }
+}
+
+extension _ExpectationType where Expected: _ArrayType, Expected.Element: Equatable {
+    /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+    /// Values can support equal by supporting the Equatable protocol.
+    ///
+    /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+    public func equal(expectedValue: Expected, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+            let actualValue = try actualExpression.evaluate()
+            if actualValue == nil {
+                return false
+            }
+            return expectedValue.array == actualValue!.array
+        }, description: description)
+    }
+}
+
+extension _ExpectationType where Expected: _SetType, Expected.Element: Comparable {
+    /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+    /// Values can support equal by supporting the Equatable protocol.
+    ///
+    /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+    public func equal(expectedValue: Expected, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            if let actualValue = try actualExpression.evaluate() {
+                let expected = expectedValue.set
+                let actual = actualValue.set
+
+                failureMessage.actualValue = "<\(Array(actual).sort { $0 < $1 })>"
+                failureMessage.postfixMessage = "equal <\(Array(expected).sort { $0 < $1 })>"
+
+                if expected == actual {
+                    return true
+                }
+
+                let missing = expected.subtract(actual)
+                if missing.count > 0 {
+                    failureMessage.postfixActual += ", missing <\(stringify(missing))>"
+                }
+
+                let extra = actual.subtract(expected)
+                if extra.count > 0 {
+                    failureMessage.postfixActual += ", extra <\(stringify(extra))>"
+                }
+            } else {
+                failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+            }
+
+            return false
+        }, description: description)
+    }
+}
+
+extension _ExpectationType where Expected: _OptionalType, Expected.WrappedType: Equatable {
+    /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
+    /// Values can support equal by supporting the Equatable protocol.
+    ///
+    /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+    public func equal(expectedValue: Expected, description: String? = nil) {
+        expectation.to(NonNilMatcherFunc { actualExpression, failureMessage in
+            failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
+            let actualValue = try actualExpression.evaluate()
+            if actualValue == nil {
+                return false
+            }
+            return expectedValue.optional == actualValue!.optional
+        }, description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
 /// Values can support equal by supporting the Equatable protocol.
 ///
@@ -145,4 +225,32 @@ extension NMBObjCMatcher {
             return try! equal(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }
+}
+
+// Required for nil equality conformances
+
+public protocol _OptionalType {
+    typealias WrappedType
+}
+extension Optional: _OptionalType {
+    public typealias WrappedType = Wrapped
+}
+extension _OptionalType {
+    var optional: WrappedType? { return self as? WrappedType }
+}
+
+public protocol _ArrayType {
+    typealias Element
+}
+extension Array: _ArrayType {}
+extension _ArrayType {
+    var array: [Element] { return self as! [Element] }
+}
+
+public protocol _SetType: Equatable {
+    typealias Element: Hashable
+}
+extension Set: _SetType {}
+extension _SetType {
+    var set: Set<Element> { return self as! Set<Element> }
 }

--- a/Nimble/Matchers/HaveCount.swift
+++ b/Nimble/Matchers/HaveCount.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension _ExpectationType where Expected: CollectionType {
+    /// A Nimble matcher that succeeds when the actual CollectionType's count equals
+    /// the expected value
+    public func haveCount(expectedValue: Expected.Index.Distance, description: String? = nil) {
+        expectation.to(Nimble.haveCount(expectedValue), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual CollectionType's count equals
 /// the expected value
 public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> NonNilMatcherFunc<T> {

--- a/Nimble/Matchers/Match.swift
+++ b/Nimble/Matchers/Match.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension _ExpectationType where Expected == String {
+    /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
+    /// described by the expected string.
+    public func match(expectedValue: String, description: String? = nil) {
+        expectation.to(Nimble.match(expectedValue), description: description)
+    }
+}
+
 /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
 /// described by the expected string.
 public func match(expectedValue: String?) -> NonNilMatcherFunc<String> {

--- a/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -54,8 +54,9 @@ extension Expectation {
     /// at each pollInterval until the timeout is reached.
     public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01, description: String? = nil) {
         if expression.isClosure {
-            let (pass, msg) = expressionMatches(
+            let (pass, msg) = Nimble.expression(
                 expression,
+                matches: matches,
                 matcher: AsyncMatcherWrapper(
                     fullMatcher: matcher,
                     timeoutInterval: timeout,
@@ -72,20 +73,7 @@ extension Expectation {
     /// Tests the actual value using a matcher to not match by checking
     /// continuously at each pollInterval until the timeout is reached.
     public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01, description: String? = nil) {
-        if expression.isClosure {
-            let (pass, msg) = expressionDoesNotMatch(
-                expression,
-                matcher: AsyncMatcherWrapper(
-                    fullMatcher: matcher,
-                    timeoutInterval: timeout,
-                    pollInterval: pollInterval),
-                toNot: "to eventually not",
-                description: description
-            )
-            verify(pass, msg)
-        } else {
-            verify(false, toEventuallyRequiresClosureError)
-        }
+        not.toEventually(matcher, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to not match by checking

--- a/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/NimbleTests/Matchers/BeCloseToTest.swift
@@ -3,40 +3,40 @@ import Nimble
 
 class BeCloseToTest: XCTestCase {
     func testBeCloseTo() {
-        expect(1.2).to(beCloseTo(1.2001))
-        expect(1.2 as CDouble).to(beCloseTo(1.2001))
-        expect(1.2 as Float).to(beCloseTo(1.2001))
+        expect(1.2).to.beCloseTo(1.2001)
+        expect(1.2 as CDouble).to.beCloseTo(1.2001)
+        expect(1.2 as Float).to.beCloseTo(1.2001)
 
         failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2000>") {
-            expect(1.2).toNot(beCloseTo(1.2001))
+            expect(1.2).to.not.beCloseTo(1.2001)
         }
     }
 
     func testBeCloseToWithin() {
-        expect(1.2).to(beCloseTo(9.300, within: 10))
+        expect(1.2).to.beCloseTo(9.300, within: 10)
 
         failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
-            expect(1.2).toNot(beCloseTo(1.2001, within: 1.0))
+            expect(1.2).to.not.beCloseTo(1.2001, within: 1.0)
         }
     }
 
     func testBeCloseToWithNSNumber() {
-        expect(NSNumber(double:1.2)).to(beCloseTo(9.300, within: 10))
-        expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
-        expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
+        expect(NSNumber(double:1.2)).to.beCloseTo(9.300, within: 10)
+        expect(NSNumber(double:1.2)).to.beCloseTo(NSNumber(double:9.300), within: 10)
+        expect(1.2).to.beCloseTo(NSNumber(double:9.300), within: 10)
 
         failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
-            expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
+            expect(NSNumber(double:1.2)).to.not.beCloseTo(1.2001, within: 1.0)
         }
     }
     
     func testBeCloseToWithNSDate() {
-        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to.beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10)
         
         failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.0040), got <2015-08-26 11:43:00.0000>") {
 
             let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
-            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to.not.beCloseTo(expectedDate, within: 0.004)
         }
     }
     
@@ -75,11 +75,59 @@ class BeCloseToTest: XCTestCase {
 
     func testBeCloseToArray() {
         expect([0.0, 1.1, 2.2]) ≈ [0.0001, 1.1001, 2.2001]
-        expect([0.0, 1.1, 2.2]).to(beCloseTo([0.1, 1.2, 2.3], within: 0.1))
+        expect([0.0, 1.1, 2.2]).to.beCloseTo([0.1, 1.2, 2.3], within: 0.1)
         
         failsWithErrorMessage("expected to be close to <[0.0000, 1.0000]> (each within 0.0001), got <[0.0, 1.1]>") {
             expect([0.0, 1.1]) ≈ [0.0, 1.0]
         }
+        failsWithErrorMessage("expected to be close to <[0.2000, 1.2000]> (each within 0.1000), got <[0.0, 1.1]>") {
+            expect([0.0, 1.1]).to.beCloseTo([0.2, 1.2], within: 0.1)
+        }
+    }
+}
+
+class BeCloseToDeprecatedTest: XCTestCase {
+    func testBeCloseTo() {
+        expect(1.2).to(beCloseTo(1.2001))
+        expect(1.2 as CDouble).to(beCloseTo(1.2001))
+        expect(1.2 as Float).to(beCloseTo(1.2001))
+
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2000>") {
+            expect(1.2).toNot(beCloseTo(1.2001))
+        }
+    }
+
+    func testBeCloseToWithin() {
+        expect(1.2).to(beCloseTo(9.300, within: 10))
+
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
+            expect(1.2).toNot(beCloseTo(1.2001, within: 1.0))
+        }
+    }
+
+    func testBeCloseToWithNSNumber() {
+        expect(NSNumber(double:1.2)).to(beCloseTo(9.300, within: 10))
+        expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
+        expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
+
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
+            expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
+        }
+    }
+
+    func testBeCloseToWithNSDate() {
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
+
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.0040), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
+        }
+    }
+
+    func testBeCloseToArray() {
+        expect([0.0, 1.1, 2.2]).to(beCloseTo([0.1, 1.2, 2.3], within: 0.1))
+
         failsWithErrorMessage("expected to be close to <[0.2000, 1.2000]> (each within 0.1000), got <[0.0, 1.1]>") {
             expect([0.0, 1.1]).to(beCloseTo([0.2, 1.2], within: 0.1))
         }

--- a/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/NimbleTests/Matchers/BeEmptyTest.swift
@@ -3,6 +3,54 @@ import Nimble
 
 class BeEmptyTest: XCTestCase {
     func testBeEmptyPositive() {
+        expect([] as [Int]).to.beEmpty()
+        expect([1]).to.not.beEmpty()
+
+        expect([] as [CInt]).to.beEmpty()
+        expect([1] as [CInt]).to.not.beEmpty()
+
+        expect(NSDictionary() as? [Int:Int]).to.beEmpty()
+        expect(NSDictionary(object: 1, forKey: 1) as? [Int:Int]).to.not.beEmpty()
+
+        expect(Dictionary<Int, Int>()).to.beEmpty()
+        expect(["hi": 1]).to.not.beEmpty()
+
+        expect(NSArray() as? [Int]).to.beEmpty()
+        expect(NSArray(array: [1]) as? [Int]).to.not.beEmpty()
+
+        expect(NSSet()).to.beEmpty()
+        expect(NSSet(array: [1])).to.not.beEmpty()
+
+        expect("").to.beEmpty()
+        expect("foo").to.not.beEmpty()
+    }
+
+    func testBeEmptyNegative() {
+        failsWithErrorMessageForNil("expected to be empty, got <nil>") {
+            expect(nil as String?).to.beEmpty()
+        }
+        failsWithErrorMessageForNil("expected to not be empty, got <nil>") {
+            expect(nil as [CInt]?).to.not.beEmpty()
+        }
+
+        failsWithErrorMessage("expected to not be empty, got <()>") {
+            expect([]).to.not.beEmpty()
+        }
+        failsWithErrorMessage("expected to be empty, got <[1]>") {
+            expect([1]).to.beEmpty()
+        }
+
+        failsWithErrorMessage("expected to not be empty, got <>") {
+            expect("").to.not.beEmpty()
+        }
+        failsWithErrorMessage("expected to be empty, got <foo>") {
+            expect("foo").to.beEmpty()
+        }
+    }
+}
+
+class BeEmptyDeprecatedTest: XCTestCase {
+    func testBeEmptyPositive_deprecated() {
         expect([] as [Int]).to(beEmpty())
         expect([1]).toNot(beEmpty())
 
@@ -28,7 +76,7 @@ class BeEmptyTest: XCTestCase {
         expect("foo").toNot(beEmpty())
     }
 
-    func testBeEmptyNegative() {
+    func testBeEmptyNegative_deprecated() {
         failsWithErrorMessageForNil("expected to be empty, got <nil>") {
             expect(nil as NSString?).to(beEmpty())
         }

--- a/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -2,7 +2,41 @@ import XCTest
 import Nimble
 
 class BeGreaterThanOrEqualToTest: XCTestCase {
+    func testGreaterThanOrEqualTo() {
+        expect(10).to.beGreaterThanOrEqualTo(10)
+        expect(10).to.beGreaterThanOrEqualTo(2)
+        expect(1).to.not.beGreaterThanOrEqualTo(2)
 
+        failsWithErrorMessage("expected to be greater than or equal to <2>, got <0>") {
+            expect(0).to.beGreaterThanOrEqualTo(2)
+            return
+        }
+        failsWithErrorMessage("expected to not be greater than or equal to <1>, got <1>") {
+            expect(1).to.not.beGreaterThanOrEqualTo(1)
+            return
+        }
+        failsWithErrorMessageForNil("expected to be greater than or equal to <-2>, got <nil>") {
+            expect(nil as Int?).to.beGreaterThanOrEqualTo(-2)
+        }
+        failsWithErrorMessageForNil("expected to not be greater than or equal to <1>, got <nil>") {
+            expect(nil as Int?).to.not.beGreaterThanOrEqualTo(1)
+        }
+    }
+
+    func testGreaterThanOrEqualToOperator() {
+        expect(0) >= 0
+        expect(1) >= 0
+        expect(NSNumber(int:1)) >= 1
+        expect(NSNumber(int:1)) >= NSNumber(int:1)
+
+        failsWithErrorMessage("expected to be greater than or equal to <2>, got <1>") {
+            expect(1) >= 2
+            return
+        }
+    }
+}
+
+class BeGreaterThanOrEqualToDeprecatedTest: XCTestCase {
     func testGreaterThanOrEqualTo() {
         expect(10).to(beGreaterThanOrEqualTo(10))
         expect(10).to(beGreaterThanOrEqualTo(2))
@@ -24,18 +58,6 @@ class BeGreaterThanOrEqualToTest: XCTestCase {
         }
         failsWithErrorMessageForNil("expected to not be greater than or equal to <1>, got <nil>") {
             expect(nil as Int?).toNot(beGreaterThanOrEqualTo(1))
-        }
-    }
-
-    func testGreaterThanOrEqualToOperator() {
-        expect(0) >= 0
-        expect(1) >= 0
-        expect(NSNumber(int:1)) >= 1
-        expect(NSNumber(int:1)) >= NSNumber(int:1)
-
-        failsWithErrorMessage("expected to be greater than or equal to <2>, got <1>") {
-            expect(1) >= 2
-            return
         }
     }
 }

--- a/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -3,6 +3,37 @@ import Nimble
 
 class BeGreaterThanTest: XCTestCase {
     func testGreaterThan() {
+        expect(10).to.beGreaterThan(2)
+        expect(1).to.not.beGreaterThan(2)
+
+        failsWithErrorMessage("expected to be greater than <2>, got <0>") {
+            expect(0).to.beGreaterThan(2)
+        }
+        failsWithErrorMessage("expected to not be greater than <0>, got <1>") {
+            expect(1).to.not.beGreaterThan(0)
+        }
+        failsWithErrorMessageForNil("expected to be greater than <-2>, got <nil>") {
+            expect(nil as Int?).to.beGreaterThan(-2)
+        }
+        failsWithErrorMessageForNil("expected to not be greater than <0>, got <nil>") {
+            expect(nil as Int?).to.not.beGreaterThan(0)
+        }
+    }
+
+    func testGreaterThanOperator() {
+        expect(1) > 0
+        expect(NSNumber(int:1)) > NSNumber(int:0)
+        expect(NSNumber(int:1)) > 0
+
+        failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
+            expect(1) > 2
+            return
+        }
+    }
+}
+
+class BeGreaterThanDeprecatedTest: XCTestCase {
+    func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))
         expect(NSNumber(int:3)).to(beGreaterThan(2))
@@ -19,17 +50,6 @@ class BeGreaterThanTest: XCTestCase {
         }
         failsWithErrorMessageForNil("expected to not be greater than <0>, got <nil>") {
             expect(nil as Int?).toNot(beGreaterThan(0))
-        }
-    }
-
-    func testGreaterThanOperator() {
-        expect(1) > 0
-        expect(NSNumber(int:1)) > NSNumber(int:0)
-        expect(NSNumber(int:1)) > 0
-
-        failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
-            expect(1) > 2
-            return
         }
     }
 }

--- a/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -3,6 +3,41 @@ import Nimble
 
 class BeLessThanOrEqualToTest: XCTestCase {
     func testLessThanOrEqualTo() {
+        expect(10).to.beLessThanOrEqualTo(10)
+        expect(2).to.beLessThanOrEqualTo(10)
+        expect(2).to.not.beLessThanOrEqualTo(1)
+
+        failsWithErrorMessage("expected to be less than or equal to <0>, got <2>") {
+            expect(2).to.beLessThanOrEqualTo(0)
+            return
+        }
+        failsWithErrorMessage("expected to not be less than or equal to <0>, got <0>") {
+            expect(0).to.not.beLessThanOrEqualTo(0)
+            return
+        }
+        failsWithErrorMessageForNil("expected to be less than or equal to <2>, got <nil>") {
+            expect(nil as Int?).to.beLessThanOrEqualTo(2)
+            return
+        }
+        failsWithErrorMessageForNil("expected to not be less than or equal to <-2>, got <nil>") {
+            expect(nil as Int?).to.not.beLessThanOrEqualTo(-2)
+            return
+        }
+    }
+
+    func testLessThanOrEqualToOperator() {
+        expect(0) <= 1
+        expect(1) <= 1
+
+        failsWithErrorMessage("expected to be less than or equal to <1>, got <2>") {
+            expect(2) <= 1
+            return
+        }
+    }
+}
+
+class BeLessThanOrEqualToDeprecatedTest: XCTestCase {
+    func testLessThanOrEqualTo() {
         expect(10).to(beLessThanOrEqualTo(10))
         expect(2).to(beLessThanOrEqualTo(10))
         expect(2).toNot(beLessThanOrEqualTo(1))
@@ -26,16 +61,6 @@ class BeLessThanOrEqualToTest: XCTestCase {
         }
         failsWithErrorMessageForNil("expected to not be less than or equal to <-2>, got <nil>") {
             expect(nil as Int?).toNot(beLessThanOrEqualTo(-2))
-            return
-        }
-    }
-
-    func testLessThanOrEqualToOperator() {
-        expect(0) <= 1
-        expect(1) <= 1
-
-        failsWithErrorMessage("expected to be less than or equal to <1>, got <2>") {
-            expect(2) <= 1
             return
         }
     }

--- a/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/NimbleTests/Matchers/BeLessThanTest.swift
@@ -2,7 +2,37 @@ import XCTest
 import Nimble
 
 class BeLessThanTest: XCTestCase {
+    func testLessThan() {
+        expect(2).to.beLessThan(10)
+        expect(2).to.not.beLessThan(1)
 
+        failsWithErrorMessage("expected to be less than <0>, got <2>") {
+            expect(2).to.beLessThan(0)
+        }
+        failsWithErrorMessage("expected to not be less than <1>, got <0>") {
+            expect(0).to.not.beLessThan(1)
+        }
+
+        failsWithErrorMessageForNil("expected to be less than <2>, got <nil>") {
+            expect(nil as Int?).to.beLessThan(2)
+        }
+        failsWithErrorMessageForNil("expected to not be less than <-1>, got <nil>") {
+            expect(nil as Int?).to.not.beLessThan(-1)
+        }
+    }
+
+    func testLessThanOperator() {
+        expect(0) < 1
+        expect(NSNumber(int:0)) < 1
+
+        failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
+            expect(2) < 1
+            return
+        }
+    }
+}
+
+class BeLessThanDeprecatedTest: XCTestCase {
     func testLessThan() {
         expect(2).to(beLessThan(10))
         expect(2).toNot(beLessThan(1))
@@ -24,16 +54,6 @@ class BeLessThanTest: XCTestCase {
         }
         failsWithErrorMessageForNil("expected to not be less than <-1>, got <nil>") {
             expect(nil as Int?).toNot(beLessThan(-1))
-        }
-    }
-
-    func testLessThanOperator() {
-        expect(0) < 1
-        expect(NSNumber(int:0)) < 1
-
-        failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
-            expect(2) < 1
-            return
         }
     }
 }

--- a/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/NimbleTests/Matchers/BeLogicalTest.swift
@@ -1,25 +1,153 @@
 import XCTest
 import Nimble
 
-enum ConvertsToBool : BooleanType, CustomStringConvertible {
-    case TrueLike, FalseLike
+class BeTruthyTest : XCTestCase {
+    func testShouldMatchNonNilTypes() {
+        expect(true as Bool?).to.beTruthy()
+        expect(1 as Int?).to.beTruthy()
+    }
 
-    var boolValue : Bool {
-        switch self {
-        case .TrueLike: return true
-        case .FalseLike: return false
+    func testShouldMatchTrue() {
+        expect(true).to.beTruthy()
+
+        failsWithErrorMessage("expected to not be truthy, got <true>") {
+            expect(true).to.not.beTruthy()
         }
     }
 
-    var description : String {
-        switch self {
-        case .TrueLike: return "TrueLike"
-        case .FalseLike: return "FalseLike"
+    func testShouldNotMatchNilTypes() {
+        expect(false as Bool?).to.not.beTruthy()
+        expect(nil as Bool?).to.not.beTruthy()
+        expect(nil as Int?).to.not.beTruthy()
+    }
+
+    func testShouldNotMatchFalse() {
+        expect(false).to.not.beTruthy()
+
+        failsWithErrorMessage("expected to be truthy, got <false>") {
+            expect(false).to.beTruthy()
+        }
+    }
+
+    func testShouldNotMatchNilBools() {
+        expect(nil as Bool?).to.not.beTruthy()
+
+        failsWithErrorMessage("expected to be truthy, got <nil>") {
+            expect(nil as Bool?).to.beTruthy()
+        }
+    }
+
+    func testShouldMatchBoolConvertibleTypesThatConvertToTrue() {
+        expect(ConvertsToBool.TrueLike).to.beTruthy()
+
+        failsWithErrorMessage("expected to not be truthy, got <TrueLike>") {
+            expect(ConvertsToBool.TrueLike).to.not.beTruthy()
+        }
+    }
+
+    func testShouldNotMatchBoolConvertibleTypesThatConvertToFalse() {
+        expect(ConvertsToBool.FalseLike).to.not.beTruthy()
+
+        failsWithErrorMessage("expected to be truthy, got <FalseLike>") {
+            expect(ConvertsToBool.FalseLike).to.beTruthy()
         }
     }
 }
 
-class BeTruthyTest : XCTestCase {
+class BeTrueTest : XCTestCase {
+    func testShouldMatchTrue() {
+        expect(true).to.beTrue()
+
+        failsWithErrorMessage("expected to not be true, got <true>") {
+            expect(true).to.not.beTrue()
+        }
+    }
+
+    func testShouldNotMatchFalse() {
+        expect(false).to.not.beTrue()
+
+        failsWithErrorMessage("expected to be true, got <false>") {
+            expect(false).to.beTrue()
+        }
+    }
+
+    func testShouldNotMatchNilBools() {
+        failsWithErrorMessageForNil("expected to not be true, got <nil>") {
+            expect(nil as Bool?).to.not.beTrue()
+        }
+
+        failsWithErrorMessageForNil("expected to be true, got <nil>") {
+            expect(nil as Bool?).to.beTrue()
+        }
+    }
+}
+
+class BeFalsyTest : XCTestCase {
+    func testShouldMatchNilTypes() {
+        expect(false as Bool?).to.beFalsy()
+        expect(nil as Bool?).to.beFalsy()
+        expect(nil as Int?).to.beFalsy()
+    }
+
+    func testShouldNotMatchTrue() {
+        expect(true).to.not.beFalsy()
+
+        failsWithErrorMessage("expected to be falsy, got <true>") {
+            expect(true).to.beFalsy()
+        }
+    }
+
+    func testShouldNotMatchNonNilTypes() {
+        expect(true as Bool?).to.not.beFalsy()
+        expect(1 as Int?).to.not.beFalsy()
+    }
+
+    func testShouldMatchFalse() {
+        expect(false).to.beFalsy()
+
+        failsWithErrorMessage("expected to not be falsy, got <false>") {
+            expect(false).to.not.beFalsy()
+        }
+    }
+
+    func testShouldMatchNilBools() {
+        expect(nil as Bool?).to.beFalsy()
+
+        failsWithErrorMessage("expected to not be falsy, got <nil>") {
+            expect(nil as Bool?).to.not.beFalsy()
+        }
+    }
+}
+
+class BeFalseTest : XCTestCase {
+    func testShouldNotMatchTrue() {
+        expect(true).to.not.beFalse()
+
+        failsWithErrorMessage("expected to be false, got <true>") {
+            expect(true).to.beFalse()
+        }
+    }
+
+    func testShouldMatchFalse() {
+        expect(false).to.beFalse()
+
+        failsWithErrorMessage("expected to not be false, got <false>") {
+            expect(false).to.not.beFalse()
+        }
+    }
+
+    func testShouldNotMatchNilBools() {
+        failsWithErrorMessageForNil("expected to be false, got <nil>") {
+            expect(nil as Bool?).to.beFalse()
+        }
+
+        failsWithErrorMessageForNil("expected to not be false, got <nil>") {
+            expect(nil as Bool?).to.not.beFalse()
+        }
+    }
+}
+
+class BeTruthyDeprecatedTest : XCTestCase {
     func testShouldMatchNonNilTypes() {
         expect(true as Bool?).to(beTruthy())
         expect(1 as Int?).to(beTruthy())
@@ -72,7 +200,7 @@ class BeTruthyTest : XCTestCase {
     }
 }
 
-class BeTrueTest : XCTestCase {
+class BeTrueDeprecatedTest : XCTestCase {
     func testShouldMatchTrue() {
         expect(true).to(beTrue())
 
@@ -100,7 +228,7 @@ class BeTrueTest : XCTestCase {
     }
 }
 
-class BeFalsyTest : XCTestCase {
+class BeFalsyDeprecatedTest : XCTestCase {
     func testShouldMatchNilTypes() {
         expect(false as Bool?).to(beFalsy())
         expect(nil as Bool?).to(beFalsy())
@@ -137,7 +265,7 @@ class BeFalsyTest : XCTestCase {
     }
 }
 
-class BeFalseTest : XCTestCase {
+class BeFalseDeprecatedTest : XCTestCase {
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalse())
 
@@ -161,6 +289,24 @@ class BeFalseTest : XCTestCase {
 
         failsWithErrorMessageForNil("expected to not be false, got <nil>") {
             expect(nil as Bool?).toNot(beFalse())
+        }
+    }
+}
+
+enum ConvertsToBool : BooleanType, CustomStringConvertible {
+    case TrueLike, FalseLike
+
+    var boolValue : Bool {
+        switch self {
+        case .TrueLike: return true
+        case .FalseLike: return false
+        }
+    }
+
+    var description : String {
+        switch self {
+        case .TrueLike: return "TrueLike"
+        case .FalseLike: return "FalseLike"
         }
     }
 }

--- a/NimbleTests/Matchers/BeNilTest.swift
+++ b/NimbleTests/Matchers/BeNilTest.swift
@@ -2,14 +2,26 @@ import XCTest
 import Nimble
 
 class BeNilTest: XCTestCase {
-    func producesNil() -> Array<Int>? {
-        return nil
-    }
+    func testBeNil() {
+        expect(nil as Int?).to.beNil()
+        expect(1 as Int?).to.not.beNil()
+        expect(producesNil()).to.beNil()
 
+        failsWithErrorMessage("expected to not be nil, got <nil>") {
+            expect(nil as Int?).to.not.beNil()
+        }
+
+        failsWithErrorMessage("expected to be nil, got <1>") {
+            expect(1 as Int?).to.beNil()
+        }
+    }
+}
+
+class BeNilDeprecatedTest: XCTestCase {
     func testBeNil() {
         expect(nil as Int?).to(beNil())
         expect(1 as Int?).toNot(beNil())
-        expect(self.producesNil()).to(beNil())
+        expect(producesNil()).to(beNil())
 
         failsWithErrorMessage("expected to not be nil, got <nil>") {
             expect(nil as Int?).toNot(beNil())
@@ -19,4 +31,8 @@ class BeNilTest: XCTestCase {
             expect(1 as Int?).to(beNil())
         }
     }
+}
+
+func producesNil() -> Array<Int>? {
+    return nil
 }

--- a/NimbleTests/Matchers/BeginWithTest.swift
+++ b/NimbleTests/Matchers/BeginWithTest.swift
@@ -2,7 +2,44 @@ import XCTest
 import Nimble
 
 class BeginWithTest: XCTestCase {
+    func testPositiveMatches() {
+        expect([1, 2, 3]).to.beginWith(1)
+        expect([1, 2, 3]).to.not.beginWith(2)
 
+        expect("foobar").to.beginWith("foo")
+        expect("foobar").to.not.beginWith("oo")
+
+        expect(NSString(string: "foobar").description).to.beginWith("foo")
+        expect(NSString(string: "foobar").description).to.not.beginWith("oo")
+
+        expect(NSArray(array: ["a", "b"]) as [AnyObject]).to.beginWith("a")
+        expect(NSArray(array: ["a", "b"]) as [AnyObject]).to.not.beginWith("b")
+    }
+
+    func testNegativeMatches() {
+        failsWithErrorMessageForNil("expected to begin with <b>, got <nil>") {
+            expect(nil as NSArray?).to(beginWith("b"))
+        }
+        failsWithErrorMessageForNil("expected to not begin with <b>, got <nil>") {
+            expect(nil as NSArray?).toNot(beginWith("b"))
+        }
+
+        failsWithErrorMessage("expected to begin with <2>, got <[1, 2, 3]>") {
+            expect([1, 2, 3]).to(beginWith(2))
+        }
+        failsWithErrorMessage("expected to not begin with <1>, got <[1, 2, 3]>") {
+            expect([1, 2, 3]).toNot(beginWith(1))
+        }
+        failsWithErrorMessage("expected to begin with <atm>, got <batman>") {
+            expect("batman").to(beginWith("atm"))
+        }
+        failsWithErrorMessage("expected to not begin with <bat>, got <batman>") {
+            expect("batman").toNot(beginWith("bat"))
+        }
+    }
+}
+
+class BeginWithDeprecatedTest: XCTestCase {
     func testPositiveMatches() {
         expect([1, 2, 3]).to(beginWith(1))
         expect([1, 2, 3]).toNot(beginWith(2))
@@ -38,5 +75,4 @@ class BeginWithTest: XCTestCase {
             expect("batman").toNot(beginWith("bat"))
         }
     }
-
 }

--- a/NimbleTests/Matchers/ContainTest.swift
+++ b/NimbleTests/Matchers/ContainTest.swift
@@ -3,6 +3,48 @@ import Nimble
 
 class ContainTest: XCTestCase {
     func testContain() {
+        expect([1, 2, 3]).to.contain(1)
+        expect([1, 2, 3] as [CInt]).to.contain(1 as CInt)
+        expect([1, 2, 3] as Array<CInt>).to.contain(1 as CInt)
+        expect(["foo", "bar", "baz"]).to.contain("baz")
+        expect([1, 2, 3]).to.not.contain(4)
+        expect(["foo", "bar", "baz"]).to.not.contain("ba")
+        expect(["a"] as [AnyObject]).to.contain("a")
+        expect(["a"] as [AnyObject]).to.not.contain("b")
+        expect([1] as [AnyObject]).to.contain(1)
+
+        failsWithErrorMessage("expected to contain <bar>, got <[\"a\", \"b\", \"c\"]>") {
+            expect(["a", "b", "c"]).to.contain("bar")
+        }
+        failsWithErrorMessage("expected to not contain <b>, got <[\"a\", \"b\", \"c\"]>") {
+            expect(["a", "b", "c"]).to.not.contain("b")
+        }
+
+        failsWithErrorMessageForNil("expected to contain <bar>, got <nil>") {
+            expect(nil as [String]?).to.contain("bar")
+        }
+        failsWithErrorMessageForNil("expected to not contain <b>, got <nil>") {
+            expect(nil as [String]?).to.not.contain("b")
+        }
+    }
+
+    func testContainSubstring() {
+        expect("foo").to.contain("o")
+        expect("foo").to.contain("oo")
+        expect("foo").to.not.contain("z")
+        expect("foo").to.not.contain("zz")
+
+        failsWithErrorMessage("expected to contain <bar>, got <foo>") {
+            expect("foo").to.contain("bar")
+        }
+        failsWithErrorMessage("expected to not contain <oo>, got <foo>") {
+            expect("foo").to.not.contain("oo")
+        }
+    }
+}
+
+class ContainDeprecatedTest: XCTestCase {
+    func testContain() {
         expect([1, 2, 3]).to(contain(1))
         expect([1, 2, 3] as [CInt]).to(contain(1 as CInt))
         expect([1, 2, 3] as Array<CInt>).to(contain(1 as CInt))

--- a/NimbleTests/Matchers/EndWithTest.swift
+++ b/NimbleTests/Matchers/EndWithTest.swift
@@ -2,7 +2,44 @@ import XCTest
 import Nimble
 
 class EndWithTest: XCTestCase {
+    func testEndWithPositives() {
+        expect([1, 2, 3]).to.endWith(3)
+        expect([1, 2, 3]).to.not.endWith(2)
 
+        expect("foobar").to.endWith("bar")
+        expect("foobar").to.not.endWith("oo")
+
+        expect(NSString(string: "foobar").description).to.endWith("bar")
+        expect(NSString(string: "foobar").description).to.not.endWith("oo")
+
+        expect(["a", "b"] as [AnyObject]).to.endWith("b")
+        expect(["a", "b"] as [AnyObject]).to.not.endWith("a")
+    }
+
+    func testEndWithNegatives() {
+        failsWithErrorMessageForNil("expected to end with <2>, got <nil>") {
+            expect(nil as [Int]?).to.endWith(2)
+        }
+        failsWithErrorMessageForNil("expected to not end with <2>, got <nil>") {
+            expect(nil as [Int]?).to.not.endWith(2)
+        }
+
+        failsWithErrorMessage("expected to end with <2>, got <[1, 2, 3]>") {
+            expect([1, 2, 3]).to.endWith(2)
+        }
+        failsWithErrorMessage("expected to not end with <3>, got <[1, 2, 3]>") {
+            expect([1, 2, 3]).to.not.endWith(3)
+        }
+        failsWithErrorMessage("expected to end with <atm>, got <batman>") {
+            expect("batman").to.endWith("atm")
+        }
+        failsWithErrorMessage("expected to not end with <man>, got <batman>") {
+            expect("batman").to.not.endWith("man")
+        }
+    }
+}
+
+class EndWithDeprecatedTest: XCTestCase {
     func testEndWithPositives() {
         expect([1, 2, 3]).to(endWith(3))
         expect([1, 2, 3]).toNot(endWith(2))
@@ -38,5 +75,4 @@ class EndWithTest: XCTestCase {
             expect("batman").toNot(endWith("man"))
         }
     }
-
 }

--- a/NimbleTests/Matchers/EqualTest.swift
+++ b/NimbleTests/Matchers/EqualTest.swift
@@ -3,6 +3,195 @@ import Nimble
 
 class EqualTest: XCTestCase {
     func testEquality() {
+        expect(1 as CInt).to.equal(1 as CInt)
+        expect(1 as CInt).to.equal(1)
+        expect(1).to.equal(1)
+        expect("hello").to.equal("hello")
+        expect("hello").to.not.equal("world")
+
+        expect {
+            1
+        }.to.equal(1)
+
+        failsWithErrorMessage("expected to equal <world>, got <hello>") {
+            expect("hello").to.equal("world")
+        }
+        failsWithErrorMessage("expected to not equal <hello>, got <hello>") {
+            expect("hello").to.not.equal("hello")
+        }
+    }
+
+    func testArrayEquality() {
+        expect([1, 2, 3]).to.equal([1, 2, 3])
+        expect([1, 2, 3]).to.not.equal([1, 2])
+        expect([1, 2, 3]).to.not.equal([1, 2, 4])
+
+        let array1: Array<Int> = [1, 2, 3]
+        let array2: Array<Int> = [1, 2, 3]
+        expect(array1).to.equal(array2)
+        expect(array1).to.equal([1, 2, 3])
+        expect(array1).to.not.equal([1, 2] as Array<Int>)
+
+        expect(NSArray(array: [1, 2, 3])).to.equal(NSArray(array: [1, 2, 3]))
+
+        failsWithErrorMessage("expected to equal <[1, 2]>, got <[1, 2, 3]>") {
+            expect([1, 2, 3]).to.equal([1, 2])
+        }
+    }
+
+    func testSetEquality() {
+        expect(Set([1, 2])).to.equal(Set([1, 2]))
+        expect(Set<Int>()).to.equal(Set<Int>())
+        expect(Set<Int>()) == Set<Int>()
+        expect(Set([1, 2])) != Set<Int>()
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3]>, missing <[1]>") {
+            expect(Set([2, 3])).to.equal(Set([1, 2, 3]))
+        }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[1, 2, 3, 4]>, extra <[4]>") {
+            expect(Set([1, 2, 3, 4])).to.equal(Set([1, 2, 3]))
+        }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>") {
+            expect(Set([2, 3, 4])).to.equal(Set([1, 2, 3]))
+        }
+
+        failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3, 4]>, missing <[1]>, extra <[4]>") {
+            expect(Set([2, 3, 4])) == Set([1, 2, 3])
+        }
+
+        failsWithErrorMessage("expected to not equal <[1, 2, 3]>, got <[1, 2, 3]>") {
+            expect(Set([1, 2, 3])) != Set([1, 2, 3])
+        }
+    }
+
+    func testDoesNotMatchNils() {
+        failsWithErrorMessageForNil("expected to not equal <bar>, got <nil>") {
+            expect(nil as String?).to.not.equal("bar")
+        }
+
+        failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
+            expect(nil as [Int]?).to(equal(nil as [Int]?))
+        }
+        failsWithErrorMessageForNil("expected to not equal <[1]>, got <nil>") {
+            expect(nil as [Int]?).toNot(equal([1]))
+        }
+        failsWithErrorMessageForNil("expected to not equal <nil>, got <[1]>") {
+            expect([1]).toNot(equal(nil as [Int]?))
+        }
+
+        failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
+            expect(nil as [Int: Int]?).to(equal(nil as [Int: Int]?))
+        }
+        failsWithErrorMessageForNil("expected to not equal <[1: 1]>, got <nil>") {
+            expect(nil as [Int: Int]?).toNot(equal([1: 1]))
+        }
+        failsWithErrorMessageForNil("expected to not equal <nil>, got <[1: 1]>") {
+            expect([1: 1]).toNot(equal(nil as [Int: Int]?))
+        }
+    }
+
+    func testDictionaryEquality() {
+        expect(["foo": "bar"]).to(equal(["foo": "bar"]))
+        expect(["foo": "bar"]).toNot(equal(["foo": "baz"]))
+
+        let actual = ["foo": "bar"]
+        let expected = ["foo": "bar"]
+        let unexpected = ["foo": "baz"]
+        expect(actual).to(equal(expected))
+        expect(actual).toNot(equal(unexpected))
+
+        expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
+        expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(expected))
+    }
+
+    func testNSObjectEquality() {
+        expect(NSNumber(integer:1)).to(equal(NSNumber(integer:1)))
+        expect(NSNumber(integer:1)) == NSNumber(integer:1)
+        expect(NSNumber(integer:1)) != NSNumber(integer:2)
+        expect { NSNumber(integer:1) }.to(equal(1))
+    }
+
+    func testOperatorEquality() {
+        expect("foo") == "foo"
+        expect("foo") != "bar"
+
+        failsWithErrorMessage("expected to equal <world>, got <hello>") {
+            expect("hello") == "world"
+            return
+        }
+        failsWithErrorMessage("expected to not equal <hello>, got <hello>") {
+            expect("hello") != "hello"
+            return
+        }
+    }
+
+    func testOperatorEqualityWithArrays() {
+        let array1: Array<Int> = [1, 2, 3]
+        let array2: Array<Int> = [1, 2, 3]
+        let array3: Array<Int> = [1, 2]
+        expect(array1) == array2
+        expect(array1) != array3
+    }
+
+    func testOperatorEqualityWithDictionaries() {
+        let dict1 = ["foo": "bar"]
+        let dict2 = ["foo": "bar"]
+        let dict3 = ["foo": "baz"]
+        expect(dict1) == dict2
+        expect(dict1) != dict3
+    }
+
+    func testOptionalEquality() {
+        expect(1 as CInt?).to(equal(1))
+        expect(1 as CInt?).to(equal(1 as CInt?))
+
+        expect(1).toNot(equal(nil))
+    }
+
+    func testDictionariesWithDifferentSequences() {
+        // see: https://github.com/Quick/Nimble/issues/61
+        // these dictionaries generate different orderings of sequences.
+        let result = ["how":1, "think":1, "didnt":2, "because":1,
+            "interesting":1, "always":1, "right":1, "such":1,
+            "to":3, "say":1, "cool":1, "you":1,
+            "weather":3, "be":1, "went":1, "was":2,
+            "sometimes":1, "and":3, "mind":1, "rain":1,
+            "whole":1, "everything":1, "weather.":1, "down":1,
+            "kind":1, "mood.":1, "it":2, "everyday":1, "might":1,
+            "more":1, "have":2, "person":1, "could":1, "tenth":2,
+            "night":1, "write":1, "Youd":1, "affects":1, "of":3,
+            "Who":1, "us":1, "an":1, "I":4, "my":1, "much":2,
+            "wrong.":1, "peacefully.":1, "amazing":3, "would":4,
+            "just":1, "grade.":1, "Its":2, "The":2, "had":1, "that":1,
+            "the":5, "best":1, "but":1, "essay":1, "for":1, "summer":2,
+            "your":1, "grade":1, "vary":1, "pretty":1, "at":1, "rain.":1,
+            "about":1, "allow":1, "thought":1, "in":1, "sleep":1, "a":1,
+            "hot":1, "really":1, "beach":1, "life.":1, "we":1, "although":1]
+
+        let storyCount = ["The":2, "summer":2, "of":3, "tenth":2, "grade":1,
+            "was":2, "the":5, "best":1, "my":1, "life.":1, "I":4,
+            "went":1, "to":3, "beach":1, "everyday":1, "and":3,
+            "we":1, "had":1, "amazing":3, "weather.":1, "weather":3,
+            "didnt":2, "really":1, "vary":1, "much":2, "always":1,
+            "pretty":1, "hot":1, "although":1, "sometimes":1, "at":1,
+            "night":1, "it":2, "would":4, "rain.":1, "mind":1, "rain":1,
+            "because":1, "cool":1, "everything":1, "down":1, "allow":1,
+            "us":1, "sleep":1, "peacefully.":1, "Its":2, "how":1,
+            "affects":1, "your":1, "mood.":1, "Who":1, "have":2,
+            "thought":1, "that":1, "could":1, "write":1, "a":1,
+            "whole":1, "essay":1, "just":1, "about":1, "in":1,
+            "grade.":1, "kind":1, "right":1, "Youd":1, "think":1,
+            "for":1, "such":1, "an":1, "interesting":1, "person":1,
+            "might":1, "more":1, "say":1, "but":1, "you":1, "be":1, "wrong.":1]
+
+        expect(result).to(equal(storyCount))
+    }
+}
+
+class EqualDeprecatedTest: XCTestCase {
+    func testEquality() {
         expect(1 as CInt).to(equal(1 as CInt))
         expect(1 as CInt).to(equal(1))
         expect(1).to(equal(1))

--- a/NimbleTests/Matchers/HaveCountTest.swift
+++ b/NimbleTests/Matchers/HaveCountTest.swift
@@ -3,6 +3,47 @@ import Nimble
 
 class HaveCountTest: XCTestCase {
     func testHaveCountForArray() {
+        expect([1, 2, 3]).to.haveCount(3)
+        expect([1, 2, 3]).not.to.haveCount(1)
+
+        failsWithErrorMessage("expected to have [1, 2, 3] with count 1, got 3") {
+            expect([1, 2, 3]).to.haveCount(1)
+        }
+
+        failsWithErrorMessage("expected to not have [1, 2, 3] with count 3, got 3") {
+            expect([1, 2, 3]).not.to.haveCount(3)
+        }
+    }
+
+    func testHaveCountForDictionary() {
+        expect(["1":1, "2":2, "3":3]).to.haveCount(3)
+        expect(["1":1, "2":2, "3":3]).not.to.haveCount(1)
+
+        failsWithErrorMessage("expected to have [\"2\": 2, \"1\": 1, \"3\": 3] with count 1, got 3") {
+            expect(["1":1, "2":2, "3":3]).to.haveCount(1)
+        }
+
+        failsWithErrorMessage("expected to not have [\"2\": 2, \"1\": 1, \"3\": 3] with count 3, got 3") {
+            expect(["1":1, "2":2, "3":3]).not.to.haveCount(3)
+        }
+    }
+
+    func testHaveCountForSet() {
+        expect(Set([1, 2, 3])).to.haveCount(3)
+        expect(Set([1, 2, 3])).not.to.haveCount(1)
+
+        failsWithErrorMessage("expected to have [2, 3, 1] with count 1, got 3") {
+            expect(Set([1, 2, 3])).to.haveCount(1)
+        }
+
+        failsWithErrorMessage("expected to not have [2, 3, 1] with count 3, got 3") {
+            expect(Set([1, 2, 3])).not.to.haveCount(3)
+        }
+    }
+}
+
+class HaveCountDeprecatedTest: XCTestCase {
+    func testHaveCountForArray() {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))
 

--- a/NimbleTests/Matchers/MatchTest.swift
+++ b/NimbleTests/Matchers/MatchTest.swift
@@ -1,22 +1,56 @@
 import XCTest
 import Nimble
 
-class MatchTest:XCTestCase {
+class MatchTest: XCTestCase {
     func testMatchPositive() {
-        expect("11:14").to(match("\\d{2}:\\d{2}"))
+        expect("11:14").to.match("\\d{2}:\\d{2}")
     }
     
     func testMatchNegative() {
-        expect("hello").toNot(match("\\d{2}:\\d{2}"))
+        expect("hello").to.not.match("\\d{2}:\\d{2}")
     }
     
+    func testMatchPositiveMessage() {
+        let message = "expected to match <\\d{2}:\\d{2}>, got <hello>"
+        failsWithErrorMessage(message) {
+            expect("hello").to.match("\\d{2}:\\d{2}")
+        }
+    }
+    
+    func testMatchNegativeMessage() {
+        let message = "expected to not match <\\d{2}:\\d{2}>, got <11:14>"
+        failsWithErrorMessage(message) {
+            expect("11:14").to.not.match("\\d{2}:\\d{2}")
+        }
+    }
+
+    func testMatchNils() {
+        failsWithErrorMessageForNil("expected to match <\\d{2}:\\d{2}>, got <nil>") {
+            expect(nil as String?).to.match("\\d{2}:\\d{2}")
+        }
+
+        failsWithErrorMessageForNil("expected to not match <\\d{2}:\\d{2}>, got <nil>") {
+            expect(nil as String?).to.not.match("\\d{2}:\\d{2}")
+        }
+    }
+}
+
+class MatchDeprecatedTest: XCTestCase {
+    func testMatchPositive() {
+        expect("11:14").to(match("\\d{2}:\\d{2}"))
+    }
+
+    func testMatchNegative() {
+        expect("hello").toNot(match("\\d{2}:\\d{2}"))
+    }
+
     func testMatchPositiveMessage() {
         let message = "expected to match <\\d{2}:\\d{2}>, got <hello>"
         failsWithErrorMessage(message) {
             expect("hello").to(match("\\d{2}:\\d{2}"))
         }
     }
-    
+
     func testMatchNegativeMessage() {
         let message = "expected to not match <\\d{2}:\\d{2}>, got <11:14>"
         failsWithErrorMessage(message) {


### PR DESCRIPTION
This is based on the discussion in #217.

It ended up requiring a lot of new code, so I figured I'd show some incremental progress (with more bite-sized commits if you want to avoid the monstrous diff). It's a work-in-progress and will be rebased for feedback.

The pull request adds protocol extension support for the built-in matchers:
- [x] `beCloseTo()`
- [x] `beEmpty()`
- [x] `be{Greater,Less}Than{,OrEqualTo}()`
- [x] `beNil()`
- [x] `be{Tru{e,thy},Fals{e,y}}`
- [x] `{begin,end}With()`
- [x] `contain()`
- [x] `equal()`
- [x] `haveCount()`
- [x] `match()`
- [ ] `beAKindOf()`
- [ ] `beAnInstanceOf()`
- [ ] `raisesException()`
- [ ] `throwsError()`

It also adds `.to` and `.not` chaining for tests:

``` swift
expect(foo).to.equal(bar)
expect(bar).not.to.equal(baz)
```

Other to-dos:
- [ ] Update documentation.

Topics of discussion (as they come to me) below.
### Explicit Foundation Typing

I found that certain protocol extensions had ambiguity trouble with explicit Foundation typing to NSArray/NSString/NSSet/NSNumber, which is done throughout the tests. Seeing as Objective-C code automatically bridges these types to their Swift counterparts, do you think it's safe to remove this code? I can't think of an instance where supporting Swift tests against new `NSArray()`, etc., instances would happen in practice.
### `to.not` & `not.to` _vs._ `toNot` & `notTo`

This is a matter of taste, I guess. The former version requires slightly less aliasing.
### Objective-C Version

Previously, the Objective-C version of Nimble had the same syntax (where `to()` is a caller that takes a matcher and a description). This fragments the API. Nothing prevents the Objective-C API from working with the same syntax (see how https://github.com/specta/expecta is implemented), but seems out of scope for this pull.
