### PR TITLE
make stringify public

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -275,6 +275,15 @@
 		7B5358C01C38479700A23FAA /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */; };
 		7B5358C51C39184200A23FAA /* ObjCSatisfyAnyOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */; };
 		7B5358C61C39184200A23FAA /* ObjCSatisfyAnyOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */; };
+		8DF1C3F01C94F7D4004B2D36 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DF1C3EE1C94F7D4004B2D36 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DF1C3F11C94F7D4004B2D36 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DF1C3EE1C94F7D4004B2D36 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DF1C3F21C94F7D4004B2D36 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DF1C3EE1C94F7D4004B2D36 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DF1C3F31C94F7D4004B2D36 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3EF1C94F7D4004B2D36 /* NMBStringify.m */; };
+		8DF1C3F41C94F7D4004B2D36 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3EF1C94F7D4004B2D36 /* NMBStringify.m */; };
+		8DF1C3F51C94F7D4004B2D36 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3EF1C94F7D4004B2D36 /* NMBStringify.m */; };
+		8DF1C3F71C94FC75004B2D36 /* ObjcStringersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */; };
+		8DF1C3F81C94FC75004B2D36 /* ObjcStringersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */; };
+		8DF1C3F91C94FD0C004B2D36 /* ObjcStringersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */; };
 		965B0D091B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0A1B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0C1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
@@ -469,6 +478,9 @@
 		7B5358B91C3846C900A23FAA /* SatisfyAnyOfTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SatisfyAnyOfTest.swift; sourceTree = "<group>"; };
 		7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSatisfyAnyOfTest.m; sourceTree = "<group>"; };
+		8DF1C3EE1C94F7D4004B2D36 /* NMBStringify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NMBStringify.h; sourceTree = "<group>"; };
+		8DF1C3EF1C94F7D4004B2D36 /* NMBStringify.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NMBStringify.m; sourceTree = "<group>"; };
+		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
 		965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCUserDescriptionTest.m; sourceTree = "<group>"; };
 		965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDescriptionTest.swift; sourceTree = "<group>"; };
 		AEBA646F1C5C5FD10060A057 /* CurrentTestCaseTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CurrentTestCaseTracker.m; sourceTree = "<group>"; };
@@ -696,6 +708,8 @@
 				1FD8CD211968AB07008ED995 /* DSL.m */,
 				1FD8CD221968AB07008ED995 /* NMBExceptionCapture.h */,
 				1FD8CD231968AB07008ED995 /* NMBExceptionCapture.m */,
+				8DF1C3EE1C94F7D4004B2D36 /* NMBStringify.h */,
+				8DF1C3EF1C94F7D4004B2D36 /* NMBStringify.m */,
 				AEBA646F1C5C5FD10060A057 /* CurrentTestCaseTracker.m */,
 			);
 			path = objc;
@@ -752,6 +766,7 @@
 				965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */,
 				DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */,
 				7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */,
+				8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */,
 			);
 			path = objc;
 			sourceTree = "<group>";
@@ -763,6 +778,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8DF1C3F01C94F7D4004B2D36 /* NMBStringify.h in Headers */,
 				1FD8CD601968AB07008ED995 /* DSL.h in Headers */,
 				1FD8CD641968AB07008ED995 /* NMBExceptionCapture.h in Headers */,
 				1F1A742F1940169200FFFC47 /* Nimble.h in Headers */,
@@ -773,6 +789,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8DF1C3F21C94F7D4004B2D36 /* NMBStringify.h in Headers */,
 				1F5DF1AF1BDCA17600C3A531 /* DSL.h in Headers */,
 				1F5DF1B01BDCA17600C3A531 /* NMBExceptionCapture.h in Headers */,
 				1F5DF1AE1BDCA17600C3A531 /* Nimble.h in Headers */,
@@ -783,6 +800,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8DF1C3F11C94F7D4004B2D36 /* NMBStringify.h in Headers */,
 				1FD8CD611968AB07008ED995 /* DSL.h in Headers */,
 				1FD8CD651968AB07008ED995 /* NMBExceptionCapture.h in Headers */,
 				1F925EC7195C0DD100ED456B /* Nimble.h in Headers */,
@@ -1019,6 +1037,7 @@
 				1FD8CD4E1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
 				1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728A1A1B343800EB80F8 /* Functional.swift in Sources */,
+				8DF1C3F31C94F7D4004B2D36 /* NMBStringify.m in Sources */,
 				AEBA64701C5C5FD10060A057 /* CurrentTestCaseTracker.m in Sources */,
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -1073,6 +1092,7 @@
 				DDB4D5F019FE442800E9D9FE /* MatchTest.swift in Sources */,
 				1F4A56731A3B3210009E1637 /* ObjCBeginWithTest.m in Sources */,
 				1F4A56821A3B336F009E1637 /* ObjCBeLessThanOrEqualToTest.m in Sources */,
+				8DF1C3F71C94FC75004B2D36 /* ObjcStringersTest.m in Sources */,
 				1F925F02195C189500ED456B /* ContainTest.swift in Sources */,
 				1F4A56881A3B33CB009E1637 /* ObjCBeFalsyTest.m in Sources */,
 				1F4A568E1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */,
@@ -1134,6 +1154,7 @@
 				1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */,
 				1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */,
 				1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */,
+				8DF1C3F51C94F7D4004B2D36 /* NMBStringify.m in Sources */,
 				AEBA64721C5C5FD10060A057 /* CurrentTestCaseTracker.m in Sources */,
 				1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */,
 				1F5DF1811BDCA0F500C3A531 /* BeLogical.swift in Sources */,
@@ -1203,6 +1224,7 @@
 				1F5DF1A41BDCA10200C3A531 /* BeNilTest.swift in Sources */,
 				347155CC1C337C8900549F03 /* XCTestCaseProvider.swift in Sources */,
 				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
+				8DF1C3F91C94FD0C004B2D36 /* ObjcStringersTest.m in Sources */,
 				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
 				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F91DD2F1C74BF36002C309F /* BeVoidTest.swift in Sources */,
@@ -1223,6 +1245,7 @@
 				1FD8CD4F1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
 				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				1F43728B1A1B343900EB80F8 /* Functional.swift in Sources */,
+				8DF1C3F41C94F7D4004B2D36 /* NMBStringify.m in Sources */,
 				AEBA64711C5C5FD10060A057 /* CurrentTestCaseTracker.m in Sources */,
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -1277,6 +1300,7 @@
 				DDB4D5F119FE442800E9D9FE /* MatchTest.swift in Sources */,
 				1F4A56741A3B3210009E1637 /* ObjCBeginWithTest.m in Sources */,
 				1F4A56831A3B336F009E1637 /* ObjCBeLessThanOrEqualToTest.m in Sources */,
+				8DF1C3F81C94FC75004B2D36 /* ObjcStringersTest.m in Sources */,
 				1F925F03195C189500ED456B /* ContainTest.swift in Sources */,
 				1F4A56891A3B33CB009E1637 /* ObjCBeFalsyTest.m in Sources */,
 				1F4A568F1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */,

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -7,8 +7,8 @@ internal let DefaultDelta = 0.0001
 
 internal func isCloseTo(actualValue: NMBDoubleConvertible?, expectedValue: NMBDoubleConvertible, delta: Double, failureMessage: FailureMessage) -> Bool {
     failureMessage.postfixMessage = "be close to <\(stringify(expectedValue))> (within \(stringify(delta)))"
-    if actualValue != nil {
-        failureMessage.actualValue = "<\(stringify(actualValue!))>"
+    if let actualValue = actualValue {
+        failureMessage.actualValue = "<\(stringify(actualValue))>"
     } else {
         failureMessage.actualValue = "<nil>"
     }

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -7,11 +7,7 @@ internal let DefaultDelta = 0.0001
 
 internal func isCloseTo(actualValue: NMBDoubleConvertible?, expectedValue: NMBDoubleConvertible, delta: Double, failureMessage: FailureMessage) -> Bool {
     failureMessage.postfixMessage = "be close to <\(stringify(expectedValue))> (within \(stringify(delta)))"
-    if let actualValue = actualValue {
-        failureMessage.actualValue = "<\(stringify(actualValue))>"
-    } else {
-        failureMessage.actualValue = "<nil>"
-    }
+    failureMessage.actualValue = "<\(stringify(actualValue))>"
     return actualValue != nil && abs(actualValue!.doubleValue - expectedValue.doubleValue) < delta
 }
 

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -109,24 +109,9 @@ extension NSDate: NMBDoubleConvertible {
 }
 #endif
 
-
-extension NMBDoubleConvertible {
-    public var stringRepresentation: String {
-        get {
-            if let date = self as? NSDate {
-                return dateFormatter.stringFromDate(date)
-            }
-            
-            if let debugStringConvertible = self as? CustomDebugStringConvertible {
-                return debugStringConvertible.debugDescription
-            }
-            
-            if let stringConvertible = self as? CustomStringConvertible {
-                return stringConvertible.description
-            }
-            
-            return ""
-        }
+extension NSDate: Stringifiable {
+    public var stringify: String {
+        return dateFormatter.stringFromDate(self)
     }
 }
 

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -109,8 +109,8 @@ extension NSDate: NMBDoubleConvertible {
 }
 #endif
 
-extension NSDate: Stringifiable {
-    public var stringify: String {
+extension NSDate: TestOutputStringConvertible {
+    public var testDescription: String {
         return dateFormatter.stringFromDate(self)
     }
 }

--- a/Sources/Nimble/Nimble.h
+++ b/Sources/Nimble/Nimble.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "NMBExceptionCapture.h"
+#import "NMBStringify.h"
 #import "DSL.h"
 
 FOUNDATION_EXPORT double NimbleVersionNumber;

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -37,44 +37,100 @@ extension NSArray : NMBStringer {
 }
 #endif
 
-internal func stringify<S: SequenceType>(value: S) -> String {
-    var generator = value.generate()
-    var strings = [String]()
-    var value: S.Generator.Element?
-    repeat {
-        value = generator.next()
-        if value != nil {
-            strings.append(stringify(value))
-        }
-    } while value != nil
-    let str = strings.joinWithSeparator(", ")
-    return "[\(str)]"
+/// A type with a customized test output text representation.
+///
+/// This textual representation is produced when values will be
+/// printed in test runs, and may be useful when producing
+/// error messages in custom matchers.
+///
+/// - SeeAlso: `CustomDebugStringConvertible`
+public protocol Stringifiable {
+    var stringify: String { get }
 }
 
-internal func stringify<T>(value: T) -> String {
-    if let value = value as? Double {
-        return NSString(format: "%.4f", (value)).description
-    } else if let value = value as? NSData {
-#if os(Linux)
-        // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11)
-        return "NSData<length=\(value.length)>"
-#else
-        return "NSData<hash=\(value.hash),length=\(value.length)>"
-#endif
+extension Double: Stringifiable {
+    public var stringify: String {
+        // These are using `NSString(format:)` instead of 
+        // `String(format:)` because the latter somehow breaks
+        // the travis CI build on linux.
+        return NSString(format: "%0.4f", self).description
     }
+}
+
+extension Float: Stringifiable {
+    public var stringify: String {
+        return NSString(format: "%0.4f", self).description
+    }
+}
+
+extension NSNumber: Stringifiable {
+    public var stringify: String {
+        return NSString(format: "%0.4f", self.doubleValue).description
+    }
+}
+
+extension Array: Stringifiable {
+    public var stringify: String {
+        let list = self.map(Nimble.stringify).joinWithSeparator(", ")
+        return "[\(list)]"
+    }
+}
+
+extension NSArray: Stringifiable {
+    public var stringify: String {
+        return self.description
+    }
+}
+
+extension String: Stringifiable {
+    public var stringify: String {
+        return self
+    }
+}
+
+extension NSData: Stringifiable {
+    public var stringify: String {
+        #if os(Linux)
+            // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11-16)
+            return "NSData<length=\(self.length)>"
+        #else
+            return "NSData<hash=\(self.hash),length=\(self.length)>"
+        #endif
+    }
+}
+
+///
+/// Returns a string appropriate for displaying in test output
+/// from the provided value.
+///
+/// - parameter value: A value that will show up in a test's output.
+///
+/// - returns: The string that is returned can be
+///     customized per type by conforming a type to the `Stringifiable`
+///     protocol. When stringifying a non-`Stringifiable` type, this
+///     function will return the value's debug description and then its
+///     normal description if available and in that order. Otherwise it
+///     will return the result of constructing a string from the value.
+///
+/// - SeeAlso: `Stringifiable`
+@warn_unused_result
+public func stringify<T>(value: T) -> String {
+    if let value = value as? Stringifiable {
+        return value.stringify
+    }
+    
+    if let value = value as? CustomDebugStringConvertible {
+        return value.debugDescription
+    }
+    
     return String(value)
 }
 
-internal func stringify(value: NMBDoubleConvertible) -> String {
-    if let value = value as? Double {
-        return NSString(format: "%.4f", (value)).description
-    }
-    return value.stringRepresentation
-}
-
-internal func stringify<T>(value: T?) -> String {
+/// -SeeAlso: `stringify<T>(value: T)`
+@warn_unused_result
+public func stringify<T>(value: T?) -> String {
     if let unboxed = value {
-       return stringify(unboxed)
+        return stringify(unboxed)
     }
     return "nil"
 }

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -31,27 +31,27 @@ internal func arrayAsString<T>(items: [T], joiner: String = ", ") -> String {
 /// error messages in custom matchers.
 ///
 /// - SeeAlso: `CustomDebugStringConvertible`
-public protocol Stringifiable {
-    var stringify: String { get }
+public protocol TestOutputStringConvertible {
+    var testDescription: String { get }
 }
 
-extension Double: Stringifiable {
-    public var stringify: String {
-        return NSNumber(double: self).stringify
+extension Double: TestOutputStringConvertible {
+    public var testDescription: String {
+        return NSNumber(double: self).testDescription
     }
 }
 
-extension Float: Stringifiable {
-    public var stringify: String {
-        return NSNumber(float: self).stringify
+extension Float: TestOutputStringConvertible {
+    public var testDescription: String {
+        return NSNumber(float: self).testDescription
     }
 }
 
-extension NSNumber: Stringifiable {
+extension NSNumber: TestOutputStringConvertible {
     // This is using `NSString(format:)` instead of
     // `String(format:)` because the latter somehow breaks
     // the travis CI build on linux.
-    public var stringify: String {
+    public var testDescription: String {
         let description = self.description
         
         if description.containsString(".") {
@@ -69,28 +69,28 @@ extension NSNumber: Stringifiable {
     }
 }
 
-extension Array: Stringifiable {
-    public var stringify: String {
+extension Array: TestOutputStringConvertible {
+    public var testDescription: String {
         let list = self.map(Nimble.stringify).joinWithSeparator(", ")
         return "[\(list)]"
     }
 }
 
-extension NSArray: Stringifiable {
-    public var stringify: String {
+extension NSArray: TestOutputStringConvertible {
+    public var testDescription: String {
         let list = Array(self).map(Nimble.stringify).joinWithSeparator(", ")
         return "(\(list))"
     }
 }
 
-extension String: Stringifiable {
-    public var stringify: String {
+extension String: TestOutputStringConvertible {
+    public var testDescription: String {
         return self
     }
 }
 
-extension NSData: Stringifiable {
-    public var stringify: String {
+extension NSData: TestOutputStringConvertible {
+    public var testDescription: String {
         #if os(Linux)
             // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11-16)
             return "NSData<length=\(self.length)>"
@@ -107,17 +107,17 @@ extension NSData: Stringifiable {
 /// - parameter value: A value that will show up in a test's output.
 ///
 /// - returns: The string that is returned can be
-///     customized per type by conforming a type to the `Stringifiable`
-///     protocol. When stringifying a non-`Stringifiable` type, this
+///     customized per type by conforming a type to the `TestOutputStringConvertible`
+///     protocol. When stringifying a non-`TestOutputStringConvertible` type, this
 ///     function will return the value's debug description and then its
 ///     normal description if available and in that order. Otherwise it
 ///     will return the result of constructing a string from the value.
 ///
-/// - SeeAlso: `Stringifiable`
+/// - SeeAlso: `TestOutputStringConvertible`
 @warn_unused_result
 public func stringify<T>(value: T) -> String {
-    if let value = value as? Stringifiable {
-        return value.stringify
+    if let value = value as? TestOutputStringConvertible {
+        return value.testDescription
     }
     
     if let value = value as? CustomDebugStringConvertible {

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -76,6 +76,24 @@ extension Array: TestOutputStringConvertible {
     }
 }
 
+extension AnySequence: TestOutputStringConvertible {
+    public var testDescription: String {
+        let generator = self.generate()
+        var strings = [String]()
+        var value: AnySequence.Generator.Element?
+        
+        repeat {
+            value = generator.next()
+            if let value = value {
+                strings.append(stringify(value))
+            }
+        } while value != nil
+        
+        let list = strings.joinWithSeparator(", ")
+        return "[\(list)]"
+    }
+}
+
 extension NSArray: TestOutputStringConvertible {
     public var testDescription: String {
         let list = Array(self).map(Nimble.stringify).joinWithSeparator(", ")

--- a/Sources/Nimble/objc/NMBStringify.h
+++ b/Sources/Nimble/objc/NMBStringify.h
@@ -1,3 +1,18 @@
 @class NSString;
 
+/**
+ * Returns a string appropriate for displaying in test output
+ * from the provided value.
+ *
+ * @param value A value that will show up in a test's output.
+ *
+ * @return The string that is returned can be
+ *     customized per type by conforming a type to the `TestOutputStringConvertible`
+ *     protocol. When stringifying a non-`TestOutputStringConvertible` type, this
+ *     function will return the value's debug description and then its
+ *     normal description if available and in that order. Otherwise it
+ *     will return the result of constructing a string from the value.
+ *
+ * @see `TestOutputStringConvertible`
+ */
 extern NSString *_Nonnull NMBStringify(id _Nullable anyObject) __attribute__((warn_unused_result));

--- a/Sources/Nimble/objc/NMBStringify.h
+++ b/Sources/Nimble/objc/NMBStringify.h
@@ -1,0 +1,3 @@
+@class NSString;
+
+extern NSString *_Nonnull NMBStringify(id _Nullable anyObject) __attribute__((warn_unused_result));

--- a/Sources/Nimble/objc/NMBStringify.m
+++ b/Sources/Nimble/objc/NMBStringify.m
@@ -1,0 +1,6 @@
+#import "NMBStringify.h"
+#import <Nimble/Nimble-Swift.h>
+
+NSString *_Nonnull NMBStringify(id _Nullable anyObject) {
+    return [NMBStringer stringify:anyObject];
+}

--- a/Tests/Nimble/Matchers/BeCloseToTest.swift
+++ b/Tests/Nimble/Matchers/BeCloseToTest.swift
@@ -38,13 +38,8 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(NSNumber(double:1.2)).to(beCloseTo(9.300, within: 10))
         expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
         expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
-
-#if _runtime(_ObjC)
-        let expectedRepresentation = "1.2000"
-#else
-        let expectedRepresentation = "1.2"
-#endif
-        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <\(expectedRepresentation)>") {
+        
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
             expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }

--- a/Tests/Nimble/Matchers/BeCloseToTest.swift
+++ b/Tests/Nimble/Matchers/BeCloseToTest.swift
@@ -21,7 +21,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2 as CDouble).to(beCloseTo(1.2001))
         expect(1.2 as Float).to(beCloseTo(1.2001))
 
-        failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2000>") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2>") {
             expect(1.2).toNot(beCloseTo(1.2001))
         }
     }
@@ -29,7 +29,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
     func testBeCloseToWithin() {
         expect(1.2).to(beCloseTo(9.300, within: 10))
 
-        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1), got <1.2>") {
             expect(1.2).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }
@@ -39,7 +39,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(NSNumber(double:1.2)).to(beCloseTo(NSNumber(double:9.300), within: 10))
         expect(1.2).to(beCloseTo(NSNumber(double:9.300), within: 10))
         
-        failsWithErrorMessage("expected to not be close to <1.2001> (within 1.0000), got <1.2000>") {
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1), got <1.2>") {
             expect(NSNumber(double:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }
@@ -48,7 +48,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
 #if _runtime(_ObjC) // NSDateFormatter isn't functional in swift-corelibs-foundation yet.
         expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
         
-        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.0040), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
 
             let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
             expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
@@ -60,7 +60,7 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2) ≈ 1.2001
         expect(1.2 as CDouble) ≈ 1.2001
         
-        failsWithErrorMessage("expected to be close to <1.2002> (within 0.0001), got <1.2000>") {
+        failsWithErrorMessage("expected to be close to <1.2002> (within 0.0001), got <1.2>") {
             expect(1.2) ≈ 1.2002
         }
     }
@@ -69,10 +69,10 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2) ≈ (9.300, 10)
         expect(1.2) == (9.300, 10)
         
-        failsWithErrorMessage("expected to be close to <1.0000> (within 0.1000), got <1.2000>") {
+        failsWithErrorMessage("expected to be close to <1> (within 0.1), got <1.2>") {
             expect(1.2) ≈ (1.0, 0.1)
         }
-        failsWithErrorMessage("expected to be close to <1.0000> (within 0.1000), got <1.2000>") {
+        failsWithErrorMessage("expected to be close to <1> (within 0.1), got <1.2>") {
             expect(1.2) == (1.0, 0.1)
         }
     }
@@ -81,10 +81,10 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2) ≈ 9.300 ± 10
         expect(1.2) == 9.300 ± 10
         
-        failsWithErrorMessage("expected to be close to <1.0000> (within 0.1000), got <1.2000>") {
+        failsWithErrorMessage("expected to be close to <1> (within 0.1), got <1.2>") {
             expect(1.2) ≈ 1.0 ± 0.1
         }
-        failsWithErrorMessage("expected to be close to <1.0000> (within 0.1000), got <1.2000>") {
+        failsWithErrorMessage("expected to be close to <1> (within 0.1), got <1.2>") {
             expect(1.2) == 1.0 ± 0.1
         }
     }
@@ -93,10 +93,10 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect([0.0, 1.1, 2.2]) ≈ [0.0001, 1.1001, 2.2001]
         expect([0.0, 1.1, 2.2]).to(beCloseTo([0.1, 1.2, 2.3], within: 0.1))
         
-        failsWithErrorMessage("expected to be close to <[0.0000, 1.0000]> (each within 0.0001), got <[0.0000, 1.1000]>") {
+        failsWithErrorMessage("expected to be close to <[0, 1]> (each within 0.0001), got <[0, 1.1]>") {
             expect([0.0, 1.1]) ≈ [0.0, 1.0]
         }
-        failsWithErrorMessage("expected to be close to <[0.2000, 1.2000]> (each within 0.1000), got <[0.0000, 1.1000]>") {
+        failsWithErrorMessage("expected to be close to <[0.2, 1.2]> (each within 0.1), got <[0, 1.1]>") {
             expect([0.0, 1.1]).to(beCloseTo([0.2, 1.2], within: 0.1))
         }
     }

--- a/Tests/Nimble/Matchers/BeGreaterThanTest.swift
+++ b/Tests/Nimble/Matchers/BeGreaterThanTest.swift
@@ -38,13 +38,7 @@ class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
 #if _runtime(_ObjC)
         expect(NSNumber(int:1)) > 0
 #endif
-
-#if _runtime(_ObjC)
-        let (expectedRepresentation, actualRepresentation) = ("2.0000", "1.0000")
-#else
-        let (expectedRepresentation, actualRepresentation) = ("2", "1")
-#endif
-        failsWithErrorMessage("expected to be greater than <\(expectedRepresentation)>, got <\(actualRepresentation)>") {
+        failsWithErrorMessage("expected to be greater than <2>, got <1>") {
             expect(1) > 2
             return
         }

--- a/Tests/Nimble/Matchers/BeLessThanTest.swift
+++ b/Tests/Nimble/Matchers/BeLessThanTest.swift
@@ -41,13 +41,7 @@ class BeLessThanTest: XCTestCase, XCTestCaseProvider {
 #if _runtime(_ObjC)
         expect(NSNumber(int:0)) < 1
 #endif
-
-#if _runtime(_ObjC)
-        let (expectedRepresentation, actualRepresentation) = ("1.0000", "2.0000")
-#else
-        let (expectedRepresentation, actualRepresentation) = ("1", "2")
-#endif
-        failsWithErrorMessage("expected to be less than <\(expectedRepresentation)>, got <\(actualRepresentation)>") {
+        failsWithErrorMessage("expected to be less than <1>, got <2>") {
             expect(2) < 1
             return
         }

--- a/Tests/Nimble/Matchers/ContainTest.swift
+++ b/Tests/Nimble/Matchers/ContainTest.swift
@@ -25,10 +25,10 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
         expect(NSArray(object: 1) as NSArray?).to(contain(1))
 #endif
 
-        failsWithErrorMessage("expected to contain <bar>, got <[\"a\", \"b\", \"c\"]>") {
+        failsWithErrorMessage("expected to contain <bar>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).to(contain("bar"))
         }
-        failsWithErrorMessage("expected to not contain <b>, got <[\"a\", \"b\", \"c\"]>") {
+        failsWithErrorMessage("expected to not contain <b>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).toNot(contain("b"))
         }
 
@@ -66,11 +66,11 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
         expect([1, 2, 3]).to(contain(1, 2))
         expect([1, 2, 3]).toNot(contain(1, 4))
 
-        failsWithErrorMessage("expected to contain <a, bar>, got <[\"a\", \"b\", \"c\"]>") {
+        failsWithErrorMessage("expected to contain <a, bar>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).to(contain("a", "bar"))
         }
 
-        failsWithErrorMessage("expected to not contain <bar, b>, got <[\"a\", \"b\", \"c\"]>") {
+        failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).toNot(contain("bar", "b"))
         }
     }

--- a/Tests/Nimble/Matchers/SatisfyAnyOfTest.swift
+++ b/Tests/Nimble/Matchers/SatisfyAnyOfTest.swift
@@ -33,7 +33,7 @@ class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
                 expect(false).to(satisfyAnyOf(beTrue()))
         }
         failsWithErrorMessage(
-            "expected to not match one of: {be less than <10.5000>}, or {be greater than <100.7500>}, or {be close to <50.1000> (within 0.0001)}, got 50.10001") {
+            "expected to not match one of: {be less than <10.5>}, or {be greater than <100.75>}, or {be close to <50.1> (within 0.0001)}, got 50.10001") {
                 expect(50.10001).toNot(satisfyAnyOf(beLessThan(10.5), beGreaterThan(100.75), beCloseTo(50.1)))
         }
     }

--- a/Tests/Nimble/objc/ObjCAllPassTest.m
+++ b/Tests/Nimble/objc/ObjCAllPassTest.m
@@ -16,22 +16,22 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to all be less than <3.0000>, but failed first at element"
-                         " <3.0000> in <[1.0000, 2.0000, 3.0000, 4.0000]>", ^{
+    expectFailureMessage(@"expected to all be less than <3>, but failed first at element"
+                         " <3> in <[1, 2, 3, 4]>", ^{
                              expect(@[@1, @2, @3,@4]).to(allPass(beLessThan(@3)));
                          });
-    expectFailureMessage(@"expected to not all be less than <5.0000>", ^{
+    expectFailureMessage(@"expected to not all be less than <5>", ^{
         expect(@[@1, @2, @3,@4]).toNot(allPass(beLessThan(@5)));
     });
-    expectFailureMessage(@"expected to not all be less than <5.0000>", ^{
+    expectFailureMessage(@"expected to not all be less than <5>", ^{
         expect([NSSet setWithArray:@[@1, @2, @3,@4]]).toNot(allPass(beLessThan(@5)));
     });
     expectFailureMessage(@"allPass only works with NSFastEnumeration"
-                         " (NSArray, NSSet, ...) of NSObjects, got <3.0000>", ^{
+                         " (NSArray, NSSet, ...) of NSObjects, got <3>", ^{
                              expect(@3).to(allPass(beLessThan(@5)));
                          });
     expectFailureMessage(@"allPass only works with NSFastEnumeration"
-                         " (NSArray, NSSet, ...) of NSObjects, got <3.0000>", ^{
+                         " (NSArray, NSSet, ...) of NSObjects, got <3>", ^{
                              expect(@3).toNot(allPass(beLessThan(@5)));
                          });
 }

--- a/Tests/Nimble/objc/ObjCBeCloseToTest.m
+++ b/Tests/Nimble/objc/ObjCBeCloseToTest.m
@@ -15,19 +15,19 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be close to <0.0000> (within 0.0010), got <1.0000>", ^{
+    expectFailureMessage(@"expected to be close to <0> (within 0.001), got <1>", ^{
         expect(@1).to(beCloseTo(@0));
     });
-    expectFailureMessage(@"expected to not be close to <0.0000> (within 0.0010), got <0.0001>", ^{
+    expectFailureMessage(@"expected to not be close to <0> (within 0.001), got <0.0001>", ^{
         expect(@(0.0001)).toNot(beCloseTo(@0));
     });
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to be close to <0.0000> (within 0.0010), got <nil>", ^{
+    expectNilFailureMessage(@"expected to be close to <0> (within 0.001), got <nil>", ^{
         expect(nil).to(beCloseTo(@0));
     });
-    expectNilFailureMessage(@"expected to not be close to <0.0000> (within 0.0010), got <nil>", ^{
+    expectNilFailureMessage(@"expected to not be close to <0> (within 0.001), got <nil>", ^{
         expect(nil).toNot(beCloseTo(@0));
     });
 }

--- a/Tests/Nimble/objc/ObjCBeFalsyTest.m
+++ b/Tests/Nimble/objc/ObjCBeFalsyTest.m
@@ -17,10 +17,10 @@
     expectFailureMessage(@"expected to not be falsy, got <nil>", ^{
         expect(nil).toNot(beFalsy());
     });
-    expectFailureMessage(@"expected to be falsy, got <1.0000>", ^{
+    expectFailureMessage(@"expected to be falsy, got <1>", ^{
         expect(@1).to(beFalsy());
     });
-    expectFailureMessage(@"expected to be truthy, got <0.0000>", ^{
+    expectFailureMessage(@"expected to be truthy, got <0>", ^{
         expect(@NO).to(beTruthy());
     });
 }

--- a/Tests/Nimble/objc/ObjCBeGreaterThanOrEqualToTest.m
+++ b/Tests/Nimble/objc/ObjCBeGreaterThanOrEqualToTest.m
@@ -13,19 +13,19 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be greater than or equal to <0.0000>, got <-1.0000>", ^{
+    expectFailureMessage(@"expected to be greater than or equal to <0>, got <-1>", ^{
         expect(@(-1)).to(beGreaterThanOrEqualTo(@0));
     });
-    expectFailureMessage(@"expected to not be greater than or equal to <1.0000>, got <2.0000>", ^{
+    expectFailureMessage(@"expected to not be greater than or equal to <1>, got <2>", ^{
         expect(@2).toNot(beGreaterThanOrEqualTo(@(1)));
     });
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to be greater than or equal to <-1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to be greater than or equal to <-1>, got <nil>", ^{
         expect(nil).to(beGreaterThanOrEqualTo(@(-1)));
     });
-    expectNilFailureMessage(@"expected to not be greater than or equal to <1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to not be greater than or equal to <1>, got <nil>", ^{
         expect(nil).toNot(beGreaterThanOrEqualTo(@(1)));
     });
 }

--- a/Tests/Nimble/objc/ObjCBeGreaterThanTest.m
+++ b/Tests/Nimble/objc/ObjCBeGreaterThanTest.m
@@ -13,19 +13,19 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be greater than <0.0000>, got <-1.0000>", ^{
+    expectFailureMessage(@"expected to be greater than <0>, got <-1>", ^{
         expect(@(-1)).to(beGreaterThan(@(0)));
     });
-    expectFailureMessage(@"expected to not be greater than <1.0000>, got <0.0000>", ^{
+    expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
         expect(@0).toNot(beGreaterThan(@(1)));
     });
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to be greater than <-1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to be greater than <-1>, got <nil>", ^{
         expect(nil).to(beGreaterThan(@(-1)));
     });
-    expectNilFailureMessage(@"expected to not be greater than <1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to not be greater than <1>, got <nil>", ^{
         expect(nil).toNot(beGreaterThan(@(1)));
     });
 }

--- a/Tests/Nimble/objc/ObjCBeLessThanOrEqualToTest.m
+++ b/Tests/Nimble/objc/ObjCBeLessThanOrEqualToTest.m
@@ -13,19 +13,19 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be less than or equal to <1.0000>, got <2.0000>", ^{
+    expectFailureMessage(@"expected to be less than or equal to <1>, got <2>", ^{
         expect(@2).to(beLessThanOrEqualTo(@1));
     });
-    expectFailureMessage(@"expected to not be less than or equal to <1.0000>, got <1.0000>", ^{
+    expectFailureMessage(@"expected to not be less than or equal to <1>, got <1>", ^{
         expect(@1).toNot(beLessThanOrEqualTo(@1));
     });
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to be less than or equal to <1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to be less than or equal to <1>, got <nil>", ^{
         expect(nil).to(beLessThanOrEqualTo(@1));
     });
-    expectNilFailureMessage(@"expected to not be less than or equal to <-1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to not be less than or equal to <-1>, got <nil>", ^{
         expect(nil).toNot(beLessThanOrEqualTo(@(-1)));
     });
 }

--- a/Tests/Nimble/objc/ObjCBeLessThanTest.m
+++ b/Tests/Nimble/objc/ObjCBeLessThanTest.m
@@ -13,19 +13,19 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be less than <0.0000>, got <-1.0000>", ^{
+    expectFailureMessage(@"expected to be less than <0>, got <-1>", ^{
         expect(@(-1)).to(beLessThan(@0));
     });
-    expectFailureMessage(@"expected to not be less than <1.0000>, got <0.0000>", ^{
+    expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
         expect(@0).toNot(beLessThan(@1));
     });
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to be less than <-1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to be less than <-1>, got <nil>", ^{
         expect(nil).to(beLessThan(@(-1)));
     });
-    expectNilFailureMessage(@"expected to not be less than <1.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to not be less than <1>, got <nil>", ^{
         expect(nil).toNot(beLessThan(@1));
     });
 }

--- a/Tests/Nimble/objc/ObjCBeNilTest.m
+++ b/Tests/Nimble/objc/ObjCBeNilTest.m
@@ -13,7 +13,7 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be nil, got <1.0000>", ^{
+    expectFailureMessage(@"expected to be nil, got <1>", ^{
         expect(@1).to(beNil());
     });
     expectFailureMessage(@"expected to not be nil, got <nil>", ^{

--- a/Tests/Nimble/objc/ObjCBeTrueTest.m
+++ b/Tests/Nimble/objc/ObjCBeTrueTest.m
@@ -14,7 +14,7 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be true, got <0.0000>", ^{
+    expectFailureMessage(@"expected to be true, got <0>", ^{
         expect(@NO).to(beTrue());
     });
     expectFailureMessage(@"expected to be true, got <nil>", ^{

--- a/Tests/Nimble/objc/ObjCBeTruthyTest.m
+++ b/Tests/Nimble/objc/ObjCBeTruthyTest.m
@@ -17,10 +17,10 @@
     expectFailureMessage(@"expected to be truthy, got <nil>", ^{
         expect(nil).to(beTruthy());
     });
-    expectFailureMessage(@"expected to not be truthy, got <1.0000>", ^{
+    expectFailureMessage(@"expected to not be truthy, got <1>", ^{
         expect(@1).toNot(beTruthy());
     });
-    expectFailureMessage(@"expected to be truthy, got <0.0000>", ^{
+    expectFailureMessage(@"expected to be truthy, got <0>", ^{
         expect(@NO).to(beTruthy());
     });
 }

--- a/Tests/Nimble/objc/ObjCContainTest.m
+++ b/Tests/Nimble/objc/ObjCContainTest.m
@@ -16,10 +16,10 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to contain <Optional(3)>, got <(1,2)>", ^{
+    expectFailureMessage(@"expected to contain <Optional(3)>, got <(1, 2)>", ^{
         expect((@[@1, @2])).to(contain(@3));
     });
-    expectFailureMessage(@"expected to not contain <Optional(2)>, got <(1,2)>", ^{
+    expectFailureMessage(@"expected to not contain <Optional(2)>, got <(1, 2)>", ^{
         expect((@[@1, @2])).toNot(contain(@2));
     });
 
@@ -32,10 +32,10 @@
 }
 
 - (void)testNilMatches {
-    expectNilFailureMessage(@"expected to contain <3.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to contain <3>, got <nil>", ^{
         expect(nil).to(contain(@3));
     });
-    expectNilFailureMessage(@"expected to not contain <3.0000>, got <nil>", ^{
+    expectNilFailureMessage(@"expected to not contain <3>, got <nil>", ^{
         expect(nil).toNot(contain(@3));
     });
 
@@ -55,11 +55,11 @@
     expect(@"Other").toNot(contain(@"Str", @"Oth"));
 
 
-    expectFailureMessage(@"expected to contain <Optional(a), Optional(bar)>, got <(a,b,c)>", ^{
+    expectFailureMessage(@"expected to contain <Optional(a), Optional(bar)>, got <(a, b, c)>", ^{
         expect(@[@"a", @"b", @"c"]).to(contain(@"a", @"bar"));
     });
 
-    expectFailureMessage(@"expected to not contain <Optional(bar), Optional(b)>, got <(a,b,c)>", ^{
+    expectFailureMessage(@"expected to not contain <Optional(bar), Optional(b)>, got <(a, b, c)>", ^{
         expect(@[@"a", @"b", @"c"]).toNot(contain(@"bar", @"b"));
     });
 }

--- a/Tests/Nimble/objc/ObjCEqualTest.m
+++ b/Tests/Nimble/objc/ObjCEqualTest.m
@@ -15,10 +15,10 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to equal <2.0000>, got <1.0000>", ^{
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
         expect(@1).to(equal(@2));
     });
-    expectFailureMessage(@"expected to not equal <1.0000>, got <1.0000>", ^{
+    expectFailureMessage(@"expected to not equal <1>, got <1>", ^{
         expect(@1).toNot(equal(@1));
     });
 }

--- a/Tests/Nimble/objc/ObjCSatisfyAnyOfTest.m
+++ b/Tests/Nimble/objc/ObjCSatisfyAnyOfTest.m
@@ -16,12 +16,12 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to match one of: {equal <3.0000>}, or {equal <4.0000>}, or {equal <5.0000>}, got 2", ^{
+    expectFailureMessage(@"expected to match one of: {equal <3>}, or {equal <4>}, or {equal <5>}, got 2", ^{
         expect(@2).to(satisfyAnyOf(equal(@3), equal(@4), equal(@5)));
     });
     
-    expectFailureMessage(@"expected to match one of: {all be less than <4.0000>, but failed first at element"
-                         " <5.0000> in <[5.0000, 6.0000, 7.0000]>}, or {equal <(1,2,3,4)>}, got (5,6,7)", ^{
+    expectFailureMessage(@"expected to match one of: {all be less than <4>, but failed first at element"
+                         " <5> in <[5, 6, 7]>}, or {equal <(1, 2, 3, 4)>}, got (5,6,7)", ^{
                              expect(@[@5, @6, @7]).to(satisfyAnyOf(allPass(beLessThan(@4)), equal(@[@1, @2, @3, @4])));
                          });
     

--- a/Tests/Nimble/objc/ObjCUserDescriptionTest.m
+++ b/Tests/Nimble/objc/ObjCUserDescriptionTest.m
@@ -9,42 +9,42 @@
 
 - (void)testToWithDescription {
     expectFailureMessage(@"These are equal!\n"
-                         "expected to equal <2.0000>, got <1.0000>", ^{
+                         "expected to equal <2>, got <1>", ^{
                              expect(@1).toWithDescription(equal(@2), @"These are equal!");
                          });
 }
 
 - (void)testToNotWithDescription {
     expectFailureMessage(@"These aren't equal!\n"
-                         "expected to not equal <1.0000>, got <1.0000>", ^{
+                         "expected to not equal <1>, got <1>", ^{
                              expect(@1).toNotWithDescription(equal(@1), @"These aren't equal!");
                          });
 }
 
 - (void)testNotToWithDescription {
     expectFailureMessage(@"These aren't equal!\n"
-                         "expected to not equal <1.0000>, got <1.0000>", ^{
+                         "expected to not equal <1>, got <1>", ^{
                              expect(@1).notToWithDescription(equal(@1), @"These aren't equal!");
                          });
 }
 
 - (void)testToEventuallyWithDescription {
     expectFailureMessage(@"These are equal!\n"
-                         "expected to eventually equal <2.0000>, got <1.0000>", ^{
+                         "expected to eventually equal <2>, got <1>", ^{
                              expect(@1).toEventuallyWithDescription(equal(@2), @"These are equal!");
                          });
 }
 
 - (void)testToEventuallyNotWithDescription {
     expectFailureMessage(@"These aren't equal!\n"
-                         "expected to eventually not equal <1.0000>, got <1.0000>", ^{
+                         "expected to eventually not equal <1>, got <1>", ^{
                              expect(@1).toEventuallyNotWithDescription(equal(@1), @"These aren't equal!");
                          });
 }
 
 - (void)testToNotEventuallyWithDescription {
     expectFailureMessage(@"These aren't equal!\n"
-                         "expected to eventually not equal <1.0000>, got <1.0000>", ^{
+                         "expected to eventually not equal <1>, got <1>", ^{
                              expect(@1).toNotEventuallyWithDescription(equal(@1), @"These aren't equal!");
                          });
 }

--- a/Tests/Nimble/objc/ObjcStringersTest.m
+++ b/Tests/Nimble/objc/ObjcStringersTest.m
@@ -1,0 +1,24 @@
+@import XCTest;
+@import Nimble;
+
+@interface ObjcStringersTest : XCTestCase
+
+@end
+
+@implementation ObjcStringersTest
+
+- (void)testItCanStringifyArrays {
+    NSArray *array = @[@1, @2, @3];
+    NSString *result = NMBStringify(array);
+    
+    XCTAssert([result isEqualToString:@"(1, 2, 3)"], @"got <%@>, expected <(1, 2, 3)>", result);
+}
+
+- (void)testItRoundsLongDecimals {
+    NSNumber *num = @291.123782163;
+    NSString *result = NMBStringify(num);
+    
+    XCTAssert([result isEqualToString:@"291.1238"], @"got <%@>, expected <291.1238>", result);
+}
+
+@end

--- a/Tests/Nimble/objc/ObjcStringersTest.m
+++ b/Tests/Nimble/objc/ObjcStringersTest.m
@@ -11,14 +11,14 @@
     NSArray *array = @[@1, @2, @3];
     NSString *result = NMBStringify(array);
     
-    XCTAssert([result isEqualToString:@"(1, 2, 3)"], @"got <%@>, expected <(1, 2, 3)>", result);
+    expect(result).to(equal(@"(1, 2, 3)"));
 }
 
 - (void)testItRoundsLongDecimals {
     NSNumber *num = @291.123782163;
     NSString *result = NMBStringify(num);
     
-    XCTAssert([result isEqualToString:@"291.1238"], @"got <%@>, expected <291.1238>", result);
+    expect(result).to(equal(@"291.1238"));
 }
 
 @end


### PR DESCRIPTION
An attempt at #258.

A few things to note:
- I removed the `stringify` function for `SequenceType` because `SequenceType` doesn't make guarantees about what its generator does, so `stringify`ing a `SequenceType` that maintained some sort of internal state could have unexpected side effects. `SequenceType`s can still be stringified via the top-level function or by individuals manually conforming their sequences to `Stringifiable`.

- I changed the behavior slightly for printing arrays with strings in them. Previously Nimble would wrap the strings in an array in double quotes. Now they don't. Strings aren't wrapped in double quotes anywhere else, and inside of the array they seemed redundant. But maybe they're not, and I messed up--please let me know!

- `Stringifiable` is a really vague protocol name; maybe we should imitate the standard library and call our protocol `TestOutputStringConvertible`. Or something else.


As always, feedback is welcome!