### PR TITLE
Make non variadic contains matchers public

### DIFF
--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -5,7 +5,7 @@ public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T
     return contain(items)
 }
 
-private func contain<S: SequenceType, T: Equatable where S.Generator.Element == T>(items: [T]) -> NonNilMatcherFunc<S> {
+public func contain<S: SequenceType, T: Equatable where S.Generator.Element == T>(items: [T]) -> NonNilMatcherFunc<S> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
         if let actual = try actualExpression.evaluate() {
@@ -22,7 +22,7 @@ public func contain(substrings: String...) -> NonNilMatcherFunc<String> {
     return contain(substrings)
 }
 
-private func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
+public func contain(substrings: [String]) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
@@ -40,7 +40,7 @@ public func contain(substrings: NSString...) -> NonNilMatcherFunc<NSString> {
     return contain(substrings)
 }
 
-private func contain(substrings: [NSString]) -> NonNilMatcherFunc<NSString> {
+public func contain(substrings: [NSString]) -> NonNilMatcherFunc<NSString> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
         if let actual = try actualExpression.evaluate() {
@@ -55,7 +55,7 @@ public func contain(items: AnyObject?...) -> NonNilMatcherFunc<NMBContainer> {
     return contain(items)
 }
 
-private func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
+public func contain(items: [AnyObject?]) -> NonNilMatcherFunc<NMBContainer> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
         guard let actual = try actualExpression.evaluate() else { return false }

--- a/Tests/Nimble/Matchers/ContainTest.swift
+++ b/Tests/Nimble/Matchers/ContainTest.swift
@@ -9,6 +9,7 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
             ("testContainSubstring", testContainSubstring),
             ("testContainObjCSubstring", testContainObjCSubstring),
             ("testVariadicArguments", testVariadicArguments),
+            ("testCollectionArguments", testCollectionArguments),
         ]
     }
 
@@ -72,6 +73,23 @@ class ContainTest: XCTestCase, XCTestCaseProvider {
 
         failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
             expect(["a", "b", "c"]).toNot(contain("bar", "b"))
+        }
+    }
+
+    func testCollectionArguments() {
+        expect([1, 2, 3]).to(contain([1, 2]))
+        expect([1, 2, 3]).toNot(contain([1, 4]))
+
+        let collection = Array(1...10)
+        let slice = Array(collection[3...5])
+        expect(collection).to(contain(slice))
+
+        failsWithErrorMessage("expected to contain <a, bar>, got <[a, b, c]>") {
+            expect(["a", "b", "c"]).to(contain(["a", "bar"]))
+        }
+
+        failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
+            expect(["a", "b", "c"]).toNot(contain(["bar", "b"]))
         }
     }
 }


### PR DESCRIPTION
Currently we can match for `expect([1, 2, 3]).to(contain(1, 2))`  but we can not match `expect([1, 2, 3]).to(contain([1, 2]))`. The matching functions are already present, and I don't see the reason for them  to not be public.

This makes the following scenario easier to write:
```swift
    expect(zoo.catsAndDogs).to(contain(zoo.cats))
    expect(zoo.catsAndDogs).to(contain(zoo.dogs))
```

There's also a swift bug filed that would support this use case out of the box, but it's still open: https://bugs.swift.org/browse/SR-128