### PR TITLE
Add BeEmpty() support to NSIndexSet

### DIFF
--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -82,7 +82,7 @@ extension NMBObjCMatcher {
                 let expr = Expression(expression: ({ value as String }), location: location)
                 return try! beEmpty().matches(expr, failureMessage: failureMessage)
             } else if let actualValue = actualValue {
-                failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings)"
+                failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings)"
                 failureMessage.actualValue = "\(classAsString(actualValue.dynamicType)) type"
             }
             return false

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -5,7 +5,7 @@ import Foundation
 public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
+            failureMessage.postfixMessage = "have \(stringify(actualValue)) with count \(stringify(expectedValue))"
             let result = expectedValue == actualValue.count
             failureMessage.actualValue = "\(actualValue.count)"
             return result
@@ -20,7 +20,7 @@ public func haveCount<T: CollectionType>(expectedValue: T.Index.Distance) -> Non
 public func haveCount(expectedValue: Int) -> MatcherFunc<NMBCollection> {
     return MatcherFunc { actualExpression, failureMessage in
         if let actualValue = try actualExpression.evaluate() {
-            failureMessage.postfixMessage = "have \(actualValue) with count \(expectedValue)"
+            failureMessage.postfixMessage = "have \(stringify(actualValue)) with count \(stringify(expectedValue))"
             let result = expectedValue == actualValue.count
             failureMessage.actualValue = "\(actualValue.count)"
             return result

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -46,6 +46,7 @@ public protocol NMBCollection {
 #endif
 
 extension NSSet : NMBCollection {}
+extension NSIndexSet : NMBCollection {}
 extension NSDictionary : NMBCollection {}
 
 #if _runtime(_ObjC)

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -101,6 +101,13 @@ extension NSArray: TestOutputStringConvertible {
     }
 }
 
+extension NSIndexSet: TestOutputStringConvertible {
+    public var testDescription: String {
+        let list = Array(self).map(Nimble.stringify).joinWithSeparator(", ")
+        return "(\(list))"
+    }
+}
+
 extension String: TestOutputStringConvertible {
     public var testDescription: String {
         return self

--- a/Tests/Nimble/Matchers/BeEmptyTest.swift
+++ b/Tests/Nimble/Matchers/BeEmptyTest.swift
@@ -33,6 +33,9 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         expect(NSSet()).to(beEmpty())
         expect(NSSet(array: [NSNumber(integer: 1)])).toNot(beEmpty())
 
+        expect(NSIndexSet()).to(beEmpty())
+        expect(NSIndexSet(index: 1)).toNot(beEmpty())
+
         expect(NSString()).to(beEmpty())
         expect(NSString(string: "hello")).toNot(beEmpty())
 
@@ -53,6 +56,20 @@ class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         }
         failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())
+        }
+
+        failsWithErrorMessage("expected to not be empty, got <{()}>") {
+            expect(NSSet()).toNot(beEmpty());
+        }
+        failsWithErrorMessage("expected to be empty, got <{(1)}>") {
+            expect(NSSet(object: NSNumber(int: 1))).to(beEmpty());
+        }
+
+        failsWithErrorMessage("expected to not be empty, got <()>") {
+            expect(NSIndexSet()).toNot(beEmpty());
+        }
+        failsWithErrorMessage("expected to be empty, got <(1)>") {
+            expect(NSIndexSet(index: 1)).to(beEmpty());
         }
 
         failsWithErrorMessage("expected to not be empty, got <>") {

--- a/Tests/Nimble/Matchers/HaveCountTest.swift
+++ b/Tests/Nimble/Matchers/HaveCountTest.swift
@@ -28,11 +28,11 @@ class HaveCountTest: XCTestCase, XCTestCaseProvider {
         expect(dictionary).to(haveCount(3))
         expect(dictionary).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have \(dictionary) with count 1, got 3") {
+        failsWithErrorMessage("expected to have \(stringify(dictionary)) with count 1, got 3") {
             expect(dictionary).to(haveCount(1))
         }
 
-        failsWithErrorMessage("expected to not have \(dictionary) with count 3, got 3") {
+        failsWithErrorMessage("expected to not have \(stringify(dictionary)) with count 3, got 3") {
             expect(dictionary).notTo(haveCount(3))
         }
     }
@@ -42,11 +42,11 @@ class HaveCountTest: XCTestCase, XCTestCaseProvider {
         expect(set).to(haveCount(3))
         expect(set).notTo(haveCount(1))
 
-        failsWithErrorMessage("expected to have \(set) with count 1, got 3") {
+        failsWithErrorMessage("expected to have \(stringify(set)) with count 1, got 3") {
             expect(set).to(haveCount(1))
         }
 
-        failsWithErrorMessage("expected to not have \(set) with count 3, got 3") {
+        failsWithErrorMessage("expected to not have \(stringify(set)) with count 3, got 3") {
             expect(set).notTo(haveCount(3))
         }
     }

--- a/Tests/Nimble/objc/ObjCBeEmptyTest.m
+++ b/Tests/Nimble/objc/ObjCBeEmptyTest.m
@@ -11,12 +11,14 @@
     expect(@"").to(beEmpty());
     expect(@{}).to(beEmpty());
     expect([NSSet set]).to(beEmpty());
+    expect([NSIndexSet indexSet]).to(beEmpty());
     expect([NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory]).to(beEmpty());
 
     expect(@[@1, @2]).toNot(beEmpty());
     expect(@"a").toNot(beEmpty());
     expect(@{@"key": @"value"}).toNot(beEmpty());
     expect([NSSet setWithObject:@1]).toNot(beEmpty());
+    expect([NSIndexSet indexSetWithIndex:1]).toNot(beEmpty());
 
     NSHashTable *table = [NSHashTable hashTableWithOptions:NSPointerFunctionsStrongMemory];
     [table addObject:@1];
@@ -35,6 +37,9 @@
     });
     expectFailureMessage(@"expected to be empty, got <{(1)}>", ^{
         expect([NSSet setWithObject:@1]).to(beEmpty());
+    });
+    expectFailureMessage(@"expected to be empty, got <(1)>", ^{
+        expect([NSIndexSet indexSetWithIndex:1]).to(beEmpty());
     });
     NSHashTable *table = [NSHashTable hashTableWithOptions:NSPointerFunctionsStrongMemory];
     [table addObject:@1];
@@ -55,6 +60,9 @@
     expectFailureMessage(@"expected to not be empty, got <{(1)}>", ^{
         expect([NSSet setWithObject:@1]).toNot(beEmpty());
     });
+    expectFailureMessage(@"expected to not be empty, got <(1)>", ^{
+        expect([NSIndexSet indexSetWithIndex:1]).toNot(beEmpty());
+    });
     expectFailureMessage(@"expected to not be empty, got <NSHashTable {}>", ^{
         expect([NSHashTable hashTableWithOptions:NSPointerFunctionsStrongMemory]).toNot(beEmpty());
     });
@@ -70,10 +78,10 @@
 }
 
 - (void)testItReportsTypesItMatchesAgainst {
-    expectFailureMessage(@"expected to be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings), got __NSCFNumber type", ^{
+    expectFailureMessage(@"expected to be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings), got __NSCFNumber type", ^{
         expect(@1).to(beEmpty());
     });
-    expectFailureMessage(@"expected to not be empty (only works for NSArrays, NSSets, NSDictionaries, NSHashTables, and NSStrings), got __NSCFNumber type", ^{
+    expectFailureMessage(@"expected to not be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings), got __NSCFNumber type", ^{
         expect(@1).toNot(beEmpty());
     });
 }

--- a/Tests/Nimble/objc/ObjCHaveCount.m
+++ b/Tests/Nimble/objc/ObjCHaveCount.m
@@ -14,11 +14,11 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
-    expectFailureMessage(@"expected to have (1,2,3) with count 1, got 3", ^{
+    expectFailureMessage(@"expected to have (1, 2, 3) with count 1, got 3", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
 
-    expectFailureMessage(@"expected to not have (1,2,3) with count 3, got 3", ^{
+    expectFailureMessage(@"expected to not have (1, 2, 3) with count 3, got 3", ^{
         expect(@[@1, @2, @3]).notTo(haveCount(@3));
     });
 
@@ -73,6 +73,21 @@
     });
 
     expectFailureMessage(@"expected to not have {(3,1,2)} with count 3, got 3", ^{
+        expect(set).notTo(haveCount(@3));
+    });
+}
+
+- (void)testHaveCountForNSIndexSet {
+    NSIndexSet *const set = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 3)];
+
+    expect(set).to(haveCount(@3));
+    expect(set).notTo(haveCount(@1));
+
+    expectFailureMessage(@"expected to have (1, 2, 3) with count 1, got 3", ^{
+        expect(set).to(haveCount(@1));
+    });
+
+    expectFailureMessage(@"expected to not have (1, 2, 3) with count 3, got 3", ^{
         expect(set).notTo(haveCount(@3));
     });
 }

--- a/Tests/Nimble/objc/ObjcStringersTest.m
+++ b/Tests/Nimble/objc/ObjcStringersTest.m
@@ -14,6 +14,13 @@
     expect(result).to(equal(@"(1, 2, 3)"));
 }
 
+- (void)testItCanStringifyIndexSets {
+    NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 3)];
+    NSString *result = NMBStringify(indexSet);
+
+    expect(result).to(equal(@"(1, 2, 3)"));
+}
+
 - (void)testItRoundsLongDecimals {
     NSNumber *num = @291.123782163;
     NSString *result = NMBStringify(num);


### PR DESCRIPTION
`NSIndexSet` conforms to `NMBCollection`, so this is made explicit.