### PR TITLE
Additions for Swift Package Manager and Corelibs XCTest

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -246,6 +246,9 @@
 		29EA59641B551ED2002D767E /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
 		29EA59661B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
 		29EA59671B551EE6002D767E /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
+		347155CA1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
+		347155CB1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
+		347155CC1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347155C91C337C8900549F03 /* XCTestCaseProvider.swift */; };
 		472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD1391B9E0A9700C7B8DA /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		472FD13A1B9E0A9F00C7B8DA /* HaveCountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */; };
@@ -441,6 +444,7 @@
 		1FFD729B1963FCAB00CD29A2 /* NimbleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NimbleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		29EA59621B551ED2002D767E /* ThrowErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowErrorTest.swift; sourceTree = "<group>"; };
 		29EA59651B551EE6002D767E /* ThrowError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowError.swift; sourceTree = "<group>"; };
+		347155C91C337C8900549F03 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
 		472FD1341B9E085700C7B8DA /* HaveCount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveCount.swift; sourceTree = "<group>"; };
 		472FD1361B9E094B00C7B8DA /* HaveCountTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveCountTest.swift; sourceTree = "<group>"; };
 		4793854C1BA0BB2500296F85 /* ObjCHaveCount.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCHaveCount.m; sourceTree = "<group>"; };
@@ -512,6 +516,7 @@
 			children = (
 				1F14FB63194180C5009F2A08 /* utils.swift */,
 				1F0648CB19639F5A001F9C46 /* ObjectWithLazyProperty.swift */,
+				347155C91C337C8900549F03 /* XCTestCaseProvider.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1072,6 +1077,7 @@
 				1F4A56851A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
 				DD9A9A8F19CF439B00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F0648D41963AAB2001F9C46 /* SynchronousTests.swift in Sources */,
+				347155CA1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				4793854D1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */,
 				1F925F08195C18CF00ED456B /* BeGreaterThanTest.swift in Sources */,
 				7B5358BA1C3846C900A23FAA /* SatisfyAnyOfTest.swift in Sources */,
@@ -1163,6 +1169,7 @@
 				1F5DF1931BDCA10200C3A531 /* SynchronousTests.swift in Sources */,
 				1F5DF19D1BDCA10200C3A531 /* BeGreaterThanOrEqualToTest.swift in Sources */,
 				1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */,
+				347155CC1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
 				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
 				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
@@ -1264,6 +1271,7 @@
 				1F4A56861A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
 				DD9A9A9019CF43AD00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F0648D51963AAB2001F9C46 /* SynchronousTests.swift in Sources */,
+				347155CB1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				4793854E1BA0BB2500296F85 /* ObjCHaveCount.m in Sources */,
 				1F925F09195C18CF00ED456B /* BeGreaterThanTest.swift in Sources */,
 				7B5358BB1C3846C900A23FAA /* SatisfyAnyOfTest.swift in Sources */,

--- a/Sources/Nimble/Utils/ExceptionCapture.swift
+++ b/Sources/Nimble/Utils/ExceptionCapture.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+#if !_runtime(_ObjC)
+// swift-corelibs-foundation doesn't provide NSException at all, so provide a dummy
+class NSException {}
+#endif
+
+// NOTE: This file is not intended to be included in the Xcode project. It
+//       is picked up by the Swift Package Manager during its build process.
+
+/// A dummy reimplementation of the `NMBExceptionCapture` class to serve
+/// as a stand-in for build and runtime environments that don't support
+/// Objective C.
+internal class ExceptionCapture {
+    let finally: (() -> Void)?
+
+    init(handler: ((NSException!) -> Void)?, finally: (() -> Void)?) {
+        self.finally = finally
+    }
+
+    func tryBlock(unsafeBlock: (() -> Void)) {
+        // We have no way of handling Objective C exceptions in Swift,
+        // so we just go ahead and run the unsafeBlock as-is
+        unsafeBlock()
+
+        finally?()
+    }
+}
+
+/// Compatibility with the actual Objective-C implementation
+typealias NMBExceptionCapture = ExceptionCapture

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -1,7 +1,23 @@
 import XCTest
 import Nimble
 
-class AsyncTest: XCTestCase {
+class AsyncTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
+            ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
+            ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
+            ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
+            ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
+            ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
+            ("testWaitUntilDetectsStalledMainThreadActivity", testWaitUntilDetectsStalledMainThreadActivity),
+            ("testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed", testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed),
+            ("testWaitUntilErrorsIfDoneIsCalledMultipleTimes", testWaitUntilErrorsIfDoneIsCalledMultipleTimes),
+            ("testWaitUntilMustBeInMainThread", testWaitUntilMustBeInMainThread),
+            ("testToEventuallyMustBeInMainThread", testToEventuallyMustBeInMainThread),
+        ]
+    }
+    
     let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
 
     private func doThrowError() throws -> Int {

--- a/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+
+// XCTestCaseProvider is defined in swift-corelibs-xctest, but is not available
+// in the XCTest that ships with Xcode. By defining this protocol on Apple platforms,
+// we ensure that the tests fail in Xcode if they haven't been configured properly to
+// be run with the open-source tools.
+
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+
+public protocol XCTestCaseProvider {
+    var allTests : [(String, () -> Void)] { get }
+}
+
+extension XCTestCase {
+    override public func tearDown() {
+        if let provider = self as? XCTestCaseProvider {
+            provider.assertContainsTest(invocation!.selector.description)
+        }
+
+        super.tearDown()
+    }
+}
+
+extension XCTestCaseProvider {
+    private func assertContainsTest(name: String) {
+        let contains = self.allTests.contains({ test in
+            return test.0 == name
+        })
+
+        XCTAssert(contains, "Test '\(name)' is missing from the allTests array")
+    }
+}
+
+#endif

--- a/Sources/NimbleTests/Matchers/AllPassTest.swift
+++ b/Sources/NimbleTests/Matchers/AllPassTest.swift
@@ -1,7 +1,18 @@
 import XCTest
 import Nimble
 
-class AllPassTest: XCTestCase {
+class AllPassTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testAllPassArray", testAllPassArray),
+            ("testAllPassMatcher", testAllPassMatcher),
+            ("testAllPassCollectionsWithOptionalsDontWork", testAllPassCollectionsWithOptionalsDontWork),
+            ("testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer", testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer),
+            ("testAllPassSet", testAllPassSet),
+            ("testAllPassWithNilAsExpectedValue", testAllPassWithNilAsExpectedValue),
+        ]
+    }
+
     func testAllPassArray() {
         expect([1,2,3,4]).to(allPass({$0 < 5}))
         expect([1,2,3,4]).toNot(allPass({$0 > 5}))

--- a/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -3,7 +3,15 @@ import Nimble
 
 class TestNull : NSNull {}
 
-class BeAKindOfTest: XCTestCase {
+class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatch", testPositiveMatch),
+            ("testFailureMessages", testFailureMessages),
+            ("testSwiftTypesFailureMessages", testSwiftTypesFailureMessages),
+        ]
+    }
+
     func testPositiveMatch() {
         expect(TestNull()).to(beAKindOf(NSNull))
         expect(NSObject()).to(beAKindOf(NSObject))

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -1,7 +1,15 @@
 import XCTest
 import Nimble
 
-class BeAnInstanceOfTest: XCTestCase {
+class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatch", testPositiveMatch),
+            ("testFailureMessages", testFailureMessages),
+            ("testSwiftTypesFailureMessages", testSwiftTypesFailureMessages),
+        ]
+    }
+
     func testPositiveMatch() {
         expect(NSNull()).to(beAnInstanceOf(NSNull))
         expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSDate))

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -1,7 +1,20 @@
 import XCTest
 import Nimble
 
-class BeCloseToTest: XCTestCase {
+class BeCloseToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeCloseTo", testBeCloseTo),
+            ("testBeCloseToWithin", testBeCloseToWithin),
+            ("testBeCloseToWithNSNumber", testBeCloseToWithNSNumber),
+            ("testBeCloseToWithNSDate", testBeCloseToWithNSDate),
+            ("testBeCloseToOperator", testBeCloseToOperator),
+            ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
+            ("testPlusMinusOperator", testPlusMinusOperator),
+            ("testBeCloseToArray", testBeCloseToArray),
+        ]
+    }
+
     func testBeCloseTo() {
         expect(1.2).to(beCloseTo(1.2001))
         expect(1.2 as CDouble).to(beCloseTo(1.2001))

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeEmptyTest: XCTestCase {
+class BeEmptyTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeEmptyPositive", testBeEmptyPositive),
+            ("testBeEmptyNegative", testBeEmptyNegative),
+        ]
+    }
+
     func testBeEmptyPositive() {
         expect([] as [Int]).to(beEmpty())
         expect([1]).toNot(beEmpty())

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeGreaterThanOrEqualToTest: XCTestCase {
+class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testGreaterThanOrEqualTo", testGreaterThanOrEqualTo),
+            ("testGreaterThanOrEqualToOperator", testGreaterThanOrEqualToOperator),
+        ]
+    }
 
     func testGreaterThanOrEqualTo() {
         expect(10).to(beGreaterThanOrEqualTo(10))

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeGreaterThanTest: XCTestCase {
+class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testGreaterThan", testGreaterThan),
+            ("testGreaterThanOperator", testGreaterThanOperator),
+        ]
+    }
+    
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))

--- a/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -1,7 +1,18 @@
 import XCTest
 import Nimble
 
-class BeIdenticalToObjectTest: XCTestCase {
+class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+            ("testFailsOnNils", testFailsOnNils),
+            ("testOperators", testOperators),
+        ]
+    }
+
     private class BeIdenticalToObjectTester {}
     private let testObjectA = BeIdenticalToObjectTester()
     private let testObjectB = BeIdenticalToObjectTester()

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class BeIdenticalToTest: XCTestCase {
+class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+            ("testOperators", testOperators),
+        ]
+    }
+
     func testBeIdenticalToPositive() {
         expect(NSNumber(integer:1)).to(beIdenticalTo(NSNumber(integer:1)))
     }

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class BeLessThanOrEqualToTest: XCTestCase {
+class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testLessThanOrEqualTo", testLessThanOrEqualTo),
+            ("testLessThanOrEqualToOperator", testLessThanOrEqualToOperator),
+        ]
+    }
+
     func testLessThanOrEqualTo() {
         expect(10).to(beLessThanOrEqualTo(10))
         expect(2).to(beLessThanOrEqualTo(10))

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeLessThanTest: XCTestCase {
+class BeLessThanTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testLessThan", testLessThan),
+            ("testLessThanOperator", testLessThanOperator),
+        ]
+    }
 
     func testLessThan() {
         expect(2).to(beLessThan(10))

--- a/Sources/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLogicalTest.swift
@@ -19,7 +19,19 @@ enum ConvertsToBool : BooleanType, CustomStringConvertible {
     }
 }
 
-class BeTruthyTest : XCTestCase {
+class BeTruthyTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchNonNilTypes", testShouldMatchNonNilTypes),
+            ("testShouldMatchTrue", testShouldMatchTrue),
+            ("testShouldNotMatchNilTypes", testShouldNotMatchNilTypes),
+            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+            ("testShouldMatchBoolConvertibleTypesThatConvertToTrue", testShouldMatchBoolConvertibleTypesThatConvertToTrue),
+            ("testShouldNotMatchBoolConvertibleTypesThatConvertToFalse", testShouldNotMatchBoolConvertibleTypesThatConvertToFalse),
+        ]
+    }
+
     func testShouldMatchNonNilTypes() {
         expect(true as Bool?).to(beTruthy())
         expect(1 as Int?).to(beTruthy())
@@ -72,7 +84,15 @@ class BeTruthyTest : XCTestCase {
     }
 }
 
-class BeTrueTest : XCTestCase {
+class BeTrueTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchTrue", testShouldMatchTrue),
+            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ]
+    }
+
     func testShouldMatchTrue() {
         expect(true).to(beTrue())
 
@@ -100,7 +120,17 @@ class BeTrueTest : XCTestCase {
     }
 }
 
-class BeFalsyTest : XCTestCase {
+class BeFalsyTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldMatchNilTypes", testShouldMatchNilTypes),
+            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+            ("testShouldNotMatchNonNilTypes", testShouldNotMatchNonNilTypes),
+            ("testShouldMatchFalse", testShouldMatchFalse),
+            ("testShouldMatchNilBools", testShouldMatchNilBools),
+        ]
+    }
+
     func testShouldMatchNilTypes() {
         expect(false as Bool?).to(beFalsy())
         expect(nil as Bool?).to(beFalsy())
@@ -137,7 +167,15 @@ class BeFalsyTest : XCTestCase {
     }
 }
 
-class BeFalseTest : XCTestCase {
+class BeFalseTest : XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+            ("testShouldMatchFalse", testShouldMatchFalse),
+            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ]
+    }
+
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalse())
 

--- a/Sources/NimbleTests/Matchers/BeNilTest.swift
+++ b/Sources/NimbleTests/Matchers/BeNilTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeNilTest: XCTestCase {
+class BeNilTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testBeNil", testBeNil),
+        ]
+    }
+
     func producesNil() -> Array<Int>? {
         return nil
     }

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class BeginWithTest: XCTestCase {
+class BeginWithTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testNegativeMatches", testNegativeMatches),
+        ]
+    }
 
     func testPositiveMatches() {
         expect([1, 2, 3]).to(beginWith(1))

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -1,7 +1,16 @@
 import XCTest
 import Nimble
 
-class ContainTest: XCTestCase {
+class ContainTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testContain", testContain),
+            ("testContainSubstring", testContainSubstring),
+            ("testContainObjCSubstring", testContainObjCSubstring),
+            ("testVariadicArguments", testVariadicArguments),
+        ]
+    }
+
     func testContain() {
         expect([1, 2, 3]).to(contain(1))
         expect([1, 2, 3] as [CInt]).to(contain(1 as CInt))

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -1,7 +1,13 @@
 import XCTest
 import Nimble
 
-class EndWithTest: XCTestCase {
+class EndWithTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testEndWithPositives", testEndWithPositives),
+            ("testEndWithNegatives", testEndWithNegatives),
+        ]
+    }
 
     func testEndWithPositives() {
         expect([1, 2, 3]).to(endWith(3))

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -1,7 +1,24 @@
 import XCTest
 import Nimble
 
-class EqualTest: XCTestCase {
+class EqualTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testEquality", testEquality),
+            ("testArrayEquality", testArrayEquality),
+            ("testSetEquality", testSetEquality),
+            ("testDoesNotMatchNils", testDoesNotMatchNils),
+            ("testDictionaryEquality", testDictionaryEquality),
+            ("testNSObjectEquality", testNSObjectEquality),
+            ("testOperatorEquality", testOperatorEquality),
+            ("testOperatorEqualityWithArrays", testOperatorEqualityWithArrays),
+            ("testOperatorEqualityWithDictionaries", testOperatorEqualityWithDictionaries),
+            ("testOptionalEquality", testOptionalEquality),
+            ("testArrayOfOptionalsEquality", testArrayOfOptionalsEquality),
+            ("testDictionariesWithDifferentSequences", testDictionariesWithDifferentSequences),
+        ]
+    }
+
     func testEquality() {
         expect(1 as CInt).to(equal(1 as CInt))
         expect(1 as CInt).to(equal(1))

--- a/Sources/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Sources/NimbleTests/Matchers/HaveCountTest.swift
@@ -1,7 +1,15 @@
 import XCTest
 import Nimble
 
-class HaveCountTest: XCTestCase {
+class HaveCountTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testHaveCountForArray", testHaveCountForArray),
+            ("testHaveCountForDictionary", testHaveCountForDictionary),
+            ("testHaveCountForSet", testHaveCountForSet),
+        ]
+    }
+
     func testHaveCountForArray() {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))

--- a/Sources/NimbleTests/Matchers/MatchTest.swift
+++ b/Sources/NimbleTests/Matchers/MatchTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class MatchTest:XCTestCase {
+class MatchTest:XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testMatchPositive", testMatchPositive),
+            ("testMatchNegative", testMatchNegative),
+            ("testMatchPositiveMessage", testMatchPositiveMessage),
+            ("testMatchNegativeMessage", testMatchNegativeMessage),
+            ("testMatchNils", testMatchNils),
+        ]
+    }
+
     func testMatchPositive() {
         expect("11:14").to(match("\\d{2}:\\d{2}"))
     }

--- a/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class RaisesExceptionTest: XCTestCase {
+class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
+            ("testNegativeMatches", testNegativeMatches),
+            ("testNegativeMatchesDoNotCallClosureWithoutException", testNegativeMatchesDoNotCallClosureWithoutException),
+            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+        ]
+    }
+
     var anException = NSException(name: "laugh", reason: "Lulz", userInfo: ["key": "value"])
 
     func testPositiveMatches() {

--- a/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -1,7 +1,14 @@
 import XCTest
 import Nimble
 
-class SatisfyAnyOfTest: XCTestCase {
+class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testSatisfyAnyOf", testSatisfyAnyOf),
+            ("testOperatorOr", testOperatorOr),
+        ]
+    }
+
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
         expect(2).toNot(satisfyAnyOf(equal(3), equal("turtles")))

--- a/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -31,7 +31,19 @@ extension CustomDebugStringConvertibleError : CustomDebugStringConvertible {
     }
 }
 
-class ThrowErrorTest: XCTestCase {
+class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testPositiveMatches", testPositiveMatches),
+            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
+            ("testNegativeMatches", testNegativeMatches),
+            ("testPositiveNegatedMatches", testPositiveNegatedMatches),
+            ("testNegativeNegatedMatches", testNegativeNegatedMatches),
+            ("testNegativeMatchesDoNotCallClosureWithoutError", testNegativeMatchesDoNotCallClosureWithoutError),
+            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+        ]
+    }
+
     func testPositiveMatches() {
         expect { throw Error.Laugh }.to(throwError())
         expect { throw Error.Laugh }.to(throwError(Error.Laugh))

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -1,7 +1,25 @@
 import XCTest
 import Nimble
 
-class SynchronousTest: XCTestCase {
+class SynchronousTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testFailAlwaysFails", testFailAlwaysFails),
+            ("testUnexpectedErrorsThrownFails", testUnexpectedErrorsThrownFails),
+            ("testToMatchesIfMatcherReturnsTrue", testToMatchesIfMatcherReturnsTrue),
+            ("testToProvidesActualValueExpression", testToProvidesActualValueExpression),
+            ("testToProvidesAMemoizedActualValueExpression", testToProvidesActualValueExpression),
+            ("testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+            ("testToMatchAgainstLazyProperties", testToMatchAgainstLazyProperties),
+            ("testToNotMatchesIfMatcherReturnsTrue", testToNotMatchesIfMatcherReturnsTrue),
+            ("testToNotProvidesActualValueExpression", testToNotProvidesActualValueExpression),
+            ("testToNotProvidesAMemoizedActualValueExpression", testToNotProvidesAMemoizedActualValueExpression),
+            ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+            ("testToNotNegativeMatches", testToNotNegativeMatches),
+            ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
+        ]
+    }
+
     let errorToThrow = NSError(domain: NSInternalInconsistencyException, code: 42, userInfo: nil)
     private func doThrowError() throws -> Int {
         throw errorToThrow

--- a/Sources/NimbleTests/UserDescriptionTest.swift
+++ b/Sources/NimbleTests/UserDescriptionTest.swift
@@ -1,7 +1,17 @@
 import XCTest
 import Nimble
 
-class UserDescriptionTest: XCTestCase {
+class UserDescriptionTest: XCTestCase, XCTestCaseProvider {
+    var allTests: [(String, () -> Void)] {
+        return [
+            ("testToMatcher_CustomFailureMessage", testToMatcher_CustomFailureMessage),
+            ("testNotToMatcher_CustomFailureMessage", testNotToMatcher_CustomFailureMessage),
+            ("testToNotMatcher_CustomFailureMessage", testToNotMatcher_CustomFailureMessage),
+            ("testToEventuallyMatch_CustomFailureMessage", testToEventuallyMatch_CustomFailureMessage),
+            ("testToEventuallyNotMatch_CustomFailureMessage", testToEventuallyNotMatch_CustomFailureMessage),
+            ("testToNotEventuallyMatch_CustomFailureMessage", testToNotEventuallyMatch_CustomFailureMessage),
+        ]
+    }
     
     func testToMatcher_CustomFailureMessage() {
         failsWithErrorMessage(

--- a/Sources/NimbleTests/main.swift
+++ b/Sources/NimbleTests/main.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+// This is the entry point for NimbleTests on Linux
+
+XCTMain([
+    // AsynchronousTests(),
+    SynchronousTest(),
+    UserDescriptionTest(),
+
+    // Matchers
+    AllPassTest(),
+    // BeAKindOfTest(),
+    BeAnInstanceOfTest(),
+    BeCloseToTest(),
+    BeginWithTest(),
+    BeGreaterThanOrEqualToTest(),
+    BeGreaterThanTest(),
+    BeIdenticalToObjectTest(),
+    BeIdenticalToTest(),
+    BeLessThanOrEqualToTest(),
+    BeLessThanTest(),
+    BeTruthyTest(),
+    BeTrueTest(),
+    BeFalsyTest(),
+    BeFalseTest(),
+    BeNilTest(),
+    ContainTest(),
+    EndWithTest(),
+    EqualTest(),
+    HaveCountTest(),
+    // MatchTest(),
+    // RaisesExceptionTest(),
+    ThrowErrorTest(),
+    SatisfyAnyOfTest(),
+])


### PR DESCRIPTION
This one contains a few additions that are needed for building with Swift Package Manager in an environment without ObjC. I haven't put any conditional Linux-specific code in this PR.

* Add a main.swift entry point to be used when running the tests using Corelibs XCTest
* Add the `allTests` property to the test cases, needed when using Corelibs XCTest.
* Provide a test shim which causes test cases to fail which haven't been added to the `allTests` list when running from Xcode. This helps ensure that the test suite remains complete in non-ObjC environments, where dynamic method discovery isn't available.
* Add a "null" version of NMBExceptionCapture since there are no exceptions in a non-ObjC environment.
* Import Foundation in tests, since Corelibs XCTest doesn't export Foundation symbols.