### PR TITLE
Breaking Change: Remove FullMatcherFunc and it's usages.

### DIFF
--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -1,15 +1,9 @@
 import Foundation
 
-internal func matcherWithFailureMessage<T, M: Matcher where M.ValueType == T>(matcher: M, postprocessor: (FailureMessage) -> Void) -> FullMatcherFunc<T> {
-    return FullMatcherFunc { actualExpression, failureMessage, isNegation in
-        let pass: Bool
-        if isNegation {
-            pass = try matcher.doesNotMatch(actualExpression, failureMessage: failureMessage)
-        } else {
-            pass = try matcher.matches(actualExpression, failureMessage: failureMessage)
-        }
-        postprocessor(failureMessage)
-        return pass
+internal func matcherWithFailureMessage<T>(matcher: NonNilMatcherFunc<T>, postprocessor: (FailureMessage) -> Void) -> NonNilMatcherFunc<T> {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        defer { postprocessor(failureMessage) }
+        return try matcher.matcher(actualExpression, failureMessage)
     }
 }
 
@@ -17,7 +11,7 @@ internal func matcherWithFailureMessage<T, M: Matcher where M.ValueType == T>(ma
 
 /// A Nimble matcher that succeeds when the actual value is exactly true.
 /// This matcher will not match against nils.
-public func beTrue() -> FullMatcherFunc<Bool> {
+public func beTrue() -> NonNilMatcherFunc<Bool> {
     return matcherWithFailureMessage(equal(true)) { failureMessage in
         failureMessage.postfixMessage = "be true"
     }
@@ -25,7 +19,7 @@ public func beTrue() -> FullMatcherFunc<Bool> {
 
 /// A Nimble matcher that succeeds when the actual value is exactly false.
 /// This matcher will not match against nils.
-public func beFalse() -> FullMatcherFunc<Bool> {
+public func beFalse() -> NonNilMatcherFunc<Bool> {
     return matcherWithFailureMessage(equal(false)) { failureMessage in
         failureMessage.postfixMessage = "be false"
     }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -30,10 +30,6 @@ public func ||<T>(left: NonNilMatcherFunc<T>, right: NonNilMatcherFunc<T>) -> No
     return satisfyAnyOf(left, right)
 }
 
-public func ||<T>(left: FullMatcherFunc<T>, right: FullMatcherFunc<T>) -> NonNilMatcherFunc<T> {
-    return satisfyAnyOf(left, right)
-}
-
 public func ||<T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> NonNilMatcherFunc<T> {
     return satisfyAnyOf(left, right)
 }

--- a/Sources/Nimble/Wrappers/MatcherFunc.swift
+++ b/Sources/Nimble/Wrappers/MatcherFunc.swift
@@ -1,29 +1,3 @@
-/// A convenience API to build matchers that allow full control over
-/// to() and toNot() match cases.
-///
-/// The final bool argument in the closure is if the match is for negation.
-///
-/// You may use this when implementing your own custom matchers.
-///
-/// Use the Matcher protocol instead of this type to accept custom matchers as
-/// input parameters.
-/// @see allPass for an example that uses accepts other matchers as input.
-public struct FullMatcherFunc<T>: Matcher {
-    public let matcher: (Expression<T>, FailureMessage, Bool) throws -> Bool
-
-    public init(_ matcher: (Expression<T>, FailureMessage, Bool) throws -> Bool) {
-        self.matcher = matcher
-    }
-
-    public func matches(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
-        return try matcher(actualExpression, failureMessage, false)
-    }
-
-    public func doesNotMatch(actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
-        return try matcher(actualExpression, failureMessage, true)
-    }
-}
-
 /// A convenience API to build matchers that don't need special negation
 /// behavior. The toNot() behavior is the negation of to().
 ///


### PR DESCRIPTION
A relic of a bygone era.

FullMatcherFunc existed when to(), toNot(), toEventually(), and toEventuallyNot() were matchers. The goal is to migrate these functions away from being matchers.

-----

I think the longer term goal is to remove the `Matcher` Protocol Associated Type with just a MatcherFunc type that wraps a closure. The goal is to move more towards how [gomega](https://onsi.github.io/gomega/#a-custom-matcher-representjsonifiedobjectexpected-interface) defines it's matcher interface. This allows us to build combinators with arbitrary matchers instead of matchers of the same type.