### PR TITLE
Swift 2.2 and Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: generic
 matrix:
   include:

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -24,7 +24,7 @@ internal class NMBWait: NSObject {
     // Using a throwable closure makes this method not objc compatible.
     internal class func throwableUntil(
         timeout timeout: NSTimeInterval,
-                file: FileString = #file,
+        file: FileString = #file,
         line: UInt = #line,
         action: (() -> Void) throws -> Void) -> Void {
             let awaiter = NimbleEnvironment.activeInstance.awaiter

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -13,8 +13,8 @@ private enum ErrorResult {
 internal class NMBWait: NSObject {
     internal class func until(
         timeout timeout: NSTimeInterval,
-        file: FileString = __FILE__,
-        line: UInt = __LINE__,
+        file: FileString = #file,
+        line: UInt = #line,
         action: (() -> Void) -> Void) -> Void {
             return throwableUntil(timeout: timeout, file: file, line: line) { (done: () -> Void) throws -> Void in
                 action() { done() }
@@ -24,8 +24,8 @@ internal class NMBWait: NSObject {
     // Using a throwable closure makes this method not objc compatible.
     internal class func throwableUntil(
         timeout timeout: NSTimeInterval,
-        file: FileString = __FILE__,
-        line: UInt = __LINE__,
+                file: FileString = #file,
+        line: UInt = #line,
         action: (() -> Void) throws -> Void) -> Void {
             let awaiter = NimbleEnvironment.activeInstance.awaiter
             let leeway = timeout / 2.0
@@ -71,7 +71,7 @@ internal class NMBWait: NSObject {
     }
 
     @objc(untilFile:line:action:)
-    internal class func until(file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+    internal class func until(file: FileString = #file, line: UInt = #line, action: (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
 }
@@ -87,7 +87,7 @@ internal func blockedRunLoopErrorMessageFor(fnName: String, leeway: NSTimeInterv
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-public func waitUntil(timeout timeout: NSTimeInterval = 1, file: FileString = __FILE__, line: UInt = __LINE__, action: (() -> Void) -> Void) -> Void {
+public func waitUntil(timeout timeout: NSTimeInterval = 1, file: FileString = #file, line: UInt = #line, action: (() -> Void) -> Void) -> Void {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 #endif

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
 @warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
-public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = __FILE__, line: UInt = __LINE__) -> Expectation<T> {
+public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: FileString = #file, line: UInt = #line) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -12,7 +12,7 @@ public func expect<T>(@autoclosure(escaping) expression: () throws -> T?, file: 
 
 /// Make an expectation on a given actual value. The closure is lazily invoked.
 @warn_unused_result(message="Follow 'expect(…)' with '.to(…)', '.toNot(…)', 'toEventually(…)', '==', etc.")
-public func expect<T>(file: FileString = __FILE__, line: UInt = __LINE__, expression: () throws -> T?) -> Expectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, expression: () throws -> T?) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,
@@ -27,12 +27,12 @@ public func fail(message: String, location: SourceLocation) {
 }
 
 /// Always fails the test with a message.
-public func fail(message: String, file: FileString = __FILE__, line: UInt = __LINE__) {
+public func fail(message: String, file: FileString = #file, line: UInt = #line) {
     fail(message, location: SourceLocation(file: file, line: line))
 }
 
 /// Always fails the test.
-public func fail(file: FileString = __FILE__, line: UInt = __LINE__) {
+public func fail(file: FileString = #file, line: UInt = #line) {
     fail("fail() always fails", file: file, line: line)
 }
 
@@ -41,8 +41,8 @@ internal func nimblePrecondition(
     @autoclosure expr: () -> Bool,
     @autoclosure _ name: () -> String,
     @autoclosure _ message: () -> String,
-    file: StaticString = __FILE__,
-    line: UInt = __LINE__) -> Bool {
+    file: StaticString = #file,
+    line: UInt = #line) -> Bool {
         let result = expr()
         if !result {
 #if _runtime(_ObjC)
@@ -59,7 +59,7 @@ internal func nimblePrecondition(
 }
 
 @noreturn
-internal func internalError(msg: String, file: FileString = __FILE__, line: UInt = __LINE__) {
+internal func internalError(msg: String, file: FileString = #file, line: UInt = #line) {
     fatalError(
         "Nimble Bug Found: \(msg) at \(file):\(line).\n" +
         "Please file a bug to Nimble: https://github.com/Quick/Nimble/issues with the " +

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
-    typealias ValueType
+    associatedtype ValueType
     func matches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
     func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -220,7 +220,7 @@ internal class AwaitPromiseBuilder<T> {
     /// - The async expectation raised an unexpected error (swift)
     ///
     /// The returned AwaitResult will NEVER be .Incomplete.
-    func wait(fnName: String = __FUNCTION__, file: FileString = __FILE__, line: UInt = __LINE__) -> AwaitResult<T> {
+    func wait(fnName: String = #function, file: FileString = #file, line: UInt = #line) -> AwaitResult<T> {
         waitLock.acquireWaitingLock(
             fnName,
             file: file,
@@ -338,7 +338,7 @@ internal func pollBlock(
     timeoutInterval: NSTimeInterval,
     file: FileString,
     line: UInt,
-    fnName: String = __FUNCTION__,
+    fnName: String = #function,
     expression: () throws -> Bool) -> AwaitResult<Bool> {
         let awaiter = NimbleEnvironment.activeInstance.awaiter
         let result = awaiter.poll(pollInterval) { () throws -> Bool? in

--- a/Tests/Nimble/AsynchronousTest.swift
+++ b/Tests/Nimble/AsynchronousTest.swift
@@ -134,14 +134,14 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
     func testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed() {
         // Currently we are unable to catch Objective-C exceptions when built by the Swift Package Manager
 #if !SWIFT_PACKAGE
-        let referenceLine = __LINE__ + 9
+        let referenceLine = #line + 9
         var msg = "Unexpected exception raised: Nested async expectations are not allowed "
         msg += "to avoid creating flaky tests."
         msg += "\n\n"
         msg += "The call to\n\t"
-        msg += "expect(...).toEventually(...) at \(__FILE__):\(referenceLine + 7)\n"
+        msg += "expect(...).toEventually(...) at \(#file):\(referenceLine + 7)\n"
         msg += "triggered this exception because\n\t"
-        msg += "waitUntil(...) at \(__FILE__):\(referenceLine + 1)\n"
+        msg += "waitUntil(...) at \(#file):\(referenceLine + 1)\n"
         msg += "is currently managing the main run loop."
         failsWithErrorMessage(msg) { // reference line
             waitUntil(timeout: 2.0) { done in

--- a/Tests/Nimble/Helpers/utils.swift
+++ b/Tests/Nimble/Helpers/utils.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import Nimble
 import XCTest
 
-func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+func failsWithErrorMessage(messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -44,7 +44,7 @@ func failsWithErrorMessage(messages: [String], file: FileString = __FILE__, line
     }
 }
 
-func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessage(message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -54,7 +54,7 @@ func failsWithErrorMessage(message: String, file: FileString = __FILE__, line: U
     )
 }
 
-func failsWithErrorMessageForNil(message: String, file: FileString = __FILE__, line: UInt = __LINE__, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
+func failsWithErrorMessageForNil(message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 

--- a/Tests/Nimble/Matchers/PostNotificationTest.swift
+++ b/Tests/Nimble/Matchers/PostNotificationTest.swift
@@ -101,7 +101,7 @@ class PostNotificationTest: XCTestCase, XCTestCaseProvider {
                 return nil
             }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
         #else
-            print("\(__FUNCTION__) is missing because toEventually is not implement on this platform")
+            print("\(#function) is missing because toEventually is not implement on this platform")
         #endif
     }
 }

--- a/Tests/Nimble/objc/ObjCContainTest.m
+++ b/Tests/Nimble/objc/ObjCContainTest.m
@@ -16,10 +16,10 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to contain <Optional(3)>, got <(1, 2)>", ^{
+    expectFailureMessage(@"expected to contain <3>, got <(1, 2)>", ^{
         expect((@[@1, @2])).to(contain(@3));
     });
-    expectFailureMessage(@"expected to not contain <Optional(2)>, got <(1, 2)>", ^{
+    expectFailureMessage(@"expected to not contain <2>, got <(1, 2)>", ^{
         expect((@[@1, @2])).toNot(contain(@2));
     });
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.0"
+    version: "7.3"
 
 dependencies:
   pre:


### PR DESCRIPTION
General changes to get Nimble to build on Xcode 7.3 without warnings (aside from "Embedded dylibs/frameworks only run on iOS 8 or later")

- Replace deprecated `__FILE__`, `__LINE__` and `__FUNCTION__` with `#file`, `#line` and `#function`, respectively
- Use new `associatedtype` keyword
- Fixed a couple OS X tests that were failing due to `@3` not coming through as optional

Supersedes #265

:warning: These changes require Xcode 7.3 and Swift 2.2 or better.