### PR TITLE
Fixed issue with early test observer registration preventing console output

### DIFF
--- a/Sources/Nimble/objc/CurrentTestCaseTracker.m
+++ b/Sources/Nimble/objc/CurrentTestCaseTracker.m
@@ -12,7 +12,14 @@ SWIFT_CLASS("_TtC6Nimble22CurrentTestCaseTracker")
 
 + (void)load {
     CurrentTestCaseTracker *tracker = [CurrentTestCaseTracker sharedInstance];
-    [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:tracker];
+    // XCode 7.3 introduced a bug where early registration of a test observer prevented
+    // default XCTest test observer from being registered. That caused no longs being printed
+    // onto console, which in result broke several tools that relied on this.
+    // In order to go around the issue we're deferring registration to allow default
+    // test observer to register first.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:tracker];
+    });
 }
 
 @end


### PR DESCRIPTION
This PR is an attempt to fix #270. 

It looks like that early test observer registration (aka as early as you can - in `+load`) prevents default XCTest observer from registering in latest XCTest that shipped with Xcode 7. 

That default observer is responsible for printing output to Xcode console (or Terminal when running `xcodebuild` from command line). There are several tools that rely on this output, for instance `xcpretty`. 

This simple PR adds logic that defers the moment where `CurrentTestCaseTracker` and thus allows default XCTest observer to register. 

Potential issues: There should not be any issues with `CurrentTestCaseTracker` being registered too late as we're moving the registration to next run loop cycle (which is the moment after all classes and categories get their `+load` message). However I'm entirely certain about and any input on whether this is a viable solution is welcomed. 

Or perhaps better alternatives, as I'm not a huge fan of using `dispatch_async` this way :wink: 

I've tested this against my test suite and it works just fine. 