### PR TITLE
[WIP] Swift Package Manager and Linux support

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -246,6 +246,9 @@
 		29EA59641B551ED2002D767E /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
 		29EA59661B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
 		29EA59671B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
+		347155CA1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
+		347155CB1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
+		347155CC1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
 		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD1391B9E0A9700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD13A1B9E0A9F00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
@@ -441,6 +444,7 @@
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		29EA59621B551ED2002D767E /* ThrowErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowErrorTest.swift; sourceTree = "<group>"; };
 		29EA59651B551EE6002D767E /* ThrowError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowError.swift; sourceTree = "<group>"; };
+		347155C91C337C8900549F03 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
 		472FD1341B9E085700C7B8DA /* HaveCount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveCount.swift; sourceTree = "<group>"; };
 		472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveCountTest.swift; sourceTree = "<group>"; };
 		4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCHaveCount.m; sourceTree = "<group>"; };
@@ -512,6 +516,7 @@
 			children = (
 				1F14FB63194180C5009F2A08 /* utils.swift */,
 				1F0648CB19639F5A001F9C46 /* ObjectWithLazyProperty.swift */,
+				347155C91C337C8900549F03 /* XCTestCaseProvider.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1072,6 +1077,7 @@
 				1F4A56851A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
 				DD9A9A8F19CF439B00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F0648D41963AAB2001F9C46 /* SynchronousTests.swift in Sources */,
+				347155CA1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */,
 				1F925F08195C18CF00ED456B /* BeGreaterThanTest.swift in Sources */,
 				7B5358BA1C3846C900A23FAA /* SatisfyAnyOfTest.swift in Sources */,
@@ -1163,6 +1169,7 @@
 				1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */,
 				1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */,
 				1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */,
+				347155CC1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
 				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
 				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
@@ -1264,6 +1271,7 @@
 				1F4A56861A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
 				DD9A9A9019CF43AD00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F0648D51963AAB2001F9C46 /* SynchronousTests.swift in Sources */,
+				347155CB1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */,
 				1F925F09195C18CF00ED456B /* BeGreaterThanTest.swift in Sources */,
 				7B5358BB1C3846C900A23FAA /* SatisfyAnyOfTest.swift in Sources */,

--- a/Sources/Nimble/Adapters/NimbleEnvironment.swift
+++ b/Sources/Nimble/Adapters/NimbleEnvironment.swift
@@ -24,6 +24,8 @@ internal class NimbleEnvironment {
         get { return NimbleAssertionHandler }
         set { NimbleAssertionHandler = newValue }
     }
+
+#if _runtime(_ObjC)
     var awaiter: Awaiter
 
     init() {
@@ -32,4 +34,5 @@ internal class NimbleEnvironment {
             asyncQueue: dispatch_get_main_queue(),
             timeoutQueue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0))
     }
+#endif
 }

--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -36,5 +36,10 @@ class NimbleXCTestUnavailableHandler : AssertionHandler {
 }
 
 func isXCTestAvailable() -> Bool {
+#if _runtime(_ObjC)
+    // XCTest is weakly linked and so may not be present
     return NSClassFromString("XCTestCase") != nil
+#else
+    return true
+#endif
 }

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if _runtime(_ObjC)
 private enum ErrorResult {
     case Exception(NSException)
     case Error(ErrorType)
@@ -89,3 +90,4 @@ internal func blockedRunLoopErrorMessageFor(fnName: String, leeway: NSTimeInterv
 public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
+#endif

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -10,7 +10,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
+public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -25,12 +25,12 @@ public func fail(message: String, location: SourceLocation) {
 }
 
 /// Always fails the test with a message.
-public func fail(message: String, file: String = __FILE__, line: UInt = __LINE__) {
+public func fail(message: String, file: FileString = __FILE__, line: UInt = __LINE__) {
     fail(message, location: SourceLocation(file: file, line: line))
 }
 
 /// Always fails the test.
-public func fail(file: String = __FILE__, line: UInt = __LINE__) {
+public func fail(file: FileString = __FILE__, line: UInt = __LINE__) {
     fail("fail() always fails", file: file, line: line)
 }
 

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -38,14 +38,20 @@ public func fail(file: String = __FILE__, line: UInt = __LINE__) {
 internal func nimblePrecondition(
     @autoclosure expr: () -> Bool,
     @autoclosure _ name: () -> String,
-    @autoclosure _ message: () -> String) -> Bool {
+    @autoclosure _ message: () -> String,
+    file: StaticString = __FILE__,
+    line: UInt = __LINE__) -> Bool {
         let result = expr()
         if !result {
+#if _runtime(_ObjC)
             let e = NSException(
                 name: name(),
                 reason: message(),
                 userInfo: nil)
             e.raise()
+#else
+            preconditionFailure("\(name()) - \(message())", file: file, line: line)
+#endif
         }
         return result
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -34,9 +34,9 @@ public class FailureMessage: NSObject {
     }
 
     internal func stripNewlines(str: String) -> String {
-        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as [String]
+        var lines: [String] = NSString(string: str).componentsSeparatedByString("\n") as [String]
         let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
+        lines = lines.map { line in NSString(string: line).stringByTrimmingCharactersInSet(whitespace) }
         return lines.joinWithSeparator("")
     }
 

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -47,6 +47,7 @@ private func createAllPassMatcher<T,U where U: SequenceType, U.Generator.Element
         }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func allPassMatcher(matcher: NMBObjCMatcher) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -88,3 +89,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 // A Nimble matcher that catches attempts to use beAKindOf with non Objective-C types
 public func beAKindOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in
@@ -32,3 +34,5 @@ extension NMBObjCMatcher {
         }
     }
 }
+
+#endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -18,11 +18,11 @@ public func beAKindOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         let instance = try actualExpression.evaluate()
         if let validInstance = instance {
-            failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
+            failureMessage.actualValue = "<\(classAsString(validInstance.dynamicType)) instance>"
         } else {
             failureMessage.actualValue = "<nil>"
         }
-        failureMessage.postfixMessage = "be a kind of \(NSStringFromClass(expectedClass))"
+        failureMessage.postfixMessage = "be a kind of \(classAsString(expectedClass))"
         return instance != nil && instance!.isKindOfClass(expectedClass)
     }
 }

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -29,6 +29,7 @@ public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObjec
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beAnInstanceOfMatcher(expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -36,3 +37,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -16,12 +16,16 @@ public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObjec
     return NonNilMatcherFunc { actualExpression, failureMessage in
         let instance = try actualExpression.evaluate()
         if let validInstance = instance {
-            failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
+            failureMessage.actualValue = "<\(classAsString(validInstance.dynamicType)) instance>"
         } else {
             failureMessage.actualValue = "<nil>"
         }
-        failureMessage.postfixMessage = "be an instance of \(NSStringFromClass(expectedClass))"
+        failureMessage.postfixMessage = "be an instance of \(classAsString(expectedClass))"
+#if _runtime(_ObjC)
         return instance != nil && instance!.isMemberOfClass(expectedClass)
+#else
+        return instance != nil && instance!.dynamicType == expectedClass
+#endif
     }
 }
 

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -35,6 +35,7 @@ public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double 
     }
 }
 
+#if _runtime(_ObjC)
 public class NMBObjCBeCloseToMatcher : NSObject, NMBMatcher {
     var _expected: NSNumber
     var _delta: CDouble
@@ -73,6 +74,7 @@ extension NMBObjCMatcher {
         return NMBObjCBeCloseToMatcher(expected: expected, within: within)
     }
 }
+#endif
 
 public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDelta) -> NonNilMatcherFunc <[Double]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -1,3 +1,6 @@
+#if os(Linux)
+import Glibc
+#endif
 import Foundation
 
 internal let DefaultDelta = 0.0001

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -82,7 +82,7 @@ extension NMBObjCMatcher {
                 return try! beEmpty().matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
                 failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings)"
-                failureMessage.actualValue = "\(NSStringFromClass(actualValue.dynamicType)) type"
+                failureMessage.actualValue = "\(classAsString(actualValue.dynamicType)) type"
             }
             return false
         }

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -68,6 +68,7 @@ public func beEmpty() -> NonNilMatcherFunc<NMBCollection> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beEmptyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -88,3 +89,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -21,7 +21,7 @@ public func beEmpty() -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
         let actualString = try actualExpression.evaluate()
-        return actualString == nil || (actualString! as NSString).length  == 0
+        return actualString == nil || NSString(string: actualString!).length  == 0
     }
 }
 

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -27,6 +27,7 @@ public func >(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beGreaterThan(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beGreaterThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -35,3 +36,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -29,6 +29,7 @@ public func >=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beGreaterThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -37,3 +38,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -19,6 +19,7 @@ public func !==<T: AnyObject>(lhs: Expectation<T>, rhs: T?) {
     lhs.toNot(beIdenticalTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beIdenticalToMatcher(expected: NSObject?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -26,3 +27,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -26,6 +26,7 @@ public func <(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beLessThan(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beLessThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -34,3 +35,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -27,6 +27,7 @@ public func <=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beLessThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil:false) { actualExpression, failureMessage in
@@ -35,3 +36,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -62,6 +62,7 @@ public func beFalsy<T>() -> MatcherFunc<T> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beTruthyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
@@ -91,3 +92,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -9,6 +9,7 @@ public func beNil<T>() -> MatcherFunc<T> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beNilMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
@@ -16,3 +17,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -37,6 +37,7 @@ public func beginWith(startingSubstring: String) -> NonNilMatcherFunc<String> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beginWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -51,3 +52,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -27,8 +27,7 @@ private func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
             return substrings.all {
-                let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
-                let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
+                let range = actual.rangeOfString($0)
                 return range != nil && !range!.isEmpty
             }
         }

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -9,7 +9,7 @@ private func contain<S: SequenceType, T: Equatable where S.Generator.Element == 
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
         if let actual = try actualExpression.evaluate() {
-            return all(items) {
+            return items.all {
                 return actual.contains($0)
             }
         }
@@ -26,7 +26,7 @@ private func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
-            return all(substrings) {
+            return substrings.all {
                 let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
                 let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
                 return range != nil && !range!.isEmpty
@@ -45,7 +45,7 @@ private func contain(substrings: [NSString]) -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
-            return all(substrings) { actual.rangeOfString($0.description).length != 0 }
+            return substrings.all { actual.rangeOfString($0.description).length != 0 }
         }
         return false
     }
@@ -59,9 +59,9 @@ public func contain(items: AnyObject?...) -> NonNilMatcherFunc<NMBContainer> {
 private func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
-        let actual = try actualExpression.evaluate()
-        return all(items) { item in
-            return actual != nil && actual!.containsObject(item)
+        guard let actual = try actualExpression.evaluate() else { return false }
+        return items.all { item in
+            return item != nil && actual.containsObject(item!)
         }
     }
 }

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -65,6 +65,7 @@ private func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func containMatcher(expected: [NSObject]) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -88,3 +89,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/EndWith.swift
+++ b/Sources/Nimble/Matchers/EndWith.swift
@@ -47,6 +47,7 @@ public func endWith(endingSubstring: String) -> NonNilMatcherFunc<String> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func endWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -61,3 +62,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -170,6 +170,7 @@ public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]
     lhs.toNot(equal(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func equalMatcher(expected: NSObject) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -177,3 +178,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -30,6 +30,7 @@ public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func haveCountMatcher(expected: NSNumber) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -46,3 +47,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -40,7 +40,7 @@ extension NMBObjCMatcher {
                 return try! haveCount(expected.integerValue).matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
                 failureMessage.postfixMessage = "get type of NSArray, NSSet, NSDictionary, or NSHashTable"
-                failureMessage.actualValue = "\(NSStringFromClass(actualValue.dynamicType))"
+                failureMessage.actualValue = "\(classAsString(actualValue.dynamicType))"
             }
             return false
         }

--- a/Sources/Nimble/Matchers/Match.swift
+++ b/Sources/Nimble/Matchers/Match.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
 /// described by the expected string.
 public func match(expectedValue: String?) -> NonNilMatcherFunc<String> {
@@ -25,3 +27,4 @@ extension NMBObjCMatcher {
     }
 }
 
+#endif

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -7,11 +7,13 @@ public protocol Matcher {
     func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }
 
+#if _runtime(_ObjC)
 /// Objective-C interface to the Swift variant of Matcher.
 @objc public protocol NMBMatcher {
     func matches(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool
     func doesNotMatch(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool
 }
+#endif
 
 /// Protocol for types that support contain() matcher.
 @objc public protocol NMBContainer {

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -15,33 +15,79 @@ public protocol Matcher {
 }
 #endif
 
+#if _runtime(_ObjC)
 /// Protocol for types that support contain() matcher.
 @objc public protocol NMBContainer {
     func containsObject(object: AnyObject!) -> Bool
 }
+
+extension NSHashTable : NMBContainer {} // Corelibs Foundation does not include this class yet
+#else
+public protocol NMBContainer {
+    func containsObject(object: AnyObject) -> Bool
+}
+#endif
+
 extension NSArray : NMBContainer {}
 extension NSSet : NMBContainer {}
-extension NSHashTable : NMBContainer {}
 
+#if _runtime(_ObjC)
 /// Protocol for types that support only beEmpty(), haveCount() matchers
 @objc public protocol NMBCollection {
     var count: Int { get }
 }
+
+extension NSHashTable : NMBCollection {} // Corelibs Foundation does not include these classes yet
+extension NSMapTable : NMBCollection {}
+#else
+public protocol NMBCollection {
+    var count: Int { get }
+}
+#endif
+
 extension NSSet : NMBCollection {}
 extension NSDictionary : NMBCollection {}
-extension NSHashTable : NMBCollection {}
-extension NSMapTable : NMBCollection {}
 
+#if _runtime(_ObjC)
 /// Protocol for types that support beginWith(), endWith(), beEmpty() matchers
 @objc public protocol NMBOrderedCollection : NMBCollection {
     func indexOfObject(object: AnyObject!) -> Int
 }
+#else
+public protocol NMBOrderedCollection : NMBCollection {
+    func indexOfObject(object: AnyObject) -> Int
+}
+#endif
+
 extension NSArray : NMBOrderedCollection {}
 
+#if _runtime(_ObjC)
 /// Protocol for types to support beCloseTo() matcher
 @objc public protocol NMBDoubleConvertible {
     var doubleValue: CDouble { get }
 }
+#else
+public protocol NMBDoubleConvertible {
+    var doubleValue: CDouble { get }
+}
+
+extension Double : NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return self
+        }
+    }
+}
+
+extension Float : NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return CDouble(self)
+        }
+    }
+}
+#endif
+
 extension NSNumber : NMBDoubleConvertible {
 }
 
@@ -86,9 +132,17 @@ extension NMBDoubleConvertible {
 ///  beGreaterThan(), beGreaterThanOrEqualTo(), and equal() matchers.
 ///
 /// Types that conform to Swift's Comparable protocol will work implicitly too
+#if _runtime(_ObjC)
 @objc public protocol NMBComparable {
     func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult
 }
+#else
+// This should become obsolete once Corelibs Foundation adds Comparable conformance to NSNumber
+public protocol NMBComparable {
+    func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult
+}
+#endif
+
 extension NSNumber : NMBComparable {
     public func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult {
         return compare(otherObject as! NSNumber)

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 /// A Nimble matcher that succeeds when the actual expression raises an
 /// exception with the specified name, reason, and/or userInfo.
 ///
@@ -176,3 +178,4 @@ extension NMBObjCMatcher {
         return NMBObjCRaiseExceptionMatcher(name: nil, reason: nil, userInfo: nil, block: nil)
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -59,7 +59,7 @@ internal func setFailureMessageForException(
         }
 
         if let exception = exception {
-            failureMessage.actualValue = "\(NSStringFromClass(exception.dynamicType)) { name=\(exception.name), reason='\(stringify(exception.reason))', userInfo=\(stringify(exception.userInfo)) }"
+            failureMessage.actualValue = "\(classAsString(exception.dynamicType)) { name=\(exception.name), reason='\(stringify(exception.reason))', userInfo=\(stringify(exception.userInfo)) }"
         } else {
             failureMessage.actualValue = "no exception"
         }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -8,23 +8,20 @@ public func satisfyAnyOf<T,U where U: Matcher, U.ValueType == T>(matchers: U...)
 
 internal func satisfyAnyOf<T,U where U: Matcher, U.ValueType == T>(matchers: [U]) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc<T> { actualExpression, failureMessage in
-        var fullPostfixMessage = "match one of: "
+        let postfixMessages = NSMutableArray()
         var matches = false
-        for var i = 0; i < matchers.count && !matches; ++i {
-            fullPostfixMessage += "{"
-            let matcher = matchers[i]
-            matches = try matcher.matches(actualExpression, failureMessage: failureMessage)
-            fullPostfixMessage += "\(failureMessage.postfixMessage)}"
-            if i < (matchers.count - 1) {
-                fullPostfixMessage += ", or "
+        for matcher in matchers {
+            if try matcher.matches(actualExpression, failureMessage: failureMessage) {
+                matches = true
             }
+            postfixMessages.addObject(NSString(string: "{\(failureMessage.postfixMessage)}"))
         }
-        
-        failureMessage.postfixMessage = fullPostfixMessage
+
+        failureMessage.postfixMessage = "match one of: " + postfixMessages.componentsJoinedByString(", or ")
         if let actualValue = try actualExpression.evaluate() {
             failureMessage.actualValue = "\(actualValue)"
         }
-        
+
         return matches
     }
 }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -38,6 +38,7 @@ public func ||<T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> NonNilMatcherF
     return satisfyAnyOf(left, right)
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func satisfyAnyOfMatcher(matchers: [NMBObjCMatcher]) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -61,3 +62,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/ObjCExpectation.swift
+++ b/Sources/Nimble/ObjCExpectation.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 internal struct ObjCMatcherWrapper : Matcher {
     let matcher: NMBMatcher
 
@@ -125,3 +127,5 @@ public class NMBExpectation : NSObject {
         fail(message, location: SourceLocation(file: file, line: line))
     }
 }
+
+#endif

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -44,7 +44,7 @@ private let pollLeeway: UInt64 = NSEC_PER_MSEC
 /// Stores debugging information about callers
 internal struct WaitingInfo: CustomStringConvertible {
     let name: String
-    let file: String
+    let file: FileString
     let lineNumber: UInt
 
     var description: String {
@@ -53,7 +53,7 @@ internal struct WaitingInfo: CustomStringConvertible {
 }
 
 internal protocol WaitLock {
-    func acquireWaitingLock(fnName: String, file: String, line: UInt)
+    func acquireWaitingLock(fnName: String, file: FileString, line: UInt)
     func releaseWaitingLock()
     func isWaitingLocked() -> Bool
 }
@@ -62,7 +62,7 @@ internal class AssertionWaitLock: WaitLock {
     private var currentWaiter: WaitingInfo? = nil
     init() { }
 
-    func acquireWaitingLock(fnName: String, file: String, line: UInt) {
+    func acquireWaitingLock(fnName: String, file: FileString, line: UInt) {
         let info = WaitingInfo(name: fnName, file: file, lineNumber: line)
         nimblePrecondition(
             NSThread.isMainThread(),
@@ -222,7 +222,7 @@ internal class AwaitPromiseBuilder<T> {
     /// - The async expectation raised an unexpected error (swift)
     ///
     /// The returned AwaitResult will NEVER be .Incomplete.
-    func wait(fnName: String = __FUNCTION__, file: String = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
+    func wait(fnName: String = __FUNCTION__, file: FileString = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
         waitLock.acquireWaitingLock(
             fnName,
             file: file,
@@ -340,7 +340,7 @@ internal class Awaiter {
 internal func pollBlock(
     pollInterval pollInterval: NSTimeInterval,
     timeoutInterval: NSTimeInterval,
-    file: String,
+    file: FileString,
     line: UInt,
     fnName: String = __FUNCTION__,
     expression: () throws -> Bool) -> AwaitResult<Bool> {

--- a/Sources/Nimble/Utils/ExceptionCapture.swift
+++ b/Sources/Nimble/Utils/ExceptionCapture.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+#if !_runtime(_ObjC)
+// swift-corelibs-foundation doesn't provide NSException at all, so provide a dummy
+class NSException {}
+#endif
+
+// NOTE: This file is not intended to be included in the Xcode project. It
+//       is picked up by the Swift Package Manager during its build process.
+
+/// A dummy reimplementation of the `NMBExceptionCapture` class to serve
+/// as a stand-in for build and runtime environments that don't support
+/// Objective C.
+internal class ExceptionCapture {
+    let finally: (() -> Void)?
+
+    init(handler: ((NSException!) -> Void)?, finally: (() -> Void)?) {
+        self.finally = finally
+    }
+
+    func tryBlock(unsafeBlock: (() -> Void)) {
+        // We have no way of handling Objective C exceptions in Swift,
+        // so we just go ahead and run the unsafeBlock as-is
+        unsafeBlock()
+
+        finally?()
+    }
+}
+
+/// Compatibility with the actual Objective-C implementation
+typealias NMBExceptionCapture = ExceptionCapture

--- a/Sources/Nimble/Utils/Functional.swift
+++ b/Sources/Nimble/Utils/Functional.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+extension SequenceType {
+    internal func all(fn: Generator.Element -> Bool) -> Bool {
+        for item in self {
+            if !fn(item) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
 internal func all<T>(array: [T], fn: (T) -> Bool) -> Bool {
     for item in array {
         if !fn(item) {

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+#if _runtime(_ObjC)
+public typealias FileString = String
+#else
+public typealias FileString = StaticString
+#endif
 
 public class SourceLocation : NSObject {
-    public let file: String
+    public let file: FileString
     public let line: UInt
 
     override init() {
@@ -10,7 +15,7 @@ public class SourceLocation : NSObject {
         line = 0
     }
 
-    init(file: String, line: UInt) {
+    init(file: FileString, line: UInt) {
         self.file = file
         self.line = line
     }

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -2,10 +2,11 @@ import Foundation
 
 
 internal func identityAsString(value: AnyObject?) -> String {
-    if value == nil {
+    if let value = value {
+        return NSString(format: "<%p>", unsafeBitCast(value, Int.self)).description
+    } else {
         return "nil"
     }
-    return NSString(format: "<%p>", unsafeBitCast(value!, Int.self)).description
 }
 
 internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -9,6 +9,14 @@ internal func identityAsString(value: AnyObject?) -> String {
     }
 }
 
+internal func classAsString(cls: AnyClass) -> String {
+#if _runtime(_ObjC)
+    return NSStringFromClass(cls)
+#else
+    return String(cls)
+#endif
+}
+
 internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {
     return items.reduce("") { accum, item in
         let prefix = (accum.isEmpty ? "" : joiner)

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -24,9 +24,18 @@ internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {
     }
 }
 
+#if _runtime(_ObjC)
 @objc internal protocol NMBStringer {
     func NMB_stringify() -> String
 }
+
+extension NSArray : NMBStringer {
+    func NMB_stringify() -> String {
+        let str = self.componentsJoinedByString(", ")
+        return "[\(str)]"
+    }
+}
+#endif
 
 internal func stringify<S: SequenceType>(value: S) -> String {
     var generator = value.generate()
@@ -40,13 +49,6 @@ internal func stringify<S: SequenceType>(value: S) -> String {
     } while value != nil
     let str = strings.joinWithSeparator(", ")
     return "[\(str)]"
-}
-
-extension NSArray : NMBStringer {
-    func NMB_stringify() -> String {
-        let str = self.componentsJoinedByString(", ")
-        return "[\(str)]"
-    }
 }
 
 internal func stringify<T>(value: T) -> String {

--- a/Sources/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Sources/Nimble/Wrappers/ObjCMatcher.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 public typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
 public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
 
@@ -76,3 +78,4 @@ public class NMBObjCMatcher : NSObject, NMBMatcher {
     }
 }
 
+#endif

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -2,6 +2,8 @@ import Foundation
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class AsyncTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -161,3 +163,4 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
         expect(executedAsyncBlock).toEventually(beTruthy())
     }
 }
+#endif

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -1,7 +1,23 @@
 import XCTest
 import Nimble
 
-class AsyncTest: XCTestCase {
+class AsyncTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
+            ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
+            ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
+            ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
+            ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
+            ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
+            ("testWaitUntilDetectsStalledMainThreadActivity", testWaitUntilDetectsStalledMainThreadActivity),
+            ("testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed", testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed),
+            ("testWaitUntilErrorsIfDoneIsCalledMultipleTimes", testWaitUntilErrorsIfDoneIsCalledMultipleTimes),
+            ("testWaitUntilMustBeInMainThread", testWaitUntilMustBeInMainThread),
+            ("testToEventuallyMustBeInMainThread", testToEventuallyMustBeInMainThread),
+        ]
+    }
+    
     let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
 
     private func doThrowError() throws -> Int {

--- a/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+
+// XCTestCaseProvider is defined in swift-corelibs-xctest, but is not available
+// in the XCTest that ships with Xcode. By defining this protocol on Apple platforms,
+// we ensure that the tests fail in Xcode if they haven't been configured properly to
+// be run with the open-source tools.
+
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+
+public protocol XCTestCaseProvider {
+    var allTests : [(String, () -> Void)] { get }
+}
+
+extension XCTestCase {
+    override public func tearDown() {
+        if let provider = self as? XCTestCaseProvider {
+            provider.assertContainsTest(invocation!.selector.description)
+        }
+
+        super.tearDown()
+    }
+}
+
+extension XCTestCaseProvider {
+    private func assertContainsTest(name: String) {
+        let contains = self.allTests.contains({ test in
+            return test.0 == name
+        })
+
+        XCTAssert(contains, "Test '\(name)' is missing from the allTests array")
+    }
+}
+
+#endif

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 import Nimble
 import XCTest
 
-func failsWithErrorMessage(messages: [String], file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -41,7 +41,7 @@ func failsWithErrorMessage(messages: [String], file: String = __FILE__, line: UI
     }
 }
 
-func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -51,7 +51,7 @@ func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt 
     )
 }
 
-func failsWithErrorMessageForNil(message: String, file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessageForNil(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -65,16 +65,16 @@ func deferToMainQueue(action: () -> Void) {
 #endif
 
 public class NimbleHelper : NSObject {
-    class func expectFailureMessage(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessage(message: NSString, block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessage(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    class func expectFailureMessages(messages: [NSString], block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(messages as! [String], file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessages(messages: [NSString], block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessage(messages.map({ String($0) }), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    class func expectFailureMessageForNil(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessageForNil(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessageForNil(message: NSString, block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessageForNil(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }
 

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -55,12 +55,14 @@ func failsWithErrorMessageForNil(message: String, file: String = __FILE__, line:
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
+#if _runtime(_ObjC)
 func deferToMainQueue(action: () -> Void) {
     dispatch_async(dispatch_get_main_queue()) {
         NSThread.sleepForTimeInterval(0.01)
         action()
     }
 }
+#endif
 
 public class NimbleHelper : NSObject {
     class func expectFailureMessage(message: NSString, block: () -> Void, file: String, line: UInt) {

--- a/Sources/NimbleTests/Matchers/AllPassTest.swift
+++ b/Sources/NimbleTests/Matchers/AllPassTest.swift
@@ -1,7 +1,18 @@
 import XCTest
 import Nimble
 
-class AllPassTest: XCTestCase {
+class AllPassTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testAllPassArray", testAllPassArray),
+            ("testAllPassMatcher", testAllPassMatcher),
+            ("testAllPassCollectionsWithOptionalsDontWork", testAllPassCollectionsWithOptionalsDontWork),
+            ("testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer", testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer),
+            ("testAllPassSet", testAllPassSet),
+            ("testAllPassWithNilAsExpectedValue", testAllPassWithNilAsExpectedValue),
+        ]
+    }
+
     func testAllPassArray() {
         expect([1,2,3,4]).to(allPass({$0 < 5}))
         expect([1,2,3,4]).toNot(allPass({$0 > 5}))

--- a/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class TestNull : NSNull {}
 
 class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
@@ -51,3 +53,4 @@ class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -3,7 +3,15 @@ import Nimble
 
 class TestNull : NSNull {}
 
-class BeAKindOfTest: XCTestCase {
+class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatch", testPositiveMatch),
+            ("testFailureMessages", testFailureMessages),
+            ("testSwiftTypesFailureMessages", testSwiftTypesFailureMessages),
+        ]
+    }
+
     func testPositiveMatch() {
         expect(TestNull()).to(beAKindOf(NSNull))
         expect(NSObject()).to(beAKindOf(NSObject))

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -1,7 +1,15 @@
 import XCTest
 import Nimble
 
-class BeAnInstanceOfTest: XCTestCase {
+class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatch", testPositiveMatch),
+            ("testFailureMessages", testFailureMessages),
+            ("testSwiftTypesFailureMessages", testSwiftTypesFailureMessages),
+        ]
+    }
+
     func testPositiveMatch() {
         expect(NSNull()).to(beAnInstanceOf(NSNull))
         expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSDate))

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -23,10 +23,15 @@ class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessageForNil("expected to be an instance of NSString, got <nil>") {
             expect(nil as NSString?).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected to be an instance of NSString, got <__NSCFNumber instance>") {
+#if _runtime(_ObjC)
+        let numberTypeName = "__NSCFNumber"
+#else
+        let numberTypeName = "NSNumber"
+#endif
+        failsWithErrorMessage("expected to be an instance of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(integer:1)).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected to not be an instance of NSNumber, got <__NSCFNumber instance>") {
+        failsWithErrorMessage("expected to not be an instance of NSNumber, got <\(numberTypeName) instance>") {
             expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSNumber))
         }
     }

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -1,7 +1,20 @@
 import XCTest
 import Nimble
 
-class BeCloseToTest: XCTestCase {
+class BeCloseToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeCloseTo", testBeCloseTo),
+            ("testBeCloseToWithin", testBeCloseToWithin),
+            ("testBeCloseToWithNSNumber", testBeCloseToWithNSNumber),
+            ("testBeCloseToWithNSDate", testBeCloseToWithNSDate),
+            ("testBeCloseToOperator", testBeCloseToOperator),
+            ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
+            ("testPlusMinusOperator", testPlusMinusOperator),
+            ("testBeCloseToArray", testBeCloseToArray),
+        ]
+    }
+
     func testBeCloseTo() {
         expect(1.2).to(beCloseTo(1.2001))
         expect(1.2 as CDouble).to(beCloseTo(1.2001))

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeEmptyTest: XCTestCase {
+class BeEmptyTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeEmptyPositive", testBeEmptyPositive),
+            ("testBeEmptyNegative", testBeEmptyNegative),
+        ]
+    }
+
     func testBeEmptyPositive() {
         expect([] as [Int]).to(beEmpty())
         expect([1]).toNot(beEmpty())

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -17,17 +17,21 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         expect([] as [CInt]).to(beEmpty())
         expect([1] as [CInt]).toNot(beEmpty())
 
+#if _runtime(_ObjC)
         expect(NSDictionary() as? [Int:Int]).to(beEmpty())
         expect(NSDictionary(object: 1, forKey: 1) as? [Int:Int]).toNot(beEmpty())
+#endif
 
         expect(Dictionary<Int, Int>()).to(beEmpty())
         expect(["hi": 1]).toNot(beEmpty())
 
+#if _runtime(_ObjC)
         expect(NSArray() as? [Int]).to(beEmpty())
-        expect(NSArray(array: [1]) as? [Int]).toNot(beEmpty())
+        expect(NSArray(array: [NSNumber(integer: 1)]) as? [Int]).toNot(beEmpty())
+#endif
 
         expect(NSSet()).to(beEmpty())
-        expect(NSSet(array: [1])).toNot(beEmpty())
+        expect(NSSet(array: [NSNumber(integer: 1)])).toNot(beEmpty())
 
         expect(NSString()).to(beEmpty())
         expect(NSString(string: "hello")).toNot(beEmpty())
@@ -45,7 +49,7 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         }
 
         failsWithErrorMessage("expected to not be empty, got <()>") {
-            expect([]).toNot(beEmpty())
+            expect(NSArray()).toNot(beEmpty())
         }
         failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -16,7 +16,9 @@ class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
         expect(1).toNot(beGreaterThanOrEqualTo(2))
         expect(NSNumber(int:1)).toNot(beGreaterThanOrEqualTo(2))
         expect(NSNumber(int:2)).to(beGreaterThanOrEqualTo(NSNumber(int:2)))
+#if _runtime(_ObjC)
         expect(1).to(beGreaterThanOrEqualTo(NSNumber(int:0)))
+#endif
 
         failsWithErrorMessage("expected to be greater than or equal to <2>, got <0>") {
             expect(0).to(beGreaterThanOrEqualTo(2))

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeGreaterThanOrEqualToTest: XCTestCase {
+class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testGreaterThanOrEqualTo", testGreaterThanOrEqualTo),
+            ("testGreaterThanOrEqualToOperator", testGreaterThanOrEqualToOperator),
+        ]
+    }
 
     func testGreaterThanOrEqualTo() {
         expect(10).to(beGreaterThanOrEqualTo(10))

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeGreaterThanTest: XCTestCase {
+class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testGreaterThan", testGreaterThan),
+            ("testGreaterThanOperator", testGreaterThanOperator),
+        ]
+    }
+    
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -13,7 +13,9 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))
+#if _runtime(_ObjC)
         expect(NSNumber(int:3)).to(beGreaterThan(2))
+#endif
         expect(NSNumber(int:1)).toNot(beGreaterThan(NSNumber(int:2)))
 
         failsWithErrorMessage("expected to be greater than <2>, got <0>") {
@@ -33,7 +35,9 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThanOperator() {
         expect(1) > 0
         expect(NSNumber(int:1)) > NSNumber(int:0)
+#if _runtime(_ObjC)
         expect(NSNumber(int:1)) > 0
+#endif
 
         failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
             expect(1) > 2

--- a/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 
@@ -26,30 +27,30 @@ class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeIdenticalToPositiveMessage() {
-        let message = String(format: "expected to be identical to <%p>, got <%p>",
-            unsafeBitCast(testObjectB, Int.self), unsafeBitCast(testObjectA, Int.self))
+        let message = String(NSString(format: "expected to be identical to <%p>, got <%p>",
+            unsafeBitCast(testObjectB, Int.self), unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).to(beIdenticalTo(self.testObjectB))
         }
     }
     
     func testBeIdenticalToNegativeMessage() {
-        let message = String(format: "expected to not be identical to <%p>, got <%p>",
-            unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectA, Int.self))
+        let message = String(NSString(format: "expected to not be identical to <%p>, got <%p>",
+            unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).toNot(beIdenticalTo(self.testObjectA))
         }
     }
 
     func testFailsOnNils() {
-        let message1 = String(format: "expected to be identical to <%p>, got nil",
-            unsafeBitCast(testObjectA, Int.self))
+        let message1 = String(NSString(format: "expected to be identical to <%p>, got nil",
+            unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessageForNil(message1) {
             expect(nil as BeIdenticalToObjectTester?).to(beIdenticalTo(self.testObjectA))
         }
 
-        let message2 = String(format: "expected to not be identical to <%p>, got nil",
-            unsafeBitCast(testObjectA, Int.self))
+        let message2 = String(NSString(format: "expected to not be identical to <%p>, got nil",
+            unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessageForNil(message2) {
             expect(nil as BeIdenticalToObjectTester?).toNot(beIdenticalTo(self.testObjectA))
         }

--- a/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -1,7 +1,18 @@
 import XCTest
 import Nimble
 
-class BeIdenticalToObjectTest: XCTestCase {
+class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+            ("testFailsOnNils", testFailsOnNils),
+            ("testOperators", testOperators),
+        ]
+    }
+
     private class BeIdenticalToObjectTester {}
     private let testObjectA = BeIdenticalToObjectTester()
     private let testObjectB = BeIdenticalToObjectTester()

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -19,8 +19,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testBeIdenticalToNegative() {
-        expect(NSNumber(integer:1)).toNot(beIdenticalTo("yo"))
-        expect([1]).toNot(beIdenticalTo([1]))
+        expect(NSNumber(integer:1)).toNot(beIdenticalTo(NSString(string: "yo")))
+        expect(NSArray(array: [NSNumber(integer: 1)])).toNot(beIdenticalTo(NSArray(array: [NSNumber(integer: 1)])))
     }
 
     func testBeIdenticalToPositiveMessage() {

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import Nimble
+@testable import Nimble
 
 class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
@@ -26,8 +26,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     func testBeIdenticalToPositiveMessage() {
         let num1 = NSNumber(integer:1)
         let num2 = NSNumber(integer:2)
-        let message = NSString(format: "expected to be identical to <%p>, got <%p>", num2, num1)
-        failsWithErrorMessage(message.description) {
+        let message = "expected to be identical to \(identityAsString(num2)), got \(identityAsString(num1))"
+        failsWithErrorMessage(message) {
             expect(num1).to(beIdenticalTo(num2))
         }
     }
@@ -35,8 +35,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     func testBeIdenticalToNegativeMessage() {
         let value1 = NSArray(array: [])
         let value2 = NSArray(array: [])
-        let message = NSString(format: "expected to not be identical to <%p>, got <%p>", value2, value1)
-        failsWithErrorMessage(message.description) {
+        let message = "expected to not be identical to \(identityAsString(value2)), got \(identityAsString(value1))"
+        failsWithErrorMessage(message) {
             expect(value1).toNot(beIdenticalTo(value2))
         }
     }

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class BeIdenticalToTest: XCTestCase {
+class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+            ("testOperators", testOperators),
+        ]
+    }
+
     func testBeIdenticalToPositive() {
         let value = NSDate()
         expect(value).to(beIdenticalTo(value))

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -3,7 +3,8 @@ import Nimble
 
 class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToPositive() {
-        expect(NSNumber(integer:1)).to(beIdenticalTo(NSNumber(integer:1)))
+        let value = NSDate()
+        expect(value).to(beIdenticalTo(value))
     }
 
     func testBeIdenticalToNegative() {
@@ -30,7 +31,8 @@ class BeIdenticalToTest: XCTestCase {
     }
     
     func testOperators() {
-        expect(NSNumber(integer:1)) === NSNumber(integer:1)
+        let value = NSDate()
+        expect(value) === value
         expect(NSNumber(integer:1)) !== NSNumber(integer:2)
     }
 }

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -17,8 +17,10 @@ class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
 
         expect(NSNumber(int:2)).to(beLessThanOrEqualTo(10))
         expect(NSNumber(int:2)).toNot(beLessThanOrEqualTo(1))
+#if _runtime(_ObjC)
         expect(2).to(beLessThanOrEqualTo(NSNumber(int:10)))
         expect(2).toNot(beLessThanOrEqualTo(NSNumber(int:1)))
+#endif
 
         failsWithErrorMessage("expected to be less than or equal to <0>, got <2>") {
             expect(2).to(beLessThanOrEqualTo(0))

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeLessThanOrEqualToTest: XCTestCase {
+class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testLessThanOrEqualTo", testLessThanOrEqualTo),
+            ("testLessThanOrEqualToOperator", testLessThanOrEqualToOperator),
+        ]
+    }
+
     func testLessThanOrEqualTo() {
         expect(10).to(beLessThanOrEqualTo(10))
         expect(2).to(beLessThanOrEqualTo(10))

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeLessThanTest: XCTestCase {
+class BeLessThanTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testLessThan", testLessThan),
+            ("testLessThanOperator", testLessThanOperator),
+        ]
+    }
 
     func testLessThan() {
         expect(2).to(beLessThan(10))

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -13,11 +13,13 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
     func testLessThan() {
         expect(2).to(beLessThan(10))
         expect(2).toNot(beLessThan(1))
+#if _runtime(_ObjC)
         expect(NSNumber(integer:2)).to(beLessThan(10))
         expect(NSNumber(integer:2)).toNot(beLessThan(1))
 
         expect(2).to(beLessThan(NSNumber(integer:10)))
         expect(2).toNot(beLessThan(NSNumber(integer:1)))
+#endif
 
         failsWithErrorMessage("expected to be less than <0>, got <2>") {
             expect(2).to(beLessThan(0))
@@ -36,7 +38,9 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
 
     func testLessThanOperator() {
         expect(0) < 1
+#if _runtime(_ObjC)
         expect(NSNumber(int:0)) < 1
+#endif
 
         failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
             expect(2) < 1

--- a/Sources/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLogicalTest.swift
@@ -19,7 +19,19 @@ enum ConvertsToBool : BooleanType, CustomStringConvertible {
     }
 }
 
-class BeTruthyTest : XCTestCase {
+class BeTruthyTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchNonNilTypes", testShouldMatchNonNilTypes),
+            ("testShouldMatchTrue", testShouldMatchTrue),
+            ("testShouldNotMatchNilTypes", testShouldNotMatchNilTypes),
+            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+            ("testShouldMatchBoolConvertibleTypesThatConvertToTrue", testShouldMatchBoolConvertibleTypesThatConvertToTrue),
+            ("testShouldNotMatchBoolConvertibleTypesThatConvertToFalse", testShouldNotMatchBoolConvertibleTypesThatConvertToFalse),
+        ]
+    }
+
     func testShouldMatchNonNilTypes() {
         expect(true as Bool?).to(beTruthy())
         expect(1 as Int?).to(beTruthy())
@@ -72,7 +84,15 @@ class BeTruthyTest : XCTestCase {
     }
 }
 
-class BeTrueTest : XCTestCase {
+class BeTrueTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchTrue", testShouldMatchTrue),
+            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ]
+    }
+
     func testShouldMatchTrue() {
         expect(true).to(beTrue())
 
@@ -100,7 +120,17 @@ class BeTrueTest : XCTestCase {
     }
 }
 
-class BeFalsyTest : XCTestCase {
+class BeFalsyTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchNilTypes", testShouldMatchNilTypes),
+            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+            ("testShouldNotMatchNonNilTypes", testShouldNotMatchNonNilTypes),
+            ("testShouldMatchFalse", testShouldMatchFalse),
+            ("testShouldMatchNilBools", testShouldMatchNilBools),
+        ]
+    }
+
     func testShouldMatchNilTypes() {
         expect(false as Bool?).to(beFalsy())
         expect(nil as Bool?).to(beFalsy())
@@ -137,7 +167,15 @@ class BeFalsyTest : XCTestCase {
     }
 }
 
-class BeFalseTest : XCTestCase {
+class BeFalseTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+            ("testShouldMatchFalse", testShouldMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ]
+    }
+
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalse())
 

--- a/Sources/NimbleTests/Matchers/BeNilTest.swift
+++ b/Sources/NimbleTests/Matchers/BeNilTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeNilTest: XCTestCase {
+class BeNilTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeNil", testBeNil),
+        ]
+    }
+
     func producesNil() -> Array<Int>? {
         return nil
     }

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -20,16 +20,18 @@ class BeginWithTest: XCTestCase, XCTestCaseProvider {
         expect(NSString(string: "foobar").description).to(beginWith("foo"))
         expect(NSString(string: "foobar").description).toNot(beginWith("oo"))
 
+#if _runtime(_ObjC)
         expect(NSArray(array: ["a", "b"])).to(beginWith("a"))
         expect(NSArray(array: ["a", "b"])).toNot(beginWith("b"))
+#endif
     }
 
     func testNegativeMatches() {
         failsWithErrorMessageForNil("expected to begin with <b>, got <nil>") {
-            expect(nil as NSArray?).to(beginWith("b"))
+            expect(nil as NSArray?).to(beginWith(NSString(string: "b")))
         }
         failsWithErrorMessageForNil("expected to not begin with <b>, got <nil>") {
-            expect(nil as NSArray?).toNot(beginWith("b"))
+            expect(nil as NSArray?).toNot(beginWith(NSString(string: "b")))
         }
 
         failsWithErrorMessage("expected to begin with <2>, got <[1, 2, 3]>") {

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeginWithTest: XCTestCase {
+class BeginWithTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testNegativeMatches", testNegativeMatches),
+        ]
+    }
 
     func testPositiveMatches() {
         expect([1, 2, 3]).to(beginWith(1))

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -1,7 +1,16 @@
 import XCTest
 import Nimble
 
-class ContainTest: XCTestCase {
+class ContainTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testContain", testContain),
+            ("testContainSubstring", testContainSubstring),
+            ("testContainObjCSubstring", testContainObjCSubstring),
+            ("testVariadicArguments", testVariadicArguments),
+        ]
+    }
+
     func testContain() {
         expect([1, 2, 3]).to(contain(1))
         expect([1, 2, 3] as [CInt]).to(contain(1 as CInt))

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -19,9 +19,9 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
         expect(["foo", "bar", "baz"]).to(contain("baz"))
         expect([1, 2, 3]).toNot(contain(4))
         expect(["foo", "bar", "baz"]).toNot(contain("ba"))
-        expect(NSArray(array: ["a"])).to(contain("a"))
-        expect(NSArray(array: ["a"])).toNot(contain("b"))
-        expect(NSArray(object: 1) as NSArray?).to(contain(1))
+        expect(NSArray(array: [NSString(string: "a")])).to(contain(NSString(string: "a")))
+        expect(NSArray(array: [NSString(string: "a")])).toNot(contain(NSString(string:"b")))
+        expect(NSArray(object: NSNumber(integer: 1)) as NSArray?).to(contain(NSNumber(integer: 1)))
 
         failsWithErrorMessage("expected to contain <bar>, got <[\"a\", \"b\", \"c\"]>") {
             expect(["a", "b", "c"]).to(contain("bar"))

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -20,8 +20,10 @@ class EndWithTest: XCTestCase, XCTestCaseProvider {
         expect(NSString(string: "foobar").description).to(endWith("bar"))
         expect(NSString(string: "foobar").description).toNot(endWith("oo"))
 
+#if _runtime(_ObjC)
         expect(NSArray(array: ["a", "b"])).to(endWith("b"))
         expect(NSArray(array: ["a", "b"])).toNot(endWith("a"))
+#endif
     }
 
     func testEndWithNegatives() {

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class EndWithTest: XCTestCase {
+class EndWithTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testEndWithPositives", testEndWithPositives),
+            ("testEndWithNegatives", testEndWithNegatives),
+        ]
+    }
 
     func testEndWithPositives() {
         expect([1, 2, 3]).to(endWith(3))

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -1,7 +1,24 @@
 import XCTest
 import Nimble
 
-class EqualTest: XCTestCase {
+class EqualTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testEquality", testEquality),
+            ("testArrayEquality", testArrayEquality),
+            ("testSetEquality", testSetEquality),
+            ("testDoesNotMatchNils", testDoesNotMatchNils),
+            ("testDictionaryEquality", testDictionaryEquality),
+            ("testNSObjectEquality", testNSObjectEquality),
+            ("testOperatorEquality", testOperatorEquality),
+            ("testOperatorEqualityWithArrays", testOperatorEqualityWithArrays),
+            ("testOperatorEqualityWithDictionaries", testOperatorEqualityWithDictionaries),
+            ("testOptionalEquality", testOptionalEquality),
+            ("testArrayOfOptionalsEquality", testArrayOfOptionalsEquality),
+            ("testDictionariesWithDifferentSequences", testDictionariesWithDifferentSequences),
+        ]
+    }
+
     func testEquality() {
         expect(1 as CInt).to(equal(1 as CInt))
         expect(1 as CInt).to(equal(1))

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -50,7 +50,7 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(array1).to(equal([1, 2, 3]))
         expect(array1).toNot(equal([1, 2] as Array<Int>))
 
-        expect(NSArray(array: [1, 2, 3])).to(equal(NSArray(array: [1, 2, 3])))
+        expect(NSArray(array: [NSNumber(integer: 1), NSNumber(integer: 2), NSNumber(integer: 3)])).to(equal(NSArray(array: [NSNumber(integer: 1), NSNumber(integer: 2), NSNumber(integer: 3)])))
 
         failsWithErrorMessage("expected to equal <[1, 2]>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).to(equal([1, 2]))
@@ -130,8 +130,10 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(actual).to(equal(expected))
         expect(actual).toNot(equal(unexpected))
 
+#if _runtime(_ObjC)
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(expected))
+#endif
     }
 
     func testNSObjectEquality() {

--- a/Sources/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Sources/NimbleTests/Matchers/HaveCountTest.swift
@@ -1,7 +1,15 @@
 import XCTest
 import Nimble
 
-class HaveCountTest: XCTestCase {
+class HaveCountTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testHaveCountForArray", testHaveCountForArray),
+            ("testHaveCountForDictionary", testHaveCountForDictionary),
+            ("testHaveCountForSet", testHaveCountForSet),
+        ]
+    }
+
     func testHaveCountForArray() {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))

--- a/Sources/NimbleTests/Matchers/MatchTest.swift
+++ b/Sources/NimbleTests/Matchers/MatchTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class MatchTest:XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -44,3 +46,4 @@ class MatchTest:XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/Matchers/MatchTest.swift
+++ b/Sources/NimbleTests/Matchers/MatchTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class MatchTest:XCTestCase {
+class MatchTest:XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testMatchPositive", testMatchPositive),
+            ("testMatchNegative", testMatchNegative),
+            ("testMatchPositiveMessage", testMatchPositiveMessage),
+            ("testMatchNegativeMessage", testMatchNegativeMessage),
+            ("testMatchNils", testMatchNils),
+        ]
+    }
+
     func testMatchPositive() {
         expect("11:14").to(match("\\d{2}:\\d{2}"))
     }

--- a/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class RaisesExceptionTest: XCTestCase {
+class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
+            ("testNegativeMatches", testNegativeMatches),
+            ("testNegativeMatchesDoNotCallClosureWithoutException", testNegativeMatchesDoNotCallClosureWithoutException),
+            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+        ]
+    }
+
     var anException = NSException(name: "laugh", reason: "Lulz", userInfo: ["key": "value"])
 
     func testPositiveMatches() {

--- a/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -161,3 +163,4 @@ class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -11,7 +11,9 @@ class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
 
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
+#if _runtime(_ObjC)
         expect(2).toNot(satisfyAnyOf(equal(3), equal("turtles")))
+#endif
         expect([1,2,3]).to(satisfyAnyOf(equal([1,2,3]), allPass({$0 < 4}), haveCount(3)))
         expect("turtle").toNot(satisfyAnyOf(contain("a"), endWith("magic")))
         expect(82.0).toNot(satisfyAnyOf(beLessThan(10.5), beGreaterThan(100.75), beCloseTo(50.1)))
@@ -38,7 +40,9 @@ class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
     
     func testOperatorOr() {
         expect(2).to(equal(2) || equal(3))
+#if _runtime(_ObjC)
         expect(2).toNot(equal(3) || equal("turtles"))
+#endif
         expect("turtle").toNot(contain("a") || endWith("magic"))
         expect(82.0).toNot(beLessThan(10.5) || beGreaterThan(100.75))
         expect(false).to(beTrue() || beFalse())

--- a/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class SatisfyAnyOfTest: XCTestCase {
+class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testSatisfyAnyOf", testSatisfyAnyOf),
+            ("testOperatorOr", testOperatorOr),
+        ]
+    }
+
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
         expect(2).toNot(satisfyAnyOf(equal(3), equal("turtles")))

--- a/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -31,7 +31,19 @@ extension CustomDebugStringConvertibleError : CustomDebugStringConvertible {
     }
 }
 
-class ThrowErrorTest: XCTestCase {
+class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
+            ("testNegativeMatches", testNegativeMatches),
+            ("testPositiveNegatedMatches", testPositiveNegatedMatches),
+            ("testNegativeNegatedMatches", testNegativeNegatedMatches),
+            ("testNegativeMatchesDoNotCallClosureWithoutError", testNegativeMatchesDoNotCallClosureWithoutError),
+            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+        ]
+    }
+
     func testPositiveMatches() {
         expect { throw Error.Laugh }.to(throwError())
         expect { throw Error.Laugh }.to(throwError(Error.Laugh))

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -36,12 +36,14 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testUnexpectedErrorsThrownFails() {
+#if _runtime(_ObjC) // This test triggers a weird segfault on Linux currently
         failsWithErrorMessage("expected to equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.to(equal(1))
         }
         failsWithErrorMessage("expected to not equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.toNot(equal(1))
         }
+#endif
     }
 
     func testToMatchesIfMatcherReturnsTrue() {

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class SynchronousTest: XCTestCase {
-    let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
+    let errorToThrow = NSError(domain: NSCocoaErrorDomain, code: 42, userInfo: nil)
     private func doThrowError() throws -> Int {
         throw errorToThrow
     }

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -38,7 +38,7 @@ class SynchronousTest: XCTestCase {
 
     func testToProvidesAMemoizedActualValueExpression() {
         var callCount = 0
-        expect{ callCount++ }.to(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.to(MatcherFunc { expr, failure in
             try expr.evaluate()
             try expr.evaluate()
             return true
@@ -48,7 +48,7 @@ class SynchronousTest: XCTestCase {
 
     func testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl() {
         var callCount = 0
-        expect{ callCount++ }.to(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.to(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
             try expr.evaluate()
             return true
@@ -77,7 +77,7 @@ class SynchronousTest: XCTestCase {
 
     func testToNotProvidesAMemoizedActualValueExpression() {
         var callCount = 0
-        expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.toNot(MatcherFunc { expr, failure in
             try expr.evaluate()
             try expr.evaluate()
             return false
@@ -87,7 +87,7 @@ class SynchronousTest: XCTestCase {
 
     func testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl() {
         var callCount = 0
-        expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.toNot(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
             try expr.evaluate()
             return false

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -1,7 +1,25 @@
 import XCTest
 import Nimble
 
-class SynchronousTest: XCTestCase {
+class SynchronousTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testFailAlwaysFails", testFailAlwaysFails),
+            ("testUnexpectedErrorsThrownFails", testUnexpectedErrorsThrownFails),
+            ("testToMatchesIfMatcherReturnsTrue", testToMatchesIfMatcherReturnsTrue),
+            ("testToProvidesActualValueExpression", testToProvidesActualValueExpression),
+            ("testToProvidesAMemoizedActualValueExpression", testToProvidesActualValueExpression),
+            ("testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+            ("testToMatchAgainstLazyProperties", testToMatchAgainstLazyProperties),
+            ("testToNotMatchesIfMatcherReturnsTrue", testToNotMatchesIfMatcherReturnsTrue),
+            ("testToNotProvidesActualValueExpression", testToNotProvidesActualValueExpression),
+            ("testToNotProvidesAMemoizedActualValueExpression", testToNotProvidesAMemoizedActualValueExpression),
+            ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+            ("testToNotNegativeMatches", testToNotNegativeMatches),
+            ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
+        ]
+    }
+
     let errorToThrow = NSError(domain: NSCocoaErrorDomain, code: 42, userInfo: nil)
     private func doThrowError() throws -> Int {
         throw errorToThrow

--- a/Sources/NimbleTests/UserDescriptionTest.swift
+++ b/Sources/NimbleTests/UserDescriptionTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class UserDescriptionTest: XCTestCase {
+class UserDescriptionTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testToMatcher_CustomFailureMessage", testToMatcher_CustomFailureMessage),
+            ("testNotToMatcher_CustomFailureMessage", testNotToMatcher_CustomFailureMessage),
+            ("testToNotMatcher_CustomFailureMessage", testToNotMatcher_CustomFailureMessage),
+            ("testToEventuallyMatch_CustomFailureMessage", testToEventuallyMatch_CustomFailureMessage),
+            ("testToEventuallyNotMatch_CustomFailureMessage", testToEventuallyNotMatch_CustomFailureMessage),
+            ("testToNotEventuallyMatch_CustomFailureMessage", testToNotEventuallyMatch_CustomFailureMessage),
+        ]
+    }
     
     func testToMatcher_CustomFailureMessage() {
         failsWithErrorMessage(

--- a/Sources/NimbleTests/main.swift
+++ b/Sources/NimbleTests/main.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+// This is the entry point for NimbleTests on Linux
+
+XCTMain([
+    // AsynchronousTests(),
+    SynchronousTest(),
+    UserDescriptionTest(),
+
+    // Matchers
+    AllPassTest(),
+    // BeAKindOfTest(),
+    BeAnInstanceOfTest(),
+    BeCloseToTest(),
+    BeginWithTest(),
+    BeGreaterThanOrEqualToTest(),
+    BeGreaterThanTest(),
+    BeIdenticalToObjectTest(),
+    BeIdenticalToTest(),
+    BeLessThanOrEqualToTest(),
+    BeLessThanTest(),
+    BeTruthyTest(),
+    BeTrueTest(),
+    BeFalsyTest(),
+    BeFalseTest(),
+    BeNilTest(),
+    ContainTest(),
+    EndWithTest(),
+    EqualTest(),
+    HaveCountTest(),
+    // MatchTest(),
+    // RaisesExceptionTest(),
+    ThrowErrorTest(),
+    SatisfyAnyOfTest(),
+])


### PR DESCRIPTION
(See also https://github.com/Quick/Quick/pull/436 and https://github.com/Quick/Quick/pull/444)

This beast of a PR contains a first attempt at getting Nimble working on Linux using the [swift.org](https://swift.org) toolchain. At this point I would consider it effectively a proof of concept and not mergeable until the tools have a bit more time to bake and some of the workarounds can be removed.

I took pains to make focused commits for easier review, but to summarize, the work consists of three main components:

- [x] Support being built by the Swift Package Manager. This involved adding a `Package.swift` and adjusting the directory structure a little (note that this doesn't work on Mac right now because it's not possible to `import XCTest` when being compiled  by the SPM)
- [x] Remove/conditionalize classes and concepts that only work or make sense in an Objective-C context (e.g. the ObjC matchers, and the `raiseException` matcher)
- [x] Add fixes/workarounds for a variety of compiler and framework issues that (currently?) prevent 100% source compatibility. These include:

  - [x] Missing `NSString(format:, ...)`
  - [ ] Missing `NSHashTable` and `NSMapTable`
  - [ ] Can't use `@objc` anywhere because the types provided by SwiftFoundation aren't considered ObjC. This ends up requiring a bunch of annoying duplication in `MatcherProtocols.swift`
  - [x] SwiftFoundation's `NSNumber` doesn't have `compare` yet (Fixed!)
  - [x] SwiftFoundation's `NSString` doesn't have the overlays that make `rangeOfString` work with `Range<Index>`
  - [ ] Can't coerce from `String` to `NSString` using the `as` operator ([SR-309](https://bugs.swift.org/browse/SR-309))
  - [ ] SwiftXCTest's `XCTAssert` methods expect the `file:` parameter to be a `StaticString` instead of `String` ([SR-308](https://bugs.swift.org/browse/SR-308))
  - [x] Linking fails when declaring `NSObject` subclasses ([SR-272](https://bugs.swift.org/browse/SR-272))
  - [x] `NSString.stringByTrimmingCharactersInSet` is horribly broken in the current toolchain snapshot (https://github.com/apple/swift-corelibs-foundation/pull/160) (Fixed!)

Some pieces that are missing altogether but can hopefully be reintroduced are:

- [ ] The `beAKindOf` matcher, because there is no replacement for `NSObject.isKindOfClass` in Swift right now
- [ ] Everything related to async/polling/waiting, at least until `swift-corelibs-libdispatch` starts to be usable on Linux

At the tip of this branch, all the tests are passing on Mac through Xcode, and Nimble can be used as a dependency in SPM-based packages on Linux. There is no attempt at creating a test suite for Nimble on Linux yet.

Feedback please :smile: @jeffh @modocache 