### PR TITLE
Release process update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,9 +104,8 @@ The process is relatively straight forward, but here's is a useful checklist for
 
 - Look at changes from the previously tagged release and write release notes: `git log v0.4.0...HEAD`
 - Run the release script: `./script/release A.B.C release-notes-file`
-- Go to [github releases](https://github.com/Quick/Nimble/releases) and mark the tagged commit as a release.
-  - Use the same release notes you created for the tag, but tweak up formatting for github.
-  - Attach the carthage release `Nimble.framework.zip` to the release.
+- The script will prompt you to create a new [GitHub release](https://github.com/Quick/Nimble/releases).
+  - Use the same release notes you created for the tag, but tweak up formatting for GitHub.
 - Update [Quick](https://github.com/Quick/Quick)
   - Update Quick's submodule reference to the newly released Nimble version
   - Update Nimble version in `README.md` and Documentation in [Quick](https://github.com/Quick/Quick) if it's not a patch version update.

--- a/script/release
+++ b/script/release
@@ -2,9 +2,7 @@
 REMOTE_BRANCH=master
 POD_NAME=Nimble
 PODSPEC=Nimble.podspec
-CARTHAGE_FRAMEWORK_NAME=Nimble
 
-CARTHAGE=${CARTHAGE:-carthage}
 POD=${COCOAPODS:-pod}
 
 function help {
@@ -41,11 +39,6 @@ FORCE_TAG=$3
 VERSION_TAG="v$VERSION"
 
 echo "-> Verifying Local Directory for Release"
-
-if [ -z "`which $CARTHAGE`" ]; then
-    die "Carthage is required to produce a release. Aborting."
-fi
-echo " > Carthage is installed"
 
 if [ -z "`which $POD`" ]; then
     die "Cocoapods is required to produce a release. Aborting."
@@ -139,9 +132,6 @@ echo "-> Ensuring no differences to origin/$REMOTE_BRANCH"
 git fetch origin || die "Failed to fetch origin"
 git diff --quiet HEAD "origin/$REMOTE_BRANCH" || die "HEAD is not aligned to origin/$REMOTE_BRANCH. Cannot update version safely"
 
-# Don't build binaries: see https://github.com/Carthage/Carthage/issues/924
-# echo "-> Building Carthage release"
-# $CARTHAGE build --no-skip-current || die "Failed to build framework for carthage"
 
 echo "-> Setting podspec version"
 cat "$PODSPEC" | grep 's.version' | grep -q "\"$VERSION\""
@@ -178,9 +168,6 @@ fi
 echo
 echo "---------------- Released as $VERSION_TAG ----------------"
 echo 
-# Don't build binaries: see https://github.com/Carthage/Carthage/issues/924
-# echo "Archiving carthage release..."
-# $CARTHAGE archive "$CARTHAGE_FRAMEWORK_NAME" || die "Failed to archive framework for carthage"
 
 echo
 echo "Pushing to pod trunk..."
@@ -192,7 +179,6 @@ echo "================ Finalizing the Release ================"
 echo
 echo " - Opening GitHub to mark this as a release..."
 echo "   - Paste the contents of $RELEASE_NOTES into the release notes. Tweak for GitHub styling."
-# echo "   - Attach ${CARTHAGE_FRAMEWORK_NAME}.framework.zip to it."
 echo " - Announce!"
 
 open "https://github.com/Quick/Nimble/releases/new?tag=$VERSION_TAG"

--- a/script/release
+++ b/script/release
@@ -2,7 +2,6 @@
 REMOTE_BRANCH=master
 POD_NAME=Nimble
 PODSPEC=Nimble.podspec
-GITHUB_TAGS_URL=https://github.com/Quick/Nimble/tags
 CARTHAGE_FRAMEWORK_NAME=Nimble
 
 CARTHAGE=${CARTHAGE:-carthage}
@@ -172,7 +171,6 @@ else
 fi
 
 if [ $SET_PODSPEC_VERSION -ne 0 ]; then
-    rm $RELEASE_NOTES
     git push origin "$REMOTE_BRANCH" || die "Failed to push to origin"
     echo " > Pushed version to origin"
 fi
@@ -192,9 +190,11 @@ $POD trunk push "$PODSPEC"
 echo
 echo "================ Finalizing the Release ================"
 echo
-echo " - Go to $GITHUB_TAGS_URL and mark this as a release."
-echo "   - Paste the contents of $RELEASE_NOTES into the release notes. Tweak for Github styling."
+echo " - Opening GitHub to mark this as a release..."
+echo "   - Paste the contents of $RELEASE_NOTES into the release notes. Tweak for GitHub styling."
 # echo "   - Attach ${CARTHAGE_FRAMEWORK_NAME}.framework.zip to it."
 echo " - Announce!"
+
+open "https://github.com/Quick/Nimble/releases/new?tag=$VERSION_TAG"
 
 rm ${PODSPEC}.backup


### PR DESCRIPTION
Continunes a conversation from #283 about improvements to the release process. In summary:

- Removes inconsistencies between the documentation and script (the script doesn't create Carthage binaries, so we can't upload them as a release).
- Automatically opens a browser to create a new release once a tag has been pushed.
- If the release notes file is about to be deleted, we `cat` its contents first (so they can be used as GitHub release notes).