### PR TITLE
[WIP] Fixup linux tests

### DIFF
--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -80,6 +80,8 @@ public func beCloseTo(expectedValues: [Double], within delta: Double = DefaultDe
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "be close to <\(stringify(expectedValues))> (each within \(stringify(delta)))"
         if let actual = try actualExpression.evaluate() {
+            failureMessage.actualValue = "<\(stringify(actual))>"
+
             if actual.count != expectedValues.count {
                 return false
             } else {

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -99,6 +99,7 @@ private let dateFormatter: NSDateFormatter = {
     return formatter
 }()
 
+#if _runtime(_ObjC)
 extension NSDate: NMBDoubleConvertible {
     public var doubleValue: CDouble {
         get {
@@ -106,6 +107,7 @@ extension NSDate: NMBDoubleConvertible {
         }
     }
 }
+#endif
 
 
 extension NMBDoubleConvertible {

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -5,7 +5,7 @@ import Nimble
 #if _runtime(_ObjC)
 
 class AsyncTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
             ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),

--- a/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Sources/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -9,7 +9,7 @@ import XCTest
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
 
 public protocol XCTestCaseProvider {
-    var allTests : [(String, () -> Void)] { get }
+    var allTests: [(String, () throws -> Void)] { get }
 }
 
 extension XCTestCase {

--- a/Sources/NimbleTests/Matchers/AllPassTest.swift
+++ b/Sources/NimbleTests/Matchers/AllPassTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class AllPassTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testAllPassArray", testAllPassArray),
             ("testAllPassMatcher", testAllPassMatcher),

--- a/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -6,7 +6,7 @@ import Nimble
 class TestNull : NSNull {}
 
 class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testPositiveMatch", testPositiveMatch),
             ("testFailureMessages", testFailureMessages),

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testPositiveMatch", testPositiveMatch),
             ("testFailureMessages", testFailureMessages),

--- a/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Sources/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -23,10 +23,15 @@ class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessageForNil("expected to be an instance of NSString, got <nil>") {
             expect(nil as NSString?).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected to be an instance of NSString, got <__NSCFNumber instance>") {
+#if _runtime(_ObjC)
+        let numberTypeName = "__NSCFNumber"
+#else
+        let numberTypeName = "NSNumber"
+#endif
+        failsWithErrorMessage("expected to be an instance of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(integer:1)).to(beAnInstanceOf(NSString))
         }
-        failsWithErrorMessage("expected to not be an instance of NSNumber, got <__NSCFNumber instance>") {
+        failsWithErrorMessage("expected to not be an instance of NSNumber, got <\(numberTypeName) instance>") {
             expect(NSNumber(integer:1)).toNot(beAnInstanceOf(NSNumber))
         }
     }

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeCloseToTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeCloseTo", testBeCloseTo),
             ("testBeCloseToWithin", testBeCloseToWithin),

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -39,7 +39,12 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
         expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
 
-        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
+#if _runtime(_ObjC)
+        let expectedRepresentation = "1.2000"
+#else
+        let expectedRepresentation = "1.2"
+#endif
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <\(expectedRepresentation)>") {
             expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }
@@ -91,10 +96,10 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect([0.0, 1.1, 2.2]) ≈ [0.0001, 1.1001, 2.2001]
         expect([0.0, 1.1, 2.2]).to(beCloseTo([0.1, 1.2, 2.3], within: 0.1))
         
-        failsWithErrorMessage("expected to be close to <[0.0000, 1.0000]> (each within 0.0001), got <[0.0, 1.1]>") {
+        failsWithErrorMessage("expected to be close to <[0.0000, 1.0000]> (each within 0.0001), got <[0.0000, 1.1000]>") {
             expect([0.0, 1.1]) ≈ [0.0, 1.0]
         }
-        failsWithErrorMessage("expected to be close to <[0.2000, 1.2000]> (each within 0.1000), got <[0.0, 1.1]>") {
+        failsWithErrorMessage("expected to be close to <[0.2000, 1.2000]> (each within 0.1000), got <[0.0000, 1.1000]>") {
             expect([0.0, 1.1]).to(beCloseTo([0.2, 1.2], within: 0.1))
         }
     }

--- a/Sources/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeCloseToTest.swift
@@ -50,6 +50,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeCloseToWithNSDate() {
+#if _runtime(_ObjC) // NSDateFormatter isn't functional in swift-corelibs-foundation yet.
         expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
         
         failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.0040), got <2015-08-26 11:43:00.0000>") {
@@ -57,6 +58,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
             let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
             expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
         }
+#endif
     }
     
     func testBeCloseToOperator() {

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -17,17 +17,21 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         expect([] as [CInt]).to(beEmpty())
         expect([1] as [CInt]).toNot(beEmpty())
 
+#if _runtime(_ObjC)
         expect(NSDictionary() as? [Int:Int]).to(beEmpty())
         expect(NSDictionary(object: 1, forKey: 1) as? [Int:Int]).toNot(beEmpty())
+#endif
 
         expect(Dictionary<Int, Int>()).to(beEmpty())
         expect(["hi": 1]).toNot(beEmpty())
 
+#if _runtime(_ObjC)
         expect(NSArray() as? [Int]).to(beEmpty())
         expect(NSArray(array: [1]) as? [Int]).toNot(beEmpty())
+#endif
 
         expect(NSSet()).to(beEmpty())
-        expect(NSSet(array: [1])).toNot(beEmpty())
+        expect(NSSet(array: [NSNumber(integer: 1)])).toNot(beEmpty())
 
         expect(NSString()).to(beEmpty())
         expect(NSString(string: "hello")).toNot(beEmpty())
@@ -45,7 +49,7 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         }
 
         failsWithErrorMessage("expected to not be empty, got <()>") {
-            expect([]).toNot(beEmpty())
+            expect(NSArray()).toNot(beEmpty())
         }
         failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())

--- a/Sources/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Sources/NimbleTests/Matchers/BeEmptyTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeEmptyTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeEmptyPositive", testBeEmptyPositive),
             ("testBeEmptyNegative", testBeEmptyNegative),

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -16,7 +16,9 @@ class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
         expect(1).toNot(beGreaterThanOrEqualTo(2))
         expect(NSNumber(int:1)).toNot(beGreaterThanOrEqualTo(2))
         expect(NSNumber(int:2)).to(beGreaterThanOrEqualTo(NSNumber(int:2)))
+#if _runtime(_ObjC)
         expect(1).to(beGreaterThanOrEqualTo(NSNumber(int:0)))
+#endif
 
         failsWithErrorMessage("expected to be greater than or equal to <2>, got <0>") {
             expect(0).to(beGreaterThanOrEqualTo(2))

--- a/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testGreaterThanOrEqualTo", testGreaterThanOrEqualTo),
             ("testGreaterThanOrEqualToOperator", testGreaterThanOrEqualToOperator),

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testGreaterThan", testGreaterThan),
             ("testGreaterThanOperator", testGreaterThanOperator),

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -13,7 +13,9 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))
+#if _runtime(_ObjC)
         expect(NSNumber(int:3)).to(beGreaterThan(2))
+#endif
         expect(NSNumber(int:1)).toNot(beGreaterThan(NSNumber(int:2)))
 
         failsWithErrorMessage("expected to be greater than <2>, got <0>") {
@@ -33,7 +35,9 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
     func testGreaterThanOperator() {
         expect(1) > 0
         expect(NSNumber(int:1)) > NSNumber(int:0)
+#if _runtime(_ObjC)
         expect(NSNumber(int:1)) > 0
+#endif
 
         failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
             expect(1) > 2

--- a/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -39,7 +39,12 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
         expect(NSNumber(int:1)) > 0
 #endif
 
-        failsWithErrorMessage("expected to be greater than <2.0000>, got <1.0000>") {
+#if _runtime(_ObjC)
+        let (expectedRepresentation, actualRepresentation) = ("2.0000", "1.0000")
+#else
+        let (expectedRepresentation, actualRepresentation) = ("2", "1")
+#endif
+        failsWithErrorMessage("expected to be greater than <\(expectedRepresentation)>, got <\(actualRepresentation)>") {
             expect(1) > 2
             return
         }

--- a/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeIdenticalToPositive", testBeIdenticalToPositive),
             ("testBeIdenticalToNegative", testBeIdenticalToNegative),

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -19,8 +19,8 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testBeIdenticalToNegative() {
-        expect(NSNumber(integer:1)).toNot(beIdenticalTo("yo"))
-        expect([1]).toNot(beIdenticalTo([1]))
+        expect(NSNumber(integer:1)).toNot(beIdenticalTo(NSString(string: "yo")))
+        expect(NSArray(array: [NSNumber(integer: 1)])).toNot(beIdenticalTo(NSArray(array: [NSNumber(integer: 1)])))
     }
 
     func testBeIdenticalToPositiveMessage() {

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Nimble
 
 class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeIdenticalToPositive", testBeIdenticalToPositive),
             ("testBeIdenticalToNegative", testBeIdenticalToNegative),

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -17,8 +17,10 @@ class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
 
         expect(NSNumber(int:2)).to(beLessThanOrEqualTo(10))
         expect(NSNumber(int:2)).toNot(beLessThanOrEqualTo(1))
+#if _runtime(_ObjC)
         expect(2).to(beLessThanOrEqualTo(NSNumber(int:10)))
         expect(2).toNot(beLessThanOrEqualTo(NSNumber(int:1)))
+#endif
 
         failsWithErrorMessage("expected to be less than or equal to <0>, got <2>") {
             expect(2).to(beLessThanOrEqualTo(0))

--- a/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testLessThanOrEqualTo", testLessThanOrEqualTo),
             ("testLessThanOrEqualToOperator", testLessThanOrEqualToOperator),

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeLessThanTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testLessThan", testLessThan),
             ("testLessThanOperator", testLessThanOperator),

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -13,11 +13,13 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
     func testLessThan() {
         expect(2).to(beLessThan(10))
         expect(2).toNot(beLessThan(1))
+#if _runtime(_ObjC)
         expect(NSNumber(integer:2)).to(beLessThan(10))
         expect(NSNumber(integer:2)).toNot(beLessThan(1))
 
         expect(2).to(beLessThan(NSNumber(integer:10)))
         expect(2).toNot(beLessThan(NSNumber(integer:1)))
+#endif
 
         failsWithErrorMessage("expected to be less than <0>, got <2>") {
             expect(2).to(beLessThan(0))
@@ -36,7 +38,9 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
 
     func testLessThanOperator() {
         expect(0) < 1
+#if _runtime(_ObjC)
         expect(NSNumber(int:0)) < 1
+#endif
 
         failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
             expect(2) < 1

--- a/Sources/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLessThanTest.swift
@@ -42,7 +42,12 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
         expect(NSNumber(int:0)) < 1
 #endif
 
-        failsWithErrorMessage("expected to be less than <1.0000>, got <2.0000>") {
+#if _runtime(_ObjC)
+        let (expectedRepresentation, actualRepresentation) = ("1.0000", "2.0000")
+#else
+        let (expectedRepresentation, actualRepresentation) = ("1", "2")
+#endif
+        failsWithErrorMessage("expected to be less than <\(expectedRepresentation)>, got <\(actualRepresentation)>") {
             expect(2) < 1
             return
         }

--- a/Sources/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/Sources/NimbleTests/Matchers/BeLogicalTest.swift
@@ -20,7 +20,7 @@ enum ConvertsToBool : BooleanType, CustomStringConvertible {
 }
 
 class BeTruthyTest : XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testShouldMatchNonNilTypes", testShouldMatchNonNilTypes),
             ("testShouldMatchTrue", testShouldMatchTrue),
@@ -85,7 +85,7 @@ class BeTruthyTest : XCTestCase, XCTestCaseProvider {
 }
 
 class BeTrueTest : XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testShouldMatchTrue", testShouldMatchTrue),
             ("testShouldNotMatchFalse", testShouldNotMatchFalse),
@@ -121,7 +121,7 @@ class BeTrueTest : XCTestCase, XCTestCaseProvider {
 }
 
 class BeFalsyTest : XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testShouldMatchNilTypes", testShouldMatchNilTypes),
             ("testShouldNotMatchTrue", testShouldNotMatchTrue),
@@ -168,7 +168,7 @@ class BeFalsyTest : XCTestCase, XCTestCaseProvider {
 }
 
 class BeFalseTest : XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testShouldNotMatchTrue", testShouldNotMatchTrue),
             ("testShouldMatchFalse", testShouldMatchFalse),

--- a/Sources/NimbleTests/Matchers/BeNilTest.swift
+++ b/Sources/NimbleTests/Matchers/BeNilTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class BeNilTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeNil", testBeNil),
         ]

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -20,16 +20,18 @@ class BeginWithTest: XCTestCase, XCTestCaseProvider {
         expect(NSString(string: "foobar").description).to(beginWith("foo"))
         expect(NSString(string: "foobar").description).toNot(beginWith("oo"))
 
+#if _runtime(_ObjC)
         expect(NSArray(array: ["a", "b"])).to(beginWith("a"))
         expect(NSArray(array: ["a", "b"])).toNot(beginWith("b"))
+#endif
     }
 
     func testNegativeMatches() {
         failsWithErrorMessageForNil("expected to begin with <b>, got <nil>") {
-            expect(nil as NSArray?).to(beginWith("b"))
+            expect(nil as NSArray?).to(beginWith(NSString(string: "b")))
         }
         failsWithErrorMessageForNil("expected to not begin with <b>, got <nil>") {
-            expect(nil as NSArray?).toNot(beginWith("b"))
+            expect(nil as NSArray?).toNot(beginWith(NSString(string: "b")))
         }
 
         failsWithErrorMessage("expected to begin with <2>, got <[1, 2, 3]>") {

--- a/Sources/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Sources/NimbleTests/Matchers/BeginWithTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class BeginWithTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testPositiveMatches", testPositiveMatches),
             ("testNegativeMatches", testNegativeMatches),

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -19,9 +19,11 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
         expect(["foo", "bar", "baz"]).to(contain("baz"))
         expect([1, 2, 3]).toNot(contain(4))
         expect(["foo", "bar", "baz"]).toNot(contain("ba"))
-        expect(NSArray(array: ["a"])).to(contain("a"))
-        expect(NSArray(array: ["a"])).toNot(contain("b"))
+#if _runtime(_ObjC)
+        expect(NSArray(array: ["a"])).to(contain(NSString(string: "a")))
+        expect(NSArray(array: ["a"])).toNot(contain(NSString(string:"b")))
         expect(NSArray(object: 1) as NSArray?).to(contain(1))
+#endif
 
         failsWithErrorMessage("expected to contain <bar>, got <[\"a\", \"b\", \"c\"]>") {
             expect(["a", "b", "c"]).to(contain("bar"))

--- a/Sources/NimbleTests/Matchers/ContainTest.swift
+++ b/Sources/NimbleTests/Matchers/ContainTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class ContainTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testContain", testContain),
             ("testContainSubstring", testContainSubstring),

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -20,8 +20,10 @@ class EndWithTest: XCTestCase, XCTestCaseProvider {
         expect(NSString(string: "foobar").description).to(endWith("bar"))
         expect(NSString(string: "foobar").description).toNot(endWith("oo"))
 
+#if _runtime(_ObjC)
         expect(NSArray(array: ["a", "b"])).to(endWith("b"))
         expect(NSArray(array: ["a", "b"])).toNot(endWith("a"))
+#endif
     }
 
     func testEndWithNegatives() {

--- a/Sources/NimbleTests/Matchers/EndWithTest.swift
+++ b/Sources/NimbleTests/Matchers/EndWithTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class EndWithTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testEndWithPositives", testEndWithPositives),
             ("testEndWithNegatives", testEndWithNegatives),

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class EqualTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testEquality", testEquality),
             ("testArrayEquality", testArrayEquality),

--- a/Sources/NimbleTests/Matchers/EqualTest.swift
+++ b/Sources/NimbleTests/Matchers/EqualTest.swift
@@ -50,7 +50,9 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(array1).to(equal([1, 2, 3]))
         expect(array1).toNot(equal([1, 2] as Array<Int>))
 
+#if _runtime(_ObjC)
         expect(NSArray(array: [1, 2, 3])).to(equal(NSArray(array: [1, 2, 3])))
+#endif
 
         failsWithErrorMessage("expected to equal <[1, 2]>, got <[1, 2, 3]>") {
             expect([1, 2, 3]).to(equal([1, 2]))
@@ -130,8 +132,10 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(actual).to(equal(expected))
         expect(actual).toNot(equal(unexpected))
 
+#if _runtime(_ObjC)
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(expected))
+#endif
     }
 
     func testNSObjectEquality() {

--- a/Sources/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Sources/NimbleTests/Matchers/HaveCountTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class HaveCountTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testHaveCountForArray", testHaveCountForArray),
             ("testHaveCountForDictionary", testHaveCountForDictionary),

--- a/Sources/NimbleTests/Matchers/MatchTest.swift
+++ b/Sources/NimbleTests/Matchers/MatchTest.swift
@@ -4,7 +4,7 @@ import Nimble
 #if _runtime(_ObjC)
 
 class MatchTest:XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testMatchPositive", testMatchPositive),
             ("testMatchNegative", testMatchNegative),

--- a/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Sources/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -4,7 +4,7 @@ import Nimble
 #if _runtime(_ObjC)
 
 class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testPositiveMatches", testPositiveMatches),
             ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),

--- a/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -11,7 +11,9 @@ class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
 
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
+#if _runtime(_ObjC)
         expect(2).toNot(satisfyAnyOf(equal(3), equal("turtles")))
+#endif
         expect([1,2,3]).to(satisfyAnyOf(equal([1,2,3]), allPass({$0 < 4}), haveCount(3)))
         expect("turtle").toNot(satisfyAnyOf(contain("a"), endWith("magic")))
         expect(82.0).toNot(satisfyAnyOf(beLessThan(10.5), beGreaterThan(100.75), beCloseTo(50.1)))
@@ -38,7 +40,9 @@ class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
     
     func testOperatorOr() {
         expect(2).to(equal(2) || equal(3))
+#if _runtime(_ObjC)
         expect(2).toNot(equal(3) || equal("turtles"))
+#endif
         expect("turtle").toNot(contain("a") || endWith("magic"))
         expect(82.0).toNot(beLessThan(10.5) || beGreaterThan(100.75))
         expect(false).to(beTrue() || beFalse())

--- a/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Sources/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testSatisfyAnyOf", testSatisfyAnyOf),
             ("testOperatorOr", testOperatorOr),

--- a/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Sources/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -32,7 +32,7 @@ extension CustomDebugStringConvertibleError : CustomDebugStringConvertible {
 }
 
 class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testPositiveMatches", testPositiveMatches),
             ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -36,12 +36,14 @@ class SynchronousTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testUnexpectedErrorsThrownFails() {
+#if _runtime(_ObjC) // This test triggers a weird segfault on Linux currently
         failsWithErrorMessage("expected to equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.to(equal(1))
         }
         failsWithErrorMessage("expected to not equal <1>, got an unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.toNot(equal(1))
         }
+#endif
     }
 
     func testToMatchesIfMatcherReturnsTrue() {

--- a/Sources/NimbleTests/SynchronousTests.swift
+++ b/Sources/NimbleTests/SynchronousTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class SynchronousTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testFailAlwaysFails", testFailAlwaysFails),
             ("testUnexpectedErrorsThrownFails", testUnexpectedErrorsThrownFails),

--- a/Sources/NimbleTests/UserDescriptionTest.swift
+++ b/Sources/NimbleTests/UserDescriptionTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Nimble
 
 class UserDescriptionTest: XCTestCase, XCTestCaseProvider {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("testToMatcher_CustomFailureMessage", testToMatcher_CustomFailureMessage),
             ("testNotToMatcher_CustomFailureMessage", testNotToMatcher_CustomFailureMessage),


### PR DESCRIPTION
Hacking around to disable or tweak a bunch of tests that for various reasons don't build or fail at runtime on Linux. The majority of these have to do with the Foundation<->stdlib bridging behavior being very incomplete currently. I expect bits and pieces of these to start to work over time.

I consider this a WIP also because there are a handful of tests that still fail with these changes that I am still investigating.