### PR TITLE
Add SWIFT_VERSION in podspec;

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.exclude_files = "Sources/Nimble/Adapters/NonObjectiveC/*.swift"
   s.weak_framework = "XCTest"
   s.requires_arc = true
-  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'OTHER_LDFLAGS' => '-weak-lswiftXCTest', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'OTHER_LDFLAGS' => '-weak-lswiftXCTest', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"', 'SWIFT_VERSION' => '3.0' }
 end


### PR DESCRIPTION
This will fix the Xcode warning to add SWIFT_VERSION into build settings.