### PR TITLE
Conditionalize for linux

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -36,5 +36,10 @@ class NimbleXCTestUnavailableHandler : AssertionHandler {
 }
 
 func isXCTestAvailable() -> Bool {
+#if _runtime(_ObjC)
+    // XCTest is weakly linked and so may not be present
     return NSClassFromString("XCTestCase") != nil
+#else
+    return true
+#endif
 }

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: String = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -10,7 +10,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: String = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
+public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -25,12 +25,12 @@ public func fail(message: String, location: SourceLocation) {
 }
 
 /// Always fails the test with a message.
-public func fail(message: String, file: String = __FILE__, line: UInt = __LINE__) {
+public func fail(message: String, file: FileString = __FILE__, line: UInt = __LINE__) {
     fail(message, location: SourceLocation(file: file, line: line))
 }
 
 /// Always fails the test.
-public func fail(file: String = __FILE__, line: UInt = __LINE__) {
+public func fail(file: FileString = __FILE__, line: UInt = __LINE__) {
     fail("fail() always fails", file: file, line: line)
 }
 

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -38,14 +38,20 @@ public func fail(file: String = __FILE__, line: UInt = __LINE__) {
 internal func nimblePrecondition(
     @autoclosure expr: () -> Bool,
     @autoclosure _ name: () -> String,
-    @autoclosure _ message: () -> String) -> Bool {
+    @autoclosure _ message: () -> String,
+    file: StaticString = __FILE__,
+    line: UInt = __LINE__) -> Bool {
         let result = expr()
         if !result {
+#if _runtime(_ObjC)
             let e = NSException(
                 name: name(),
                 reason: message(),
                 userInfo: nil)
             e.raise()
+#else
+            preconditionFailure("\(name()) - \(message())", file: file, line: line)
+#endif
         }
         return result
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -34,9 +34,9 @@ public class FailureMessage: NSObject {
     }
 
     internal func stripNewlines(str: String) -> String {
-        var lines: [String] = (str as NSString).componentsSeparatedByString("\n") as [String]
+        var lines: [String] = NSString(string: str).componentsSeparatedByString("\n") as [String]
         let whitespace = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-        lines = lines.map { line in line.stringByTrimmingCharactersInSet(whitespace) }
+        lines = lines.map { line in NSString(string: line).stringByTrimmingCharactersInSet(whitespace) }
         return lines.joinWithSeparator("")
     }
 

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -47,6 +47,7 @@ private func createAllPassMatcher<T,U where U: SequenceType, U.Generator.Element
         }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func allPassMatcher(matcher: NMBObjCMatcher) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -88,3 +89,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -16,11 +16,11 @@ public func beAKindOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         let instance = try actualExpression.evaluate()
         if let validInstance = instance {
-            failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
+            failureMessage.actualValue = "<\(classAsString(validInstance.dynamicType)) instance>"
         } else {
             failureMessage.actualValue = "<nil>"
         }
-        failureMessage.postfixMessage = "be a kind of \(NSStringFromClass(expectedClass))"
+        failureMessage.postfixMessage = "be a kind of \(classAsString(expectedClass))"
         return instance != nil && instance!.isKindOfClass(expectedClass)
     }
 }

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -29,6 +29,7 @@ public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObjec
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beAnInstanceOfMatcher(expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -36,3 +37,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -16,12 +16,16 @@ public func beAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<NSObjec
     return NonNilMatcherFunc { actualExpression, failureMessage in
         let instance = try actualExpression.evaluate()
         if let validInstance = instance {
-            failureMessage.actualValue = "<\(NSStringFromClass(validInstance.dynamicType)) instance>"
+            failureMessage.actualValue = "<\(classAsString(validInstance.dynamicType)) instance>"
         } else {
             failureMessage.actualValue = "<nil>"
         }
-        failureMessage.postfixMessage = "be an instance of \(NSStringFromClass(expectedClass))"
+        failureMessage.postfixMessage = "be an instance of \(classAsString(expectedClass))"
+#if _runtime(_ObjC)
         return instance != nil && instance!.isMemberOfClass(expectedClass)
+#else
+        return instance != nil && instance!.dynamicType == expectedClass
+#endif
     }
 }
 

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -35,6 +35,7 @@ public func beCloseTo(expectedValue: NMBDoubleConvertible, within delta: Double 
     }
 }
 
+#if _runtime(_ObjC)
 public class NMBObjCBeCloseToMatcher : NSObject, NMBMatcher {
     var _expected: NSNumber
     var _delta: CDouble
@@ -73,6 +74,7 @@ extension NMBObjCMatcher {
         return NMBObjCBeCloseToMatcher(expected: expected, within: within)
     }
 }
+#endif
 
 public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDelta) -> NonNilMatcherFunc <[Double]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -1,3 +1,6 @@
+#if os(Linux)
+import Glibc
+#endif
 import Foundation
 
 internal let DefaultDelta = 0.0001

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -82,7 +82,7 @@ extension NMBObjCMatcher {
                 return try! beEmpty().matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
                 failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings)"
-                failureMessage.actualValue = "\(NSStringFromClass(actualValue.dynamicType)) type"
+                failureMessage.actualValue = "\(classAsString(actualValue.dynamicType)) type"
             }
             return false
         }

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -68,6 +68,7 @@ public func beEmpty() -> NonNilMatcherFunc<NMBCollection> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beEmptyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -88,3 +89,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -21,7 +21,7 @@ public func beEmpty() -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be empty"
         let actualString = try actualExpression.evaluate()
-        return actualString == nil || (actualString! as NSString).length  == 0
+        return actualString == nil || NSString(string: actualString!).length  == 0
     }
 }
 

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -27,6 +27,7 @@ public func >(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beGreaterThan(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beGreaterThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -35,3 +36,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -29,6 +29,7 @@ public func >=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beGreaterThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -37,3 +38,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -19,6 +19,7 @@ public func !==<T: AnyObject>(lhs: Expectation<T>, rhs: T?) {
     lhs.toNot(beIdenticalTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beIdenticalToMatcher(expected: NSObject?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -26,3 +27,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -26,6 +26,7 @@ public func <(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
     lhs.to(beLessThan(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beLessThanMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -34,3 +35,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -27,6 +27,7 @@ public func <=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beLessThanOrEqualToMatcher(expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil:false) { actualExpression, failureMessage in
@@ -35,3 +36,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -62,6 +62,7 @@ public func beFalsy<T>() -> MatcherFunc<T> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beTruthyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
@@ -91,3 +92,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -9,6 +9,7 @@ public func beNil<T>() -> MatcherFunc<T> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beNilMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
@@ -16,3 +17,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -37,6 +37,7 @@ public func beginWith(startingSubstring: String) -> NonNilMatcherFunc<String> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beginWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -51,3 +52,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -66,6 +66,7 @@ private func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func containMatcher(expected: [NSObject]) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -89,3 +90,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/EndWith.swift
+++ b/Sources/Nimble/Matchers/EndWith.swift
@@ -47,6 +47,7 @@ public func endWith(endingSubstring: String) -> NonNilMatcherFunc<String> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func endWithMatcher(expected: AnyObject) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -61,3 +62,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -170,6 +170,7 @@ public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]
     lhs.toNot(equal(rhs))
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func equalMatcher(expected: NSObject) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -177,3 +178,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -30,6 +30,7 @@ public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func haveCountMatcher(expected: NSNumber) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -46,3 +47,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -40,7 +40,7 @@ extension NMBObjCMatcher {
                 return try! haveCount(expected.integerValue).matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
                 failureMessage.postfixMessage = "get type of NSArray, NSSet, NSDictionary, or NSHashTable"
-                failureMessage.actualValue = "\(NSStringFromClass(actualValue.dynamicType))"
+                failureMessage.actualValue = "\(classAsString(actualValue.dynamicType))"
             }
             return false
         }

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -7,11 +7,13 @@ public protocol Matcher {
     func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }
 
+#if _runtime(_ObjC)
 /// Objective-C interface to the Swift variant of Matcher.
 @objc public protocol NMBMatcher {
     func matches(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool
     func doesNotMatch(actualBlock: () -> NSObject!, failureMessage: FailureMessage, location: SourceLocation) -> Bool
 }
+#endif
 
 /// Protocol for types that support contain() matcher.
 @objc public protocol NMBContainer {

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -15,33 +15,79 @@ public protocol Matcher {
 }
 #endif
 
+#if _runtime(_ObjC)
 /// Protocol for types that support contain() matcher.
 @objc public protocol NMBContainer {
     func containsObject(object: AnyObject!) -> Bool
 }
+
+extension NSHashTable : NMBContainer {} // Corelibs Foundation does not include this class yet
+#else
+public protocol NMBContainer {
+    func containsObject(object: AnyObject) -> Bool
+}
+#endif
+
 extension NSArray : NMBContainer {}
 extension NSSet : NMBContainer {}
-extension NSHashTable : NMBContainer {}
 
+#if _runtime(_ObjC)
 /// Protocol for types that support only beEmpty(), haveCount() matchers
 @objc public protocol NMBCollection {
     var count: Int { get }
 }
+
+extension NSHashTable : NMBCollection {} // Corelibs Foundation does not include these classes yet
+extension NSMapTable : NMBCollection {}
+#else
+public protocol NMBCollection {
+    var count: Int { get }
+}
+#endif
+
 extension NSSet : NMBCollection {}
 extension NSDictionary : NMBCollection {}
-extension NSHashTable : NMBCollection {}
-extension NSMapTable : NMBCollection {}
 
+#if _runtime(_ObjC)
 /// Protocol for types that support beginWith(), endWith(), beEmpty() matchers
 @objc public protocol NMBOrderedCollection : NMBCollection {
     func indexOfObject(object: AnyObject!) -> Int
 }
+#else
+public protocol NMBOrderedCollection : NMBCollection {
+    func indexOfObject(object: AnyObject) -> Int
+}
+#endif
+
 extension NSArray : NMBOrderedCollection {}
 
+#if _runtime(_ObjC)
 /// Protocol for types to support beCloseTo() matcher
 @objc public protocol NMBDoubleConvertible {
     var doubleValue: CDouble { get }
 }
+#else
+public protocol NMBDoubleConvertible {
+    var doubleValue: CDouble { get }
+}
+
+extension Double : NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return self
+        }
+    }
+}
+
+extension Float : NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return CDouble(self)
+        }
+    }
+}
+#endif
+
 extension NSNumber : NMBDoubleConvertible {
 }
 
@@ -86,9 +132,17 @@ extension NMBDoubleConvertible {
 ///  beGreaterThan(), beGreaterThanOrEqualTo(), and equal() matchers.
 ///
 /// Types that conform to Swift's Comparable protocol will work implicitly too
+#if _runtime(_ObjC)
 @objc public protocol NMBComparable {
     func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult
 }
+#else
+// This should become obsolete once Corelibs Foundation adds Comparable conformance to NSNumber
+public protocol NMBComparable {
+    func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult
+}
+#endif
+
 extension NSNumber : NMBComparable {
     public func NMB_compare(otherObject: NMBComparable!) -> NSComparisonResult {
         return compare(otherObject as! NSNumber)

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -57,7 +57,7 @@ internal func setFailureMessageForException(
         }
 
         if let exception = exception {
-            failureMessage.actualValue = "\(NSStringFromClass(exception.dynamicType)) { name=\(exception.name), reason='\(stringify(exception.reason))', userInfo=\(stringify(exception.userInfo)) }"
+            failureMessage.actualValue = "\(classAsString(exception.dynamicType)) { name=\(exception.name), reason='\(stringify(exception.reason))', userInfo=\(stringify(exception.userInfo)) }"
         } else {
             failureMessage.actualValue = "no exception"
         }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -41,6 +41,7 @@ public func ||<T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> NonNilMatcherF
     return satisfyAnyOf(left, right)
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func satisfyAnyOfMatcher(matchers: [NMBObjCMatcher]) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -64,3 +65,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/ObjCExpectation.swift
+++ b/Sources/Nimble/ObjCExpectation.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 internal struct ObjCMatcherWrapper : Matcher {
     let matcher: NMBMatcher
 
@@ -125,3 +127,5 @@ public class NMBExpectation : NSObject {
         fail(message, location: SourceLocation(file: file, line: line))
     }
 }
+
+#endif

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -7,7 +7,7 @@ private let pollLeeway: UInt64 = NSEC_PER_MSEC
 /// Stores debugging information about callers
 internal struct WaitingInfo: CustomStringConvertible {
     let name: String
-    let file: String
+    let file: FileString
     let lineNumber: UInt
 
     var description: String {
@@ -16,7 +16,7 @@ internal struct WaitingInfo: CustomStringConvertible {
 }
 
 internal protocol WaitLock {
-    func acquireWaitingLock(fnName: String, file: String, line: UInt)
+    func acquireWaitingLock(fnName: String, file: FileString, line: UInt)
     func releaseWaitingLock()
     func isWaitingLocked() -> Bool
 }
@@ -25,7 +25,7 @@ internal class AssertionWaitLock: WaitLock {
     private var currentWaiter: WaitingInfo? = nil
     init() { }
 
-    func acquireWaitingLock(fnName: String, file: String, line: UInt) {
+    func acquireWaitingLock(fnName: String, file: FileString, line: UInt) {
         let info = WaitingInfo(name: fnName, file: file, lineNumber: line)
         nimblePrecondition(
             NSThread.isMainThread(),
@@ -218,7 +218,7 @@ internal class AwaitPromiseBuilder<T> {
     /// - The async expectation raised an unexpected error (swift)
     ///
     /// The returned AwaitResult will NEVER be .Incomplete.
-    func wait(fnName: String = __FUNCTION__, file: String = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
+    func wait(fnName: String = __FUNCTION__, file: FileString = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
         waitLock.acquireWaitingLock(
             fnName,
             file: file,
@@ -334,7 +334,7 @@ internal class Awaiter {
 internal func pollBlock(
     pollInterval pollInterval: NSTimeInterval,
     timeoutInterval: NSTimeInterval,
-    file: String,
+    file: FileString,
     line: UInt,
     fnName: String = __FUNCTION__,
     expression: () throws -> Bool) -> AwaitResult<Bool> {

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+#if _runtime(_ObjC)
+public typealias FileString = String
+#else
+public typealias FileString = StaticString
+#endif
 
 public class SourceLocation : NSObject {
-    public let file: String
+    public let file: FileString
     public let line: UInt
 
     override init() {
@@ -10,7 +15,7 @@ public class SourceLocation : NSObject {
         line = 0
     }
 
-    init(file: String, line: UInt) {
+    init(file: FileString, line: UInt) {
         self.file = file
         self.line = line
     }

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -23,9 +23,18 @@ internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {
     }
 }
 
+#if _runtime(_ObjC)
 @objc internal protocol NMBStringer {
     func NMB_stringify() -> String
 }
+
+extension NSArray : NMBStringer {
+    func NMB_stringify() -> String {
+        let str = self.componentsJoinedByString(", ")
+        return "[\(str)]"
+    }
+}
+#endif
 
 internal func stringify<S: SequenceType>(value: S) -> String {
     var generator = value.generate()
@@ -39,13 +48,6 @@ internal func stringify<S: SequenceType>(value: S) -> String {
     } while value != nil
     let str = strings.joinWithSeparator(", ")
     return "[\(str)]"
-}
-
-extension NSArray : NMBStringer {
-    func NMB_stringify() -> String {
-        let str = self.componentsJoinedByString(", ")
-        return "[\(str)]"
-    }
 }
 
 internal func stringify<T>(value: T) -> String {

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -8,6 +8,14 @@ internal func identityAsString(value: AnyObject?) -> String {
     return NSString(format: "<%p>", unsafeBitCast(value!, Int.self)).description
 }
 
+internal func classAsString(cls: AnyClass) -> String {
+#if _runtime(_ObjC)
+    return NSStringFromClass(cls)
+#else
+    return String(cls)
+#endif
+}
+
 internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {
     return items.reduce("") { accum, item in
         let prefix = (accum.isEmpty ? "" : joiner)

--- a/Sources/Nimble/Wrappers/ObjCMatcher.swift
+++ b/Sources/Nimble/Wrappers/ObjCMatcher.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+#if _runtime(_ObjC)
+
 public typealias MatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage) -> Bool
 public typealias FullMatcherBlock = (actualExpression: Expression<NSObject>, failureMessage: FailureMessage, shouldNotMatch: Bool) -> Bool
 
@@ -76,3 +78,4 @@ public class NMBObjCMatcher : NSObject, NMBMatcher {
     }
 }
 
+#endif

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -63,16 +63,16 @@ func deferToMainQueue(action: () -> Void) {
 }
 
 public class NimbleHelper : NSObject {
-    class func expectFailureMessage(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessage(message: NSString, block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessage(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    class func expectFailureMessages(messages: [NSString], block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessage(messages as! [String], file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessages(messages: [NSString], block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessage(messages.map({ String($0) }), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    class func expectFailureMessageForNil(message: NSString, block: () -> Void, file: String, line: UInt) {
-        failsWithErrorMessageForNil(message as String, file: file, line: line, preferOriginalSourceLocation: true, closure: block)
+    class func expectFailureMessageForNil(message: NSString, block: () -> Void, file: FileString, line: UInt) {
+        failsWithErrorMessageForNil(String(message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }
 

--- a/Sources/NimbleTests/Helpers/utils.swift
+++ b/Sources/NimbleTests/Helpers/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 import Nimble
 import XCTest
 
-func failsWithErrorMessage(messages: [String], file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -41,7 +41,7 @@ func failsWithErrorMessage(messages: [String], file: String = __FILE__, line: UI
     }
 }
 
-func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -51,7 +51,7 @@ func failsWithErrorMessage(message: String, file: String = __FILE__, line: UInt 
     )
 }
 
-func failsWithErrorMessageForNil(message: String, file: String = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessageForNil(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 

--- a/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 
@@ -15,30 +16,30 @@ class BeIdenticalToObjectTest: XCTestCase {
     }
     
     func testBeIdenticalToPositiveMessage() {
-        let message = String(format: "expected to be identical to <%p>, got <%p>",
-            unsafeBitCast(testObjectB, Int.self), unsafeBitCast(testObjectA, Int.self))
+        let message = String(NSString(format: "expected to be identical to <%p>, got <%p>",
+            unsafeBitCast(testObjectB, Int.self), unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).to(beIdenticalTo(self.testObjectB))
         }
     }
     
     func testBeIdenticalToNegativeMessage() {
-        let message = String(format: "expected to not be identical to <%p>, got <%p>",
-            unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectA, Int.self))
+        let message = String(NSString(format: "expected to not be identical to <%p>, got <%p>",
+            unsafeBitCast(testObjectA, Int.self), unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessage(message) {
             expect(self.testObjectA).toNot(beIdenticalTo(self.testObjectA))
         }
     }
 
     func testFailsOnNils() {
-        let message1 = String(format: "expected to be identical to <%p>, got nil",
-            unsafeBitCast(testObjectA, Int.self))
+        let message1 = String(NSString(format: "expected to be identical to <%p>, got nil",
+            unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessageForNil(message1) {
             expect(nil as BeIdenticalToObjectTester?).to(beIdenticalTo(self.testObjectA))
         }
 
-        let message2 = String(format: "expected to not be identical to <%p>, got nil",
-            unsafeBitCast(testObjectA, Int.self))
+        let message2 = String(NSString(format: "expected to not be identical to <%p>, got nil",
+            unsafeBitCast(testObjectA, Int.self)))
         failsWithErrorMessageForNil(message2) {
             expect(nil as BeIdenticalToObjectTester?).toNot(beIdenticalTo(self.testObjectA))
         }

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-import Nimble
+@testable import Nimble
 
 class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToPositive() {
@@ -14,8 +14,8 @@ class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToPositiveMessage() {
         let num1 = NSNumber(integer:1)
         let num2 = NSNumber(integer:2)
-        let message = NSString(format: "expected to be identical to <%p>, got <%p>", num2, num1)
-        failsWithErrorMessage(message.description) {
+        let message = "expected to be identical to \(identityAsString(num2)), got \(identityAsString(num1))"
+        failsWithErrorMessage(message) {
             expect(num1).to(beIdenticalTo(num2))
         }
     }
@@ -23,8 +23,8 @@ class BeIdenticalToTest: XCTestCase {
     func testBeIdenticalToNegativeMessage() {
         let value1 = NSArray(array: [])
         let value2 = NSArray(array: [])
-        let message = NSString(format: "expected to not be identical to <%p>, got <%p>", value2, value1)
-        failsWithErrorMessage(message.description) {
+        let message = "expected to not be identical to \(identityAsString(value2)), got \(identityAsString(value1))"
+        failsWithErrorMessage(message) {
             expect(value1).toNot(beIdenticalTo(value2))
         }
     }


### PR DESCRIPTION
This one is a considerably bigger - it could be broken down further if you'd prefer @jeffh but I struggled to come up with logical divisions within it. Once again, the individual commits are quite focused and should hopefully tell the story reasonably well.

Regarding a previous comment from @jeffh about disabling all the `NMB*` symbols in `MatcherProtocols.swift`: I chose leave several of them enabled because they are needed in order to let us work with a number of classes defined in Corelibs Foundation (e.g. `NSNumber`, `NSArray`) at least until that framework finishes conforming to the stdlib protocols necessary for the "pure Swift" versions of the matchers to function properly.