### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -27,8 +27,7 @@ private func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
             return substrings.all {
-                let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
-                let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
+                let range = actual.rangeOfString($0)
                 return range != nil && !range!.isEmpty
             }
         }

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -9,7 +9,7 @@ private func contain<S: SequenceType, T: Equatable where S.Generator.Element == 
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
         if let actual = try actualExpression.evaluate() {
-            return all(items) {
+            return items.all {
                 return actual.contains($0)
             }
         }
@@ -26,7 +26,7 @@ private func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
-            return all(substrings) {
+            return substrings.all {
                 let scanRange = Range(start: actual.startIndex, end: actual.endIndex)
                 let range = actual.rangeOfString($0, options: [], range: scanRange, locale: nil)
                 return range != nil && !range!.isEmpty
@@ -45,7 +45,7 @@ private func contain(substrings: [NSString]) -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
-            return all(substrings) { actual.rangeOfString($0.description).length != 0 }
+            return substrings.all { actual.rangeOfString($0.description).length != 0 }
         }
         return false
     }
@@ -59,9 +59,9 @@ public func contain(items: AnyObject?...) -> NonNilMatcherFunc<NMBContainer> {
 private func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
-        let actual = try actualExpression.evaluate()
-        return all(items) { item in
-            return actual != nil && actual!.containsObject(item)
+        guard let actual = try actualExpression.evaluate() else { return false }
+        return items.all { item in
+            return item != nil && actual.containsObject(item!)
         }
     }
 }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -8,23 +8,20 @@ public func satisfyAnyOf<T,U where U: Matcher, U.ValueType == T>(matchers: U...)
 
 internal func satisfyAnyOf<T,U where U: Matcher, U.ValueType == T>(matchers: [U]) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc<T> { actualExpression, failureMessage in
-        var fullPostfixMessage = "match one of: "
+        let postfixMessages = NSMutableArray()
         var matches = false
-        for var i = 0; i < matchers.count && !matches; ++i {
-            fullPostfixMessage += "{"
-            let matcher = matchers[i]
-            matches = try matcher.matches(actualExpression, failureMessage: failureMessage)
-            fullPostfixMessage += "\(failureMessage.postfixMessage)}"
-            if i < (matchers.count - 1) {
-                fullPostfixMessage += ", or "
+        for matcher in matchers {
+            if try matcher.matches(actualExpression, failureMessage: failureMessage) {
+                matches = true
             }
+            postfixMessages.addObject(NSString(string: "{\(failureMessage.postfixMessage)}"))
         }
-        
-        failureMessage.postfixMessage = fullPostfixMessage
+
+        failureMessage.postfixMessage = "match one of: " + postfixMessages.componentsJoinedByString(", or ")
         if let actualValue = try actualExpression.evaluate() {
             failureMessage.actualValue = "\(actualValue)"
         }
-        
+
         return matches
     }
 }

--- a/Sources/Nimble/Utils/Functional.swift
+++ b/Sources/Nimble/Utils/Functional.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-internal func all<T>(array: [T], fn: (T) -> Bool) -> Bool {
-    for item in array {
-        if !fn(item) {
-            return false
+extension SequenceType {
+    internal func all(fn: Generator.Element -> Bool) -> Bool {
+        for item in self {
+            if !fn(item) {
+                return false
+            }
         }
+        return true
     }
-    return true
 }
-

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -2,10 +2,11 @@ import Foundation
 
 
 internal func identityAsString(value: AnyObject?) -> String {
-    if value == nil {
+    if let value = value {
+        return NSString(format: "<%p>", unsafeBitCast(value, Int.self)).description
+    } else {
         return "nil"
     }
-    return NSString(format: "<%p>", unsafeBitCast(value!, Int.self)).description
 }
 
 internal func classAsString(cls: AnyClass) -> String {

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -14,7 +14,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testBeIdenticalToPositive() {
-        expect(NSNumber(integer:1)).to(beIdenticalTo(NSNumber(integer:1)))
+        let value = NSDate()
+        expect(value).to(beIdenticalTo(value))
     }
 
     func testBeIdenticalToNegative() {
@@ -41,7 +42,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testOperators() {
-        expect(NSNumber(integer:1)) === NSNumber(integer:1)
+        let value = NSDate()
+        expect(value) === value
         expect(NSNumber(integer:1)) !== NSNumber(integer:2)
     }
 }

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -21,7 +21,7 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-    let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
+    let errorToThrow = NSError(domain: NSCocoaErrorDomain, code: 42, userInfo: nil)
     private func doThrowError() throws -> Int {
         throw errorToThrow
     }

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -57,7 +57,7 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
 
     func testToProvidesAMemoizedActualValueExpression() {
         var callCount = 0
-        expect{ callCount++ }.to(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.to(MatcherFunc { expr, failure in
             try expr.evaluate()
             try expr.evaluate()
             return true
@@ -67,7 +67,7 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
 
     func testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl() {
         var callCount = 0
-        expect{ callCount++ }.to(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.to(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
             try expr.evaluate()
             return true
@@ -96,7 +96,7 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
 
     func testToNotProvidesAMemoizedActualValueExpression() {
         var callCount = 0
-        expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.toNot(MatcherFunc { expr, failure in
             try expr.evaluate()
             try expr.evaluate()
             return false
@@ -106,7 +106,7 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
 
     func testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl() {
         var callCount = 0
-        expect{ callCount++ }.toNot(MatcherFunc { expr, failure in
+        expect{ callCount += 1 }.toNot(MatcherFunc { expr, failure in
             expect(callCount).to(equal(0))
             try expr.evaluate()
             return false


### PR DESCRIPTION
Here are a handful of minor improvements that are a part of #226 but aren't actually Linux-specific in any way. This includes removing usages of `++` and C-style `for` loops because these are deprecated in Swift 2.2.

See the individual commit messages for details.