### PR TITLE
Make it clear that identity matchers only work with reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ expect(actual).toNot(beIdenticalTo(expected))
 expect(actual) !== expected
 ```
 
-Its important to remember that beIdenticalTo only makes sense when comparing types with reference semantics, which have a notion of identity. In Swift, that means a `class`. This matcher will not work with types with value semantics such as `struct` or `enum`. If you need to compare two value types, you can either compare individual properties or if it makes sense to do so, make your type implement `Equatable` and use Nimble's equivalence matchers instead.
+Its important to remember that `beIdenticalTo` only makes sense when comparing types with reference semantics, which have a notion of identity. In Swift, that means a `class`. This matcher will not work with types with value semantics such as `struct` or `enum`. If you need to compare two value types, you can either compare individual properties or if it makes sense to do so, make your type implement `Equatable` and use Nimble's equivalence matchers instead.
 
 
 ```objc

--- a/README.md
+++ b/README.md
@@ -492,6 +492,9 @@ expect(actual).toNot(beIdenticalTo(expected))
 expect(actual) !== expected
 ```
 
+Its important to remember that beIdenticalTo only makes sense when comparing types with reference semantics, which have a notion of identity. In Swift, that means a `class`. This matcher will not work with types with value semantics such as `struct` or `enum`. If you need to compare two value types, you can either compare individual properties or if it makes sense to do so, make your type implement `Equatable` and use Nimble's equivalence matchers instead.
+
+
 ```objc
 // Objective-C
 


### PR DESCRIPTION
To clear up any confusion that might arise (see #298).