### PR TITLE
Make Expectation.expression public

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -33,7 +33,8 @@ internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(ex
 }
 
 public struct Expectation<T> {
-    let expression: Expression<T>
+
+    public let expression: Expression<T>
 
     public func verify(pass: Bool, _ message: FailureMessage) {
         let handler = NimbleEnvironment.activeInstance.assertionHandler


### PR DESCRIPTION
I am working on a project where I use Quick and Nimble for behavioral DSL and [SwiftCheck](https://github.com/typelift/SwiftCheck) for property-based testing. This requires me to _return_ test results, instead of asserting them straight in an assertion handler.

So I tried to overload `Expectation.to(_:description:)` and `Expectation.toNot(_:description:)` so that they return `SwiftCheck.Testable` and noticed that I cannot access `expression` property and therefore pass it to a matcher.

This pull request makes `Expectation.expression` public so that it is accessible outside the Nimble framework target.