### PR TITLE
Print NSData's hash instead of byte description in error messages

### DIFF
--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -54,6 +54,13 @@ internal func stringify<S: SequenceType>(value: S) -> String {
 internal func stringify<T>(value: T) -> String {
     if let value = value as? Double {
         return NSString(format: "%.4f", (value)).description
+    } else if let value = value as? NSData {
+#if os(Linux)
+        // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11)
+        return "NSData<length=\(value.length)>"
+#else
+        return "NSData<hash=\(value.hash),length=\(value.length)>"
+#endif
     }
     return String(value)
 }

--- a/Tests/Nimble/Matchers/EqualTest.swift
+++ b/Tests/Nimble/Matchers/EqualTest.swift
@@ -10,6 +10,7 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
             ("testSetEquality", testSetEquality),
             ("testDoesNotMatchNils", testDoesNotMatchNils),
             ("testDictionaryEquality", testDictionaryEquality),
+            ("testDataEquality", testDataEquality),
             ("testNSObjectEquality", testNSObjectEquality),
             ("testOperatorEquality", testOperatorEquality),
             ("testOperatorEqualityWithArrays", testOperatorEqualityWithArrays),
@@ -136,6 +137,27 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(["foo": "bar"]))
         expect(NSDictionary(object: "bar", forKey: "foo")).to(equal(expected))
 #endif
+    }
+
+    func testDataEquality() {
+        let actual = "foobar".dataUsingEncoding(NSUTF8StringEncoding)
+        let expected = "foobar".dataUsingEncoding(NSUTF8StringEncoding)
+        let unexpected = "foobarfoo".dataUsingEncoding(NSUTF8StringEncoding)
+
+        expect(actual).to(equal(expected))
+        expect(actual).toNot(equal(unexpected))
+
+        #if os(Linux)
+            // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11)
+            let expectedErrorMessage = "expected to equal <NSData<length=9>>, got <NSData<length=6>>"
+        #else
+            let expectedErrorMessage = "expected to equal <NSData<hash=92856895,length=9>>,"
+                + " got <NSData<hash=114710658,length=6>>"
+        #endif
+
+        failsWithErrorMessage(expectedErrorMessage) {
+            expect(actual).to(equal(unexpected))
+        }
     }
 
     func testNSObjectEquality() {


### PR DESCRIPTION
closes https://github.com/Quick/Nimble/issues/259

Printing the byte description of a 1MB NSData is long enough to keep printing for a while, and to freeze Xcode because of the length of the resulting message.

Print "NSData<hash>" instead as it's a decent representation of identity/equality (although not perfect).