### PR TITLE
Add beCloseTo/beCloseToWithin/plusMinus operators support for NSDate

### DIFF
--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -104,21 +104,21 @@ public func ≈(lhs: Expectation<[Double]>, rhs: [Double]) {
     lhs.to(beCloseTo(rhs))
 }
 
-public func ≈(lhs: Expectation<Double>, rhs: Double) {
+public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: NMBDoubleConvertible) {
     lhs.to(beCloseTo(rhs))
 }
 
-public func ≈(lhs: Expectation<Double>, rhs: (expected: Double, delta: Double)) {
+public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
-public func ==(lhs: Expectation<Double>, rhs: (expected: Double, delta: Double)) {
+public func ==(lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
 // make this higher precedence than exponents so the Doubles either end aren't pulled in
 // unexpectantly
 infix operator ± { precedence 170 }
-public func ±(lhs: Double, rhs: Double) -> (expected: Double, delta: Double) {
+public func ±(lhs: NMBDoubleConvertible, rhs: Double) -> (expected: NMBDoubleConvertible, delta: Double) {
     return (expected: lhs, delta: rhs)
 }

--- a/Tests/Nimble/Matchers/BeCloseToTest.swift
+++ b/Tests/Nimble/Matchers/BeCloseToTest.swift
@@ -12,6 +12,9 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
             ("testBeCloseToOperator", testBeCloseToOperator),
             ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
             ("testPlusMinusOperator", testPlusMinusOperator),
+            ("testBeCloseToOperatorWithNSDate", testBeCloseToOperatorWithNSDate),
+            ("testBeCloseToWithinOperatorWithNSDate", testBeCloseToWithinOperatorWithNSDate),
+            ("testPlusMinusOperatorWithNSDate", testPlusMinusOperatorWithNSDate),
             ("testBeCloseToArray", testBeCloseToArray),
         ]
     }
@@ -87,6 +90,54 @@ class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to be close to <1> (within 0.1), got <1.2>") {
             expect(1.2) == 1.0 ± 0.1
         }
+    }
+
+    func testBeCloseToOperatorWithNSDate() {
+#if _runtime(_ObjC) // NSDateFormatter isn't functional in swift-corelibs-foundation yet.
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ NSDate(dateTimeString: "2015-08-26 11:43:00")
+
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.0001), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate
+        }
+#endif
+    }
+
+    func testBeCloseToWithinOperatorWithNSDate() {
+#if _runtime(_ObjC) // NSDateFormatter isn't functional in swift-corelibs-foundation yet.
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ (NSDate(dateTimeString: "2015-08-26 11:43:05"), 10)
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) == (NSDate(dateTimeString: "2015-08-26 11:43:05"), 10)
+
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ (expectedDate, 0.006)
+        }
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) == (expectedDate, 0.006)
+        }
+#endif
+    }
+
+    func testPlusMinusOperatorWithNSDate() {
+#if _runtime(_ObjC) // NSDateFormatter isn't functional in swift-corelibs-foundation yet.
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ NSDate(dateTimeString: "2015-08-26 11:43:05") ± 10
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) == NSDate(dateTimeString: "2015-08-26 11:43:05") ± 10
+
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate ± 0.006
+        }
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").dateByAddingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")) == expectedDate ± 0.006
+        }
+#endif
     }
 
     func testBeCloseToArray() {


### PR DESCRIPTION
This pull request enables these expressions.

```swift
var date1, date2: NSDate!

expect(date1) ≈ date2

expect(date1) ≈ (date2, 10)
expect(date1) == (date2, 10)

expect(date1) ≈ date2 ± 10
expect(date1) == date2 ± 10
```
