### PR TITLE
Replace __FILE__ and similar with #file or related - breaking change for swift 2.2+

### DIFF
--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -13,8 +13,8 @@ private enum ErrorResult {
 internal class NMBWait: NSObject {
     internal class func until(
         timeout timeout: NSTimeInterval,
-        file: FileString = __FILE__,
-        line: UInt = __LINE__,
+        file: FileString = #file,
+        line: UInt = #line,
         action: (() -> Void) -> Void) -> Void {
             return throwableUntil(timeout: timeout, file: file, line: line) { (done: () -> Void) throws -> Void in
                 action() { done() }
@@ -24,8 +24,8 @@ internal class NMBWait: NSObject {
     // Using a throwable closure makes this method not objc compatible.
     internal class func throwableUntil(
         timeout timeout: NSTimeInterval,
-        file: FileString = __FILE__,
-        line: UInt = __LINE__,
+        file: FileString = #file,
+        line: UInt = #line,
         action: (() -> Void) throws -> Void) -> Void {
             let awaiter = NimbleEnvironment.activeInstance.awaiter
             let leeway = timeout / 2.0
@@ -71,7 +71,7 @@ internal class NMBWait: NSObject {
     }
 
     @objc(untilFile:line:action:)
-    internal class func until(file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    internal class func until(file: FileString = #file, line: UInt = #line, action: (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
 }
@@ -87,7 +87,7 @@ internal func blockedRunLoopErrorMessageFor(fnName: String, leeway: NSTimeInterv
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-public func waitUntil(timeout timeout: NSTimeInterval = 1, file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: FileString = #file, line: UInt = #line, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 #endif

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
 @warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
-public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = #file, line: UInt = #line) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -12,7 +12,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
 @warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
-public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -27,12 +27,12 @@ public func fail(message: String, location: SourceLocation) {
 }
 
 /// Always fails the test with a message.
-public func fail(message: String, file: FileString = __FILE__, line: UInt = __LINE__) {
+public func fail(message: String, file: FileString = #file, line: UInt = #line) {
     fail(message, location: SourceLocation(file: file, line: line))
 }
 
 /// Always fails the test.
-public func fail(file: FileString = __FILE__, line: UInt = __LINE__) {
+public func fail(file: FileString = #file, line: UInt = #line) {
     fail("fail() always fails", file: file, line: line)
 }
 
@@ -41,8 +41,8 @@ internal func nimblePrecondition(
     @autoclosure expr: () -> Bool,
     @autoclosure _ name: () -> String,
     @autoclosure _ message: () -> String,
-    file: StaticString = __FILE__,
-    line: UInt = __LINE__) -> Bool {
+    file: StaticString = #file,
+    line: UInt = #line) -> Bool {
         let result = expr()
         if !result {
 #if _runtime(_ObjC)
@@ -59,7 +59,7 @@ internal func nimblePrecondition(
 }
 
 @noreturn
-internal func internalError(msg: String, file: FileString = __FILE__, line: UInt = __LINE__) {
+internal func internalError(msg: String, file: FileString = #file, line: UInt = #line) {
     fatalError(
         "Nimble Bug Found: \(msg) at \(file):\(line).\n" +
         "Please file a bug to Nimble: https://github.com/Quick/Nimble/issues with the " +

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
-    typealias ValueType
+    associatedtype ValueType
     func matches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
     func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -220,7 +220,7 @@ internal class AwaitPromiseBuilder<T> {
     /// - The async expectation raised an unexpected error (swift)
     ///
     /// The returned AwaitResult will NEVER be .Incomplete.
-    func wait(fnName: String = __FUNCTION__, file: FileString = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
+    func wait(fnName: String = #function, file: FileString = #file, line: UInt = #line) -> AwaitResult<T> {
         waitLock.acquireWaitingLock(
             fnName,
             file: file,
@@ -338,7 +338,7 @@ internal func pollBlock(
     timeoutInterval: NSTimeInterval,
     file: FileString,
     line: UInt,
-    fnName: String = __FUNCTION__,
+    fnName: String = #function,
     expression: () throws -> Bool) -> AwaitResult<Bool> {
         let awaiter = NimbleEnvironment.activeInstance.awaiter
         let result = awaiter.poll(pollInterval) { () throws -> Bool? in

--- a/Tests/Nimble/AsynchronousTest.swift
+++ b/Tests/Nimble/AsynchronousTest.swift
@@ -112,14 +112,14 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
     func testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed() {
         // Currently we are unable to catch Objective-C exceptions when built by the Swift Package Manager
 #if !SWIFT_PACKAGE
-        let referenceLine = __LINE__ + 9
+        let referenceLine = #line + 9
         var msg = "Unexpected exception raised: Nested async expectations are not allowed "
         msg += "to avoid creating flaky tests."
         msg += "\n\n"
         msg += "The call to\n\t"
-        msg += "expect(...).toEventually(...) at \(__FILE__):\(referenceLine + 7)\n"
+        msg += "expect(...).toEventually(...) at \(#file):\(referenceLine + 7)\n"
         msg += "triggered this exception because\n\t"
-        msg += "waitUntil(...) at \(__FILE__):\(referenceLine + 1)\n"
+        msg += "waitUntil(...) at \(#file):\(referenceLine + 1)\n"
         msg += "is currently managing the main run loop."
         failsWithErrorMessage(msg) { // reference line
             waitUntil(timeout: 2.0) { done in

--- a/Tests/Nimble/Helpers/utils.swift
+++ b/Tests/Nimble/Helpers/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Nimble
 import XCTest
 
-func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+func failsWithErrorMessage(messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -44,7 +44,7 @@ func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line
     }
 }
 
-func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessage(message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -54,7 +54,7 @@ func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: U
     )
 }
 
-func failsWithErrorMessageForNil(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessageForNil(message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 

--- a/Tests/Nimble/Matchers/PostNotificationTest.swift
+++ b/Tests/Nimble/Matchers/PostNotificationTest.swift
@@ -101,7 +101,7 @@ class PostNotificationTest: XCTestCase, XCTestCaseProvider {
                 return nil
             }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
         #else
-            print("\(__FUNCTION__) is missing because toEventually is not implement on this platform")
+            print("\(#function) is missing because toEventually is not implement on this platform")
         #endif
     }
 }


### PR DESCRIPTION
Hey friends! (Hi Jeff! Hi Brian!)

Note that as of the most recent (mar 1) swift 3.0 prerelease, there's a compiler bug that this triggers. Might be fixed by next prerelease, might not. If not, then help would be nice?

A stack trace of the compiler bug, if you're interested:

```
Assertion failed: (isa<X>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file /Users/buildnode/jenkins/workspace/oss-swift-package-osx/llvm/include/llvm/Support/Casting.h, line 237.
0  swift                    0x00000001084e4a6b llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 43
1  swift                    0x00000001084e3d26 llvm::sys::RunSignalHandlers() + 70
2  swift                    0x00000001084e5112 SignalHandler(int) + 322
3  libsystem_platform.dylib 0x00007fff9ac4eeaa _sigtramp + 26
4  swift                    0x0000000108f995ed FirstTarget + 71701
5  swift                    0x00000001084e4f26 abort + 22
6  swift                    0x00000001084e4f01 __assert_rtn + 81
7  swift                    0x0000000105d0d00f swift::irgen::bindGenericRequirement(swift::irgen::IRGenFunction&, swift::irgen::GenericRequirement, llvm::Value*, llvm::function_ref<swift::CanType (swift::CanType)>) + 239
8  swift                    0x0000000105d0b149 swift::irgen::bindFromGenericRequirementsBuffer(swift::irgen::IRGenFunction&, llvm::ArrayRef<swift::irgen::GenericRequirement>, swift::irgen::Address, llvm::function_ref<swift::CanType (swift::CanType)>) + 361
9  swift                    0x0000000105d0afcf swift::irgen::NecessaryBindings::restore(swift::irgen::IRGenFunction&, swift::irgen::Address) const + 79
10 swift                    0x0000000105cd43bf swift::irgen::HeapLayout::getPrivateMetadata(swift::irgen::IRGenModule&) const + 447
11 swift                    0x0000000105cd4956 swift::irgen::IRGenFunction::emitUnmanagedAlloc(swift::irgen::HeapLayout const&, llvm::Twine const&, swift::irgen::HeapNonFixedOffsets const*) + 38
12 swift                    0x0000000105cc954f swift::irgen::emitFunctionPartialApplication(swift::irgen::IRGenFunction&, llvm::Value*, llvm::Value*, swift::irgen::Explosion&, llvm::ArrayRef<swift::SILParameterInfo>, llvm::ArrayRef<swift::Substitution>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::irgen::Explosion&) + 3311
13 swift                    0x0000000105d62ee6 swift::SILVisitor<(anonymous namespace)::IRGenSILFunction, void>::visit(swift::ValueBase*) + 45510
14 swift                    0x0000000105d53ffb (anonymous namespace)::IRGenSILFunction::emitSILFunction() + 9579
15 swift                    0x0000000105d516a0 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 1168
16 swift                    0x0000000105c84f5c swift::irgen::IRGenModuleDispatcher::emitGlobalTopLevel() + 428
17 swift                    0x0000000105d35725 performIRGeneration(swift::IRGenOptions&, swift::ModuleDecl*, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, swift::SourceFile*, unsigned int) + 1125
18 swift                    0x0000000105d35cf6 swift::performIRGeneration(swift::IRGenOptions&, swift::SourceFile&, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, unsigned int) + 70
19 swift                    0x0000000105be4402 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 12034
20 swift                    0x0000000105bdd489 main + 2937
21 libdyld.dylib            0x00007fff8d1265ad start + 1
22 libdyld.dylib            0x0000000000000072 start + 1928174278
Stack dump:
0.	Program arguments: /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a.xctoolchain/usr/bin/swift -frontend -c /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeCloseTo.swift /Users/you/workspace/Nimble/Sources/Nimble/Wrappers/MatcherFunc.swift /Users/you/workspace/Nimble/Sources/Nimble/Expectation.swift /Users/you/workspace/Nimble/Sources/Nimble/Adapters/NimbleXCTestHandler.swift /Users/you/workspace/Nimble/Sources/Nimble/Utils/Stringers.swift /Users/you/workspace/Nimble/Sources/Nimble/Utils/SourceLocation.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeLessThanOrEqual.swift /Users/you/workspace/Nimble/Sources/Nimble/Adapters/AssertionDispatcher.swift /Users/you/workspace/Nimble/Sources/Nimble/Utils/Functional.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeAnInstanceOf.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeLogical.swift /Users/you/workspace/Nimble/Sources/Nimble/ObjCExpectation.swift /Users/you/workspace/Nimble/Sources/Nimble/DSL+Wait.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/AllPass.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeAKindOf.swift /Users/you/workspace/Nimble/Sources/Nimble/Adapters/AssertionRecorder.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeVoid.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/PostNotification.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/Match.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/ThrowError.swift -primary-file /Users/you/workspace/Nimble/Sources/Nimble/Matchers/Equal.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeLessThan.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeGreaterThan.swift /Users/you/workspace/Nimble/Sources/Nimble/Adapters/AdapterProtocols.swift /Users/you/workspace/Nimble/Sources/Nimble/Adapters/NimbleEnvironment.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/RaisesException.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/Contain.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift /Users/you/workspace/Nimble/Sources/Nimble/Wrappers/AsyncMatcherWrapper.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeginWith.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeIdenticalTo.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeEmpty.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/BeNil.swift /Users/you/workspace/Nimble/Sources/Nimble/Utils/Async.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/EndWith.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/MatcherProtocols.swift /Users/you/workspace/Nimble/Sources/Nimble/Wrappers/ObjCMatcher.swift /Users/you/workspace/Nimble/Sources/Nimble/DSL.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/SatisfyAnyOf.swift /Users/you/workspace/Nimble/Sources/Nimble/Expression.swift /Users/you/workspace/Nimble/Sources/Nimble/FailureMessage.swift /Users/you/workspace/Nimble/Sources/Nimble/Matchers/HaveCount.swift -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -I /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Products/Debug -F /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Products/Debug -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -F /Applications/Xcode.app/Contents/Developer/Library/Frameworks -enable-testing -g -import-underlying-module -module-cache-path /Users/you/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Nimble-generated-files.hmap -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Nimble-own-target-headers.hmap -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Nimble-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Nimble-project-headers.hmap -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Products/Debug/include -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/DerivedSources/x86_64 -Xcc -I/Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/DerivedSources -Xcc -DDEBUG=1 -Xcc -DDEBUG=1 -Xcc -ivfsoverlay -Xcc /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/unextended-module-overlay.yaml -Xcc -working-directory/Users/you/workspace/Nimble -emit-module-doc-path /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal~partial.swiftdoc -Onone -module-name Nimble -emit-module-path /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal~partial.swiftmodule -serialize-diagnostics-path /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal.dia -emit-dependencies-path /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal.d -emit-reference-dependencies-path /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal.swiftdeps -o /Users/you/Library/Developer/Xcode/DerivedData/Nimble-avfmctrdkmaawddbgnnrooogzuvv/Build/Intermediates/Nimble.build/Debug/Nimble-OSX.build/Objects-normal/x86_64/Equal.o 
1.	While emitting IR SIL function @_TF6Nimble5equaluRxs8HashablerFGSqGVs3Setx__GVS_17NonNilMatcherFuncGS1_x__ for 'equal' at /Users/you/workspace/Nimble/Sources/Nimble/Matchers/Equal.swift:88:8
```