### PR TITLE
Added @warn_unused_result to expect()

### DIFF
--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
+@warn_unused_result(message="expect(…) should be followed by .to(…)")
 public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
@@ -10,6 +11,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
+@warn_unused_result(message="expect(…) should be followed by .to(…)")
 public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-@warn_unused_result(message="expect(…) should be followed by .to(…)")
+@warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
 public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
     return Expectation(
         expression: Expression(
@@ -11,7 +11,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 }
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
-@warn_unused_result(message="expect(…) should be followed by .to(…)")
+@warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
 public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(


### PR DESCRIPTION
This prevents people for forgetting to attach matchers to their expectations, e.g. this causes a compiler warning:

    expect(dingbat.isFunky)