### PR TITLE
change equal matchers to take nonnull args; add nil matcher syntax sugar

### DIFF
--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-/// Global constant instance of NilLiteral. Can be used to 
-/// compare against expectations as syntactic sugar for the
-/// `beNil` matcher.
-public let Nil = NilLiteral()
-
 /// An empty type signifying nothing.
 public struct NilLiteral: NilLiteralConvertible {
     public init(nilLiteral: ()) {}
@@ -16,7 +11,7 @@ public func ==(lhs: NilLiteral, rhs: NilLiteral) -> Bool { return true }
 
 /// Equality operator overload that can be used to simplify
 /// nil expectations. For a given expectation `expectThing`,
-/// `expectThing == Nil` and `expectThing.to(beNil)` are 
+/// `expectThing == nil` and `expectThing.to(beNil)` are
 /// equivalent expressions.
 public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.to(beNil())
@@ -24,7 +19,7 @@ public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
 
 /// Equality operator overload that can be used to simplify
 /// nonnil expectations. For a given expectation `expectThing`,
-/// `expectThing != Nil` and `expectThing.toNot(beNil)` are
+/// `expectThing != nil` and `expectThing.toNot(beNil)` are
 /// equivalent expressions.
 public func !=<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.toNot(beNil())

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -1,5 +1,23 @@
 import Foundation
 
+public let Nil = NilLiteral()
+
+public struct NilLiteral: NilLiteralConvertible {
+    public init(nilLiteral: ()) {}
+    public init() {}
+}
+
+extension NilLiteral: Equatable {}
+public func ==(lhs: NilLiteral, rhs: NilLiteral) -> Bool { return true }
+
+public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
+    lhs.to(beNil())
+}
+
+public func !=<T>(lhs: Expectation<T>, rhs: NilLiteral) {
+    lhs.toNot(beNil())
+}
+
 /// A Nimble matcher that succeeds when the actual value is nil.
 public func beNil<T>() -> MatcherFunc<T> {
     return MatcherFunc { actualExpression, failureMessage in

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -1,7 +1,11 @@
 import Foundation
 
+/// Global constant instance of NilLiteral. Can be used to 
+/// compare against expectations as syntactic sugar for the
+/// `beNil` matcher.
 public let Nil = NilLiteral()
 
+/// An empty type signifying nothing.
 public struct NilLiteral: NilLiteralConvertible {
     public init(nilLiteral: ()) {}
     public init() {}
@@ -10,10 +14,18 @@ public struct NilLiteral: NilLiteralConvertible {
 extension NilLiteral: Equatable {}
 public func ==(lhs: NilLiteral, rhs: NilLiteral) -> Bool { return true }
 
+/// Equality operator overload that can be used to simplify
+/// nil expectations. For a given expectation `expectThing`,
+/// `expectThing == Nil` and `expectThing.to(beNil)` are 
+/// equivalent expressions.
 public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.to(beNil())
 }
 
+/// Equality operator overload that can be used to simplify
+/// nonnil expectations. For a given expectation `expectThing`,
+/// `expectThing != Nil` and `expectThing.toNot(beNil)` are
+/// equivalent expressions.
 public func !=<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.toNot(beNil())
 }

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -13,6 +13,8 @@ public func ==(lhs: NilLiteral, rhs: NilLiteral) -> Bool { return true }
 /// nil expectations. For a given expectation `expectThing`,
 /// `expectThing == nil` and `expectThing.to(beNil)` are
 /// equivalent expressions.
+///
+/// - SeeAlso: `beNil()`
 public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.to(beNil())
 }
@@ -21,6 +23,8 @@ public func ==<T>(lhs: Expectation<T>, rhs: NilLiteral) {
 /// nonnil expectations. For a given expectation `expectThing`,
 /// `expectThing != nil` and `expectThing.toNot(beNil)` are
 /// equivalent expressions.
+///
+/// - SeeAlso: `beNil()`
 public func !=<T>(lhs: Expectation<T>, rhs: NilLiteral) {
     lhs.toNot(beNil())
 }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -3,7 +3,8 @@ import Foundation
 /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
 /// Values can support equal by supporting the Equatable protocol.
 ///
-/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+/// - SeeAlso: `beCloseTo(_:)` for matching imprecise types (eg - floats, doubles) and
+///    `beNil()` for matching `nil`.
 public func equal<T: Equatable>(expectedValue: T) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
@@ -15,7 +16,8 @@ public func equal<T: Equatable>(expectedValue: T) -> NonNilMatcherFunc<T> {
 /// A Nimble matcher that succeeds when the actual value is equal to the expected value.
 /// Values can support equal by supporting the Equatable protocol.
 ///
-/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
+/// - SeeAlso: `beCloseTo(_:)` for matching imprecise types (eg - floats, doubles) and
+///    `beNil()` for matching `nil`.
 public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]) -> NonNilMatcherFunc<[T: C]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -74,7 +74,9 @@ public func equal<T>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.
 public func equal<T: Comparable>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
     return equal(expectedValue, stringify: {
-        return stringify(Array($0).sort(<))
+        var output = Array($0)
+        output.sortInPlace(<)
+        return stringify(output)
     })
 }
 

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -19,8 +19,7 @@ public func equal<T: Equatable>(expectedValue: T) -> NonNilMatcherFunc<T> {
 public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]) -> NonNilMatcherFunc<[T: C]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        let _actualValue = try actualExpression.evaluate()
-        guard let actualValue = _actualValue else { return false }
+        guard let actualValue = try actualExpression.evaluate() else { return false }
         return expectedValue == actualValue
     }
 }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -75,7 +75,7 @@ public func equal<T>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.
 public func equal<T: Comparable>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
     return equal(expectedValue, stringify: {
-        return stringify(Array($0).sort { $0 < $1 })
+        return stringify(Array($0).sort(<))
     })
 }
 

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -4,18 +4,11 @@ import Foundation
 /// Values can support equal by supporting the Equatable protocol.
 ///
 /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T: Equatable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
+public func equal<T: Equatable>(expectedValue: T) -> NonNilMatcherFunc<T> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
         let actualValue = try actualExpression.evaluate()
-        let matches = actualValue == expectedValue && expectedValue != nil
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil {
-                failureMessage.postfixActual = " (use beNil() to match nils)"
-            }
-            return false
-        }
-        return matches
+        return actualValue == expectedValue
     }
 }
 
@@ -23,33 +16,23 @@ public func equal<T: Equatable>(expectedValue: T?) -> NonNilMatcherFunc<T> {
 /// Values can support equal by supporting the Equatable protocol.
 ///
 /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]?) -> NonNilMatcherFunc<[T: C]> {
+public func equal<T: Equatable, C: Equatable>(expectedValue: [T: C]) -> NonNilMatcherFunc<[T: C]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil {
-                failureMessage.postfixActual = " (use beNil() to match nils)"
-            }
-            return false
-        }
-        return expectedValue! == actualValue!
+        let _actualValue = try actualExpression.evaluate()
+        guard let actualValue = _actualValue else { return false }
+        return expectedValue == actualValue
     }
 }
 
 /// A Nimble matcher that succeeds when the actual collection is equal to the expected collection.
 /// Items must implement the Equatable protocol.
-public func equal<T: Equatable>(expectedValue: [T]?) -> NonNilMatcherFunc<[T]> {
+public func equal<T: Equatable>(expectedValue: [T]) -> NonNilMatcherFunc<[T]> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
-        let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil {
-                failureMessage.postfixActual = " (use beNil() to match nils)"
-            }
-            return false
-        }
-        return expectedValue! == actualValue!
+        let _actualValue = try actualExpression.evaluate()
+        guard let actualValue = _actualValue else { return false }
+        return expectedValue == actualValue
     }
 }
 
@@ -85,45 +68,37 @@ public func equal<T: Equatable>(expectedValue: [T?]) -> NonNilMatcherFunc<[T?]> 
 }
 
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.
-public func equal<T>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
+public func equal<T>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
     return equal(expectedValue, stringify: stringify)
 }
 
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.
-public func equal<T: Comparable>(expectedValue: Set<T>?) -> NonNilMatcherFunc<Set<T>> {
+public func equal<T: Comparable>(expectedValue: Set<T>) -> NonNilMatcherFunc<Set<T>> {
     return equal(expectedValue, stringify: {
-        if let set = $0 {
-            return stringify(Array(set).sort { $0 < $1 })
-        } else {
-            return "nil"
-        }
+        return stringify(Array($0).sort { $0 < $1 })
     })
 }
 
-private func equal<T>(expectedValue: Set<T>?, stringify: Set<T>? -> String) -> NonNilMatcherFunc<Set<T>> {
+private func equal<T>(expectedValue: Set<T>, stringify: Set<T> -> String) -> NonNilMatcherFunc<Set<T>> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "equal <\(stringify(expectedValue))>"
 
-        if let expectedValue = expectedValue {
-            if let actualValue = try actualExpression.evaluate() {
-                failureMessage.actualValue = "<\(stringify(actualValue))>"
+        if let actualValue = try actualExpression.evaluate() {
+            failureMessage.actualValue = "<\(stringify(actualValue))>"
 
-                if expectedValue == actualValue {
-                    return true
-                }
-
-                let missing = expectedValue.subtract(actualValue)
-                if missing.count > 0 {
-                    failureMessage.postfixActual += ", missing <\(stringify(missing))>"
-                }
-
-                let extra = actualValue.subtract(expectedValue)
-                if extra.count > 0 {
-                    failureMessage.postfixActual += ", extra <\(stringify(extra))>"
-                }
+            if expectedValue == actualValue {
+                return true
             }
-        } else {
-            failureMessage.postfixActual = " (use beNil() to match nils)"
+
+            let missing = expectedValue.subtract(actualValue)
+            if missing.count > 0 {
+                failureMessage.postfixActual += ", missing <\(stringify(missing))>"
+            }
+
+            let extra = actualValue.subtract(expectedValue)
+            if extra.count > 0 {
+                failureMessage.postfixActual += ", extra <\(stringify(extra))>"
+            }
         }
 
         return false
@@ -172,8 +147,13 @@ public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func equalMatcher(expected: NSObject) -> NMBMatcher {
+    public class func equalMatcher(expected: NSObject?) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+            guard let expected = expected else {
+                failureMessage.postfixMessage = "equal <\(stringify(try! actualExpression.evaluate()))>"
+                failureMessage.postfixActual = " (use beNil() to match nils)"
+                return false
+            }
             return try! equal(expected).matches(actualExpression, failureMessage: failureMessage)
         }
     }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -130,43 +130,43 @@ private func equal<T>(expectedValue: Set<T>?, stringify: Set<T>? -> String) -> N
     }
 }
 
-public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
+public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
+public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
+public func ==<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
+public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func ==<T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func !=<T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]) {
     lhs.toNot(equal(rhs))
 }
 

--- a/Tests/Nimble/Helpers/utils.swift
+++ b/Tests/Nimble/Helpers/utils.swift
@@ -45,7 +45,7 @@ func failsWithErrorMessage(messages: [String], file: FileString = #file, line: U
 }
 
 func failsWithErrorMessage(message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
-    return failsWithErrorMessage(
+    failsWithErrorMessage(
         [message],
         file: file,
         line: line,

--- a/Tests/Nimble/Matchers/BeNilTest.swift
+++ b/Tests/Nimble/Matchers/BeNilTest.swift
@@ -5,6 +5,7 @@ class BeNilTest: XCTestCase, XCTestCaseProvider {
     var allTests: [(String, () throws -> Void)] {
         return [
             ("testBeNil", testBeNil),
+            ("testBeNilWithEqualityOperator", testBeNilWithEqualityOperator)
         ]
     }
 
@@ -23,6 +24,20 @@ class BeNilTest: XCTestCase, XCTestCaseProvider {
 
         failsWithErrorMessage("expected to be nil, got <1>") {
             expect(1 as Int?).to(beNil())
+        }
+    }
+    
+    func testBeNilWithEqualityOperator() {
+        expect(nil as Float?) == Nil
+        expect(20 as Int?) != Nil
+        expect(self.producesNil()) == Nil
+        
+        failsWithErrorMessage("expected to not be nil, got <nil>") {
+            expect(nil as String?) != Nil
+        }
+        
+        failsWithErrorMessage("expected to be nil, got <-99999>") {
+            expect(-99999 as Int?) == Nil
         }
     }
 }

--- a/Tests/Nimble/Matchers/BeNilTest.swift
+++ b/Tests/Nimble/Matchers/BeNilTest.swift
@@ -28,16 +28,16 @@ class BeNilTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeNilWithEqualityOperator() {
-        expect(nil as Float?) == Nil
-        expect(20 as Int?) != Nil
-        expect(self.producesNil()) == Nil
+        expect(nil as Float?) == nil
+        expect(20 as Int?) != nil
+        expect(self.producesNil()) == nil
         
         failsWithErrorMessage("expected to not be nil, got <nil>") {
-            expect(nil as String?) != Nil
+            expect(nil as String?) != nil
         }
         
         failsWithErrorMessage("expected to be nil, got <-99999>") {
-            expect(-99999 as Int?) == Nil
+            expect(-99999 as Int?) == nil
         }
     }
 }

--- a/Tests/Nimble/Matchers/EqualTest.swift
+++ b/Tests/Nimble/Matchers/EqualTest.swift
@@ -8,6 +8,7 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
             ("testEquality", testEquality),
             ("testArrayEquality", testArrayEquality),
             ("testSetEquality", testSetEquality),
+            ("testDoesNotMatchNils", testDoesNotMatchNils),
             ("testDictionaryEquality", testDictionaryEquality),
             ("testDataEquality", testDataEquality),
             ("testNSObjectEquality", testNSObjectEquality),
@@ -65,6 +66,10 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(Set<Int>()) == Set<Int>()
         expect(Set([1, 2])) != Set<Int>()
 
+        failsWithErrorMessageForNil("expected to equal <[1, 2]>, got <nil>") {
+            expect(nil as Set<Int>?).to(equal(Set([1, 2])))
+        }
+
         failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3]>, missing <[1]>") {
             expect(Set([2, 3])).to(equal(Set([1, 2, 3])))
         }
@@ -83,6 +88,18 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
 
         failsWithErrorMessage("expected to not equal <[1, 2, 3]>, got <[1, 2, 3]>") {
             expect(Set([1, 2, 3])) != Set([1, 2, 3])
+        }
+    }
+
+    func testDoesNotMatchNils() {
+        failsWithErrorMessageForNil("expected to not equal <bar>, got <nil>") {
+            expect(nil as String?).toNot(equal("bar"))
+        }
+        failsWithErrorMessageForNil("expected to not equal <[1]>, got <nil>") {
+            expect(nil as [Int]?).toNot(equal([1]))
+        }
+        failsWithErrorMessageForNil("expected to not equal <[1: 1]>, got <nil>") {
+            expect(nil as [Int: Int]?).toNot(equal([1: 1]))
         }
     }
 

--- a/Tests/Nimble/Matchers/EqualTest.swift
+++ b/Tests/Nimble/Matchers/EqualTest.swift
@@ -179,6 +179,11 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
 
     func testOptionalEquality() {
         expect(1 as CInt?).to(equal(1))
+        expect("One" as String?).to(equal("One"))
+        
+        failsWithErrorMessageForNil("expected to equal <Two>, got <nil>") {
+            expect(nil as String?).to(equal("Two"))
+        }
     }
     
     func testArrayOfOptionalsEquality() {

--- a/Tests/Nimble/Matchers/EqualTest.swift
+++ b/Tests/Nimble/Matchers/EqualTest.swift
@@ -8,7 +8,6 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
             ("testEquality", testEquality),
             ("testArrayEquality", testArrayEquality),
             ("testSetEquality", testSetEquality),
-            ("testDoesNotMatchNils", testDoesNotMatchNils),
             ("testDictionaryEquality", testDictionaryEquality),
             ("testDataEquality", testDataEquality),
             ("testNSObjectEquality", testNSObjectEquality),
@@ -66,10 +65,6 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         expect(Set<Int>()) == Set<Int>()
         expect(Set([1, 2])) != Set<Int>()
 
-        failsWithErrorMessageForNil("expected to equal <[1, 2]>, got <nil>") {
-            expect(nil as Set<Int>?).to(equal(Set([1, 2])))
-        }
-
         failsWithErrorMessage("expected to equal <[1, 2, 3]>, got <[2, 3]>, missing <[1]>") {
             expect(Set([2, 3])).to(equal(Set([1, 2, 3])))
         }
@@ -91,38 +86,6 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
         }
     }
 
-    func testDoesNotMatchNils() {
-        failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
-            expect(nil as String?).to(equal(nil as String?))
-        }
-        failsWithErrorMessageForNil("expected to not equal <nil>, got <foo>") {
-            expect("foo").toNot(equal(nil as String?))
-        }
-        failsWithErrorMessageForNil("expected to not equal <bar>, got <nil>") {
-            expect(nil as String?).toNot(equal("bar"))
-        }
-
-        failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
-            expect(nil as [Int]?).to(equal(nil as [Int]?))
-        }
-        failsWithErrorMessageForNil("expected to not equal <[1]>, got <nil>") {
-            expect(nil as [Int]?).toNot(equal([1]))
-        }
-        failsWithErrorMessageForNil("expected to not equal <nil>, got <[1]>") {
-            expect([1]).toNot(equal(nil as [Int]?))
-        }
-
-        failsWithErrorMessageForNil("expected to equal <nil>, got <nil>") {
-            expect(nil as [Int: Int]?).to(equal(nil as [Int: Int]?))
-        }
-        failsWithErrorMessageForNil("expected to not equal <[1: 1]>, got <nil>") {
-            expect(nil as [Int: Int]?).toNot(equal([1: 1]))
-        }
-        failsWithErrorMessageForNil("expected to not equal <nil>, got <[1: 1]>") {
-            expect([1: 1]).toNot(equal(nil as [Int: Int]?))
-        }
-    }
-
     func testDictionaryEquality() {
         expect(["foo": "bar"]).to(equal(["foo": "bar"]))
         expect(["foo": "bar"]).toNot(equal(["foo": "baz"]))
@@ -140,9 +103,9 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testDataEquality() {
-        let actual = "foobar".dataUsingEncoding(NSUTF8StringEncoding)
-        let expected = "foobar".dataUsingEncoding(NSUTF8StringEncoding)
-        let unexpected = "foobarfoo".dataUsingEncoding(NSUTF8StringEncoding)
+        let actual = "foobar".dataUsingEncoding(NSUTF8StringEncoding)!
+        let expected = "foobar".dataUsingEncoding(NSUTF8StringEncoding)!
+        let unexpected = "foobarfoo".dataUsingEncoding(NSUTF8StringEncoding)!
 
         expect(actual).to(equal(expected))
         expect(actual).toNot(equal(unexpected))
@@ -199,9 +162,6 @@ class EqualTest: XCTestCase, XCTestCaseProvider {
 
     func testOptionalEquality() {
         expect(1 as CInt?).to(equal(1))
-        expect(1 as CInt?).to(equal(1 as CInt?))
-
-        expect(1).toNot(equal(nil))
     }
     
     func testArrayOfOptionalsEquality() {

--- a/Tests/Nimble/objc/ObjCEqualTest.m
+++ b/Tests/Nimble/objc/ObjCEqualTest.m
@@ -24,6 +24,7 @@
 }
 
 - (void)testNilMatches {
+    
     expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
         expect(nil).to(equal(nil));
     });

--- a/Tests/Nimble/objc/ObjCEqualTest.m
+++ b/Tests/Nimble/objc/ObjCEqualTest.m
@@ -24,7 +24,6 @@
 }
 
 - (void)testNilMatches {
-    
     expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
         expect(nil).to(equal(nil));
     });


### PR DESCRIPTION
An attempt at #214.

I'm a little sad that we need a special `Nil` constant and can't just use the reserved `nil` keyword. Conformance to the `NilLiteralConvertible` protocol provided by Swift does let us use `nil` instead of `Nil` occasionally, but only in places where Swift will infer that `NilLiteral` should be used over any other `nil` convertible type like `Optional`.

I'm also worried slightly that overloading the equality operator with wanton abandon will have negative effects on large test suites, especially for a relatively small feature. I imagine Swift's static optional checking greatly reduces the need for `nil` testing, but `nil` testing still has many legitimate uses i.e. checking that nullability-annotated ObjC methods are annotated correctly.

The equality conformance on `NilLiteral` might be unnecessary then as it's a type with only one member and thus any equality comparison between members is trivially true.
