### PR TITLE
Specifies private header file for CurrentTestCaseTracker.h in podspec

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Quick/Nimble.git", :tag => "v#{s.version}" }
 
   s.source_files = "Sources/Nimble/**/*.{swift,h,m}"
+  s.private_header_files = "Sources/Nimble/Adapters/ObjectiveC/CurrentTestCaseTracker.h"
   s.exclude_files = "Sources/Nimble/Adapters/NonObjectiveC/*.swift"
   s.weak_framework = "XCTest"
   s.requires_arc = true


### PR DESCRIPTION
This header file is private (more like, internal) to the Nimble project and shouldn't be exposed publicly in the umbrella header generated by CocoaPods. I've successfully tested the fix [here](https://github.com/RxSwiftCommunity/RxOptional/pull/22). Please let me know if this warrants a changelog entry.

Fixes #280.