### PR TITLE
Add 'be' as alias for 'beIdenticalTo'

### DIFF
--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -19,6 +19,11 @@ public func !==<T: AnyObject>(lhs: Expectation<T>, rhs: T?) {
     lhs.toNot(beIdenticalTo(rhs))
 }
 
+/// Alias for "beIdenticalTo"
+public func be<T: AnyObject>(expected: T?) -> NonNilMatcherFunc<T> {
+    return beIdenticalTo(expected)
+}
+
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beIdenticalToMatcher(expected: NSObject?) -> NMBObjCMatcher {

--- a/Sources/Nimble/objc/DSL.h
+++ b/Sources/Nimble/objc/DSL.h
@@ -53,6 +53,10 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance);
 NIMBLE_SHORT(id<NMBMatcher> beIdenticalTo(id expectedInstance),
              NMB_beIdenticalTo(expectedInstance));
 
+NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance);
+NIMBLE_SHORT(id<NMBMatcher> be(id expectedInstance),
+             NMB_be(expectedInstance));
+
 NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
 NIMBLE_SHORT(id<NMBMatcher> beLessThan(NSNumber *expectedValue),
              NMB_beLessThan(expectedValue));

--- a/Sources/Nimble/objc/DSL.m
+++ b/Sources/Nimble/objc/DSL.m
@@ -55,6 +55,10 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance) {
     return [NMBObjCMatcher beIdenticalToMatcher:expectedInstance];
 }
 
+NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance) {
+    return [NMBObjCMatcher beIdenticalToMatcher:expectedInstance];
+}
+
 NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue) {
     return [NMBObjCMatcher beLessThanMatcher:expectedValue];
 }

--- a/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Sources/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -10,6 +10,7 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
             ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
             ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
             ("testOperators", testOperators),
+            ("testBeAlias", testBeAlias)
         ]
     }
 
@@ -40,10 +41,23 @@ class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
             expect(value1).toNot(beIdenticalTo(value2))
         }
     }
-    
+
     func testOperators() {
         let value = NSDate()
         expect(value) === value
         expect(NSNumber(integer:1)) !== NSNumber(integer:2)
+    }
+
+    func testBeAlias() {
+        expect(NSNumber(integer:1)).to(be(NSNumber(integer:1)))
+        expect(NSNumber(integer:1)).toNot(be("turtles"))
+        expect([1]).toNot(be([1]))
+
+        let value1 = NSArray(array: [])
+        let value2 = NSArray(array: [])
+        let message = "expected to not be identical to \(identityAsString(value2)), got \(identityAsString(value1))"
+        failsWithErrorMessage(message) {
+            expect(value1).toNot(be(value2))
+        }
     }
 }

--- a/Sources/NimbleTests/objc/ObjCBeIdenticalToTest.m
+++ b/Sources/NimbleTests/objc/ObjCBeIdenticalToTest.m
@@ -33,4 +33,30 @@
     });
 }
 
+- (void)testAliasPositiveMatches {
+    NSNull *obj = [NSNull null];
+    expect(obj).to(be([NSNull null]));
+    expect(@2).toNot(be(@3));
+}
+
+- (void)testAliasNegativeMatches {
+    NSNull *obj = [NSNull null];
+    expectFailureMessage(([NSString stringWithFormat:@"expected to be identical to <%p>, got <%p>", obj, @2]), ^{
+        expect(@2).to(be(obj));
+    });
+    expectFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got <%p>", obj, obj]), ^{
+        expect(obj).toNot(be(obj));
+    });
+}
+
+- (void)testAliasNilMatches {
+    NSNull *obj = [NSNull null];
+    expectNilFailureMessage(@"expected to be identical to nil, got nil", ^{
+        expect(nil).to(be(nil));
+    });
+    expectNilFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got nil", obj]), ^{
+        expect(nil).toNot(be(obj));
+    });
+}
+
 @end


### PR DESCRIPTION
This PR targets #230 by adding a new function -- ```be``` -- as an alias for ```beIdenticalTo```. 

As always, looking forward to feedback. Thanks!