### PR TITLE
Add `expect(x).toAlways`

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -32,6 +32,22 @@ internal func expressionDoesNotMatch<T, U where U: Matcher, U.ValueType == T>(ex
     }
 }
 
+internal func expressionAlwaysMatches<T, U where U: Matcher, U.ValueType == T>(expression: Expression<T>, matcher: U, to: String, description: String?) -> (Bool, FailureMessage) {
+    let msg = FailureMessage()
+    msg.userDescription = description
+    msg.to = to
+    do {
+        let pass = try matcher.alwaysMatches(expression, failureMessage: msg)
+        if msg.actualValue == "" {
+            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
+        }
+        return (pass, msg)
+    } catch let error {
+        msg.actualValue = "an unexpected error thrown: <\(error)>"
+        return (false, msg)
+    }
+}
+
 public struct Expectation<T> {
 
     public let expression: Expression<T>

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -5,6 +5,13 @@ public protocol Matcher {
     associatedtype ValueType
     func matches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
     func doesNotMatch(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
+    func alwaysMatches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
+}
+
+extension Matcher {
+    public func alwaysMatches(actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool {
+        return try self.matches(actualExpression, failureMessage: failureMessage)
+    }
 }
 
 #if _runtime(_ObjC)

--- a/Tests/Nimble/AsynchronousTest.swift
+++ b/Tests/Nimble/AsynchronousTest.swift
@@ -13,6 +13,8 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
             ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
             ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
             ("testToEventuallyWithCustomDefaultTimeout", testToEventuallyWithCustomDefaultTimeout),
+            ("testToAlwaysPositiveMatches", testToAlwaysPositiveMatches),
+            ("testToAlwaysNegativeMatches", testToAlwaysNegativeMatches),
             ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
             ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
             ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
@@ -74,6 +76,40 @@ class AsyncTest: XCTestCase, XCTestCaseProvider {
             value = 0
         }
         expect { value }.toEventuallyNot(equal(1))
+    }
+
+    func testToAlwaysPositiveMatches() {
+        let value = 0
+        expect { value }.toAlways(equal(0))
+
+        var otherValue = 0
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            NSThread.sleepForTimeInterval(0.2)
+            otherValue += 1
+        }
+
+        expect { otherValue }.toAlways(beLessThan(2))
+    }
+
+    func testToAlwaysNegativeMatches() {
+        failsWithErrorMessage("expected to always equal <0>, got <1>") {
+            var value = 0
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+                NSThread.sleepForTimeInterval(0.2)
+                value = 1
+            }
+            expect { value }.toAlways(equal(0))
+        }
+
+        failsWithErrorMessage("expected to always be less than <1>, got <1>") {
+            var value = 0
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+                NSThread.sleepForTimeInterval(0.2)
+                value += 1
+            }
+
+            expect { value }.toAlways(beLessThan(1))
+        }
     }
 
     func testWaitUntilPositiveMatches() {


### PR DESCRIPTION
This expectation will make sure that a condition is met along a time interval. This is useful to make sure stuff doesn't happen, for example:

``` swift
var called = false
func thisShouldNeverBeCalled() {
    called = true
}
// (.. async stuff ..)
expect(called).toAlways(beFalse())
```

Thoughts?

Related to: https://github.com/Quick/Nimble/issues/322
