### PR TITLE
[WIP] Swift 2.2

### DIFF
--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -13,7 +13,7 @@ private enum ErrorResult {
 internal class NMBWait: NSObject {
     internal class func until(
         timeout timeout: NSTimeInterval,
-        file: String = __FILE__,
+        file: FileString = __FILE__,
         line: UInt = __LINE__,
         action: (() -> Void) -> Void) -> Void {
             return throwableUntil(timeout: timeout, file: file, line: line) { (done: () -> Void) throws -> Void in
@@ -24,7 +24,7 @@ internal class NMBWait: NSObject {
     // Using a throwable closure makes this method not objc compatible.
     internal class func throwableUntil(
         timeout timeout: NSTimeInterval,
-        file: String = __FILE__,
+        file: FileString = __FILE__,
         line: UInt = __LINE__,
         action: (() -> Void) throws -> Void) -> Void {
             let awaiter = NimbleEnvironment.activeInstance.awaiter
@@ -71,7 +71,7 @@ internal class NMBWait: NSObject {
     }
 
     @objc(untilFile:line:action:)
-    internal class func until(file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    internal class func until(file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
 }
@@ -87,7 +87,7 @@ internal func blockedRunLoopErrorMessageFor(fnName: String, leeway: NSTimeInterv
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-public func waitUntil(timeout timeout: NSTimeInterval = 1, file: String = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 #endif

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -72,6 +72,7 @@ internal class NMBWait: NSObject {
 
     @objc(untilFile:line:action:)
     internal class func until(file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+		// TODO: `StaticString` is not available in Objective-C!
         until(timeout: 1, file: file, line: line, action: action)
     }
 }

--- a/Sources/Nimble/ObjCExpectation.swift
+++ b/Sources/Nimble/ObjCExpectation.swift
@@ -24,11 +24,11 @@ internal struct ObjCMatcherWrapper : Matcher {
 public class NMBExpectation : NSObject {
     internal let _actualBlock: () -> NSObject!
     internal var _negative: Bool
-    internal let _file: String
+    internal let _file: FileString
     internal let _line: UInt
     internal var _timeout: NSTimeInterval = 1.0
 
-    public init(actualBlock: () -> NSObject!, negative: Bool, file: String, line: UInt) {
+    public init(actualBlock: () -> NSObject!, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock
         self._negative = negative
         self._file = file
@@ -123,7 +123,7 @@ public class NMBExpectation : NSObject {
 
     public var toNotEventuallyWithDescription: (NMBMatcher, String) -> Void { return toEventuallyNotWithDescription }
 
-    public class func failWithMessage(message: String, file: String, line: UInt) {
+    public class func failWithMessage(message: String, file: FileString, line: UInt) {
         fail(message, location: SourceLocation(file: file, line: line))
     }
 }

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -6,7 +6,7 @@ public typealias FileString = String
 public typealias FileString = StaticString
 #endif
 
-public class SourceLocation : NSObject {
+public final class SourceLocation : NSObject {
     public let file: FileString
     public let line: UInt
 

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -1,10 +1,6 @@
 import Foundation
 
-#if _runtime(_ObjC)
-public typealias FileString = String
-#else
 public typealias FileString = StaticString
-#endif
 
 public final class SourceLocation : NSObject {
     public let file: FileString


### PR DESCRIPTION
I've changed all types for `__FILE__` to `FileString`, and it made that always `StaticString` to match `XCTest`.

This was originally brought up in #242: `XCTest` methods now take `StaticString` (see apple/swift#888 for details). Unfortunately this won't compile now because `StaticString` is not available in Objective-C!