### PR TITLE
Allow setting custom defaults for async timeout and poll interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,19 @@ pollution for whatever incomplete code that was running on the main thread.
 Blocking the main thread can be caused by blocking IO, calls to sleep(),
 deadlocks, and synchronous IPC.
 
+In some cases (e.g. when running on slower machines) it can be useful to modify
+the default timeout and poll interval values. This can be done as follows:
+
+```swift
+// Swift
+
+// Increase the global timeout to 5 seconds:
+Nimble.Defaults.AsyncTimeout = 5
+
+// Slow the polling interval to 0.1 seconds:
+Nimble.Defaults.AsyncPollInterval = 0.1
+```
+
 ## Objective-C Support
 
 Nimble has full support for Objective-C. However, there are two things

--- a/Sources/Nimble/Wrappers/AsyncMatcherWrapper.swift
+++ b/Sources/Nimble/Wrappers/AsyncMatcherWrapper.swift
@@ -2,12 +2,17 @@ import Foundation
 
 #if _runtime(_ObjC)
 
+public struct AsyncDefaults {
+    public static var Timeout: NSTimeInterval = 1
+    public static var PollInterval: NSTimeInterval = 0.01
+}
+
 internal struct AsyncMatcherWrapper<T, U where U: Matcher, U.ValueType == T>: Matcher {
     let fullMatcher: U
     let timeoutInterval: NSTimeInterval
     let pollInterval: NSTimeInterval
 
-    init(fullMatcher: U, timeoutInterval: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01) {
+    init(fullMatcher: U, timeoutInterval: NSTimeInterval = AsyncDefaults.Timeout, pollInterval: NSTimeInterval = AsyncDefaults.PollInterval) {
       self.fullMatcher = fullMatcher
       self.timeoutInterval = timeoutInterval
       self.pollInterval = pollInterval
@@ -79,7 +84,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01, description: String? = nil) {
+    public func toEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = AsyncDefaults.Timeout, pollInterval: NSTimeInterval = AsyncDefaults.PollInterval, description: String? = nil) {
         if expression.isClosure {
             let (pass, msg) = expressionMatches(
                 expression,
@@ -102,7 +107,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01, description: String? = nil) {
+    public func toEventuallyNot<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = AsyncDefaults.Timeout, pollInterval: NSTimeInterval = AsyncDefaults.PollInterval, description: String? = nil) {
         if expression.isClosure {
             let (pass, msg) = expressionDoesNotMatch(
                 expression,
@@ -127,7 +132,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toNotEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = 1, pollInterval: NSTimeInterval = 0.01, description: String? = nil) {
+    public func toNotEventually<U where U: Matcher, U.ValueType == T>(matcher: U, timeout: NSTimeInterval = AsyncDefaults.Timeout, pollInterval: NSTimeInterval = AsyncDefaults.PollInterval, description: String? = nil) {
         return toEventuallyNot(matcher, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 }

--- a/Sources/NimbleTests/AsynchronousTest.swift
+++ b/Sources/NimbleTests/AsynchronousTest.swift
@@ -10,6 +10,7 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
             ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
             ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
             ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
+            ("testToEventuallyWithCustomDefaultTimeout", testToEventuallyWithCustomDefaultTimeout),
             ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
             ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
             ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
@@ -50,6 +51,27 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to eventually not equal <0>, got an unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.toEventuallyNot(equal(0))
         }
+    }
+
+    func testToEventuallyWithCustomDefaultTimeout() {
+        AsyncDefaults.Timeout = 2
+        defer {
+            AsyncDefaults.Timeout = 1
+        }
+
+        var value = 0
+
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            NSThread.sleepForTimeInterval(1.1)
+            value = 1
+        }
+        expect { value }.toEventually(equal(1))
+
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            NSThread.sleepForTimeInterval(1.1)
+            value = 0
+        }
+        expect { value }.toEventuallyNot(equal(1))
     }
 
     func testWaitUntilPositiveMatches() {


### PR DESCRIPTION
Fixes: #255 

In some cases (e.g. when running on slower machines) it can be useful to modify the default timeout and poll interval values like this:

```swift
// Swift

// Increase the global timeout to 5 seconds:
Nimble.Defaults.AsyncTimeout = 5

// Slow the polling interval to 0.1 seconds:
Nimble.Defaults.AsyncPollInterval = 0.1
```
