### PR TITLE
Disable unavailable features on Linux

### DIFF
--- a/Sources/Nimble/Adapters/NimbleEnvironment.swift
+++ b/Sources/Nimble/Adapters/NimbleEnvironment.swift
@@ -24,6 +24,8 @@ internal class NimbleEnvironment {
         get { return NimbleAssertionHandler }
         set { NimbleAssertionHandler = newValue }
     }
+
+#if _runtime(_ObjC)
     var awaiter: Awaiter
 
     init() {
@@ -32,4 +34,5 @@ internal class NimbleEnvironment {
             asyncQueue: dispatch_get_main_queue(),
             timeoutQueue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0))
     }
+#endif
 }

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if _runtime(_ObjC)
 private enum ErrorResult {
     case Exception(NSException)
     case Error(ErrorType)
@@ -89,3 +90,4 @@ internal func blockedRunLoopErrorMessageFor(fnName: String, leeway: NSTimeInterv
 public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 // A Nimble matcher that catches attempts to use beAKindOf with non Objective-C types
 public func beAKindOf(expectedClass: Any) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in
@@ -32,3 +34,5 @@ extension NMBObjCMatcher {
         }
     }
 }
+
+#endif

--- a/Sources/Nimble/Matchers/Match.swift
+++ b/Sources/Nimble/Matchers/Match.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
 /// described by the expected string.
 public func match(expectedValue: String?) -> NonNilMatcherFunc<String> {
@@ -25,3 +27,4 @@ extension NMBObjCMatcher {
     }
 }
 
+#endif

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 /// A Nimble matcher that succeeds when the actual expression raises an
 /// exception with the specified name, reason, and/or userInfo.
 ///
@@ -176,3 +178,4 @@ extension NMBObjCMatcher {
         return NMBObjCRaiseExceptionMatcher(name: nil, reason: nil, userInfo: nil, block: nil)
     }
 }
+#endif

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if _runtime(_ObjC)
 import Dispatch
 
 private let timeoutLeeway: UInt64 = NSEC_PER_MSEC
@@ -352,3 +354,5 @@ internal func pollBlock(
 
         return result
 }
+
+#endif

--- a/Sources/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Sources/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Matcher {
     let fullMatcher: U
     let timeoutInterval: NSTimeInterval
@@ -129,3 +131,5 @@ extension Expectation {
         return toEventuallyNot(matcher, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 }
+
+#endif

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -2,6 +2,8 @@ import Foundation
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class AsyncTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -161,3 +163,4 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
         expect(executedAsyncBlock).toEventually(beTruthy())
     }
 }
+#endif

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -55,12 +55,14 @@ func failsWithErrorMessageForNil(message: String, file: FileString = __FILE__, l
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
+#if _runtime(_ObjC)
 func deferToMainQueue(action: () -> Void) {
     dispatch_async(dispatch_get_main_queue()) {
         NSThread.sleepForTimeInterval(0.01)
         action()
     }
 }
+#endif
 
 public class NimbleHelper : NSObject {
     class func expectFailureMessage(message: NSString, block: () -> Void, file: FileString, line: UInt) {

--- a/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class TestNull : NSNull {}
 
 class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
@@ -51,3 +53,4 @@ class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/Matchers/MatchTest.swift
+++ b/Sources/NimbleTests/Matchers/MatchTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class MatchTest:XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -44,3 +46,4 @@ class MatchTest:XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Nimble
 
+#if _runtime(_ObjC)
+
 class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () -> Void)] {
         return [
@@ -161,3 +163,4 @@ class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+#endif

--- a/Sources/NimbleTests/UserDescriptionTest.swift
+++ b/Sources/NimbleTests/UserDescriptionTest.swift
@@ -38,27 +38,33 @@ class UserDescriptionTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testToEventuallyMatch_CustomFailureMessage() {
+#if _runtime(_ObjC)
         failsWithErrorMessage(
             "These aren't eventually equal!\n" +
             "expected to eventually equal <1>, got <0>") {
                 expect { 0 }.toEventually(equal(1), description: "These aren't eventually equal!")
         }
+#endif
     }
     
     func testToEventuallyNotMatch_CustomFailureMessage() {
+#if _runtime(_ObjC)
         failsWithErrorMessage(
             "These are eventually equal!\n" +
             "expected to eventually not equal <1>, got <1>") {
                 expect { 1 }.toEventuallyNot(equal(1), description: "These are eventually equal!")
         }
+#endif
     }
     
     func testToNotEventuallyMatch_CustomFailureMessage() {
+#if _runtime(_ObjC)
         failsWithErrorMessage(
             "These are eventually equal!\n" +
             "expected to eventually not equal <1>, got <1>") {
                 expect { 1 }.toEventuallyNot(equal(1), description: "These are eventually equal!")
         }
+#endif
     }
 
 }


### PR DESCRIPTION
There's a bunch of stuff that's not available in the open-source Swift toolchain right now. This includes

* `isKindOfClass:`
* GCD
* `NSRegularExpression`

This PR conditionally disables features and tests (all async, plus some matchers) that rely on those unavailable utilities.