### PR TITLE
Fix endsWith for duplicated elements in collection

### DIFF
--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -21,8 +21,16 @@ public func beginWith<S: Sequence, T: Equatable>(_ startingElement: T) -> NonNil
 public func beginWith(_ startingElement: Any) -> NonNilMatcherFunc<NMBOrderedCollection> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "begin with <\(startingElement)>"
-        let collection = try actualExpression.evaluate()
-        return collection != nil && collection!.index(of: startingElement) == 0
+        guard let collection = try actualExpression.evaluate() else { return false }
+        guard collection.count > 0 else { return false }
+        #if os(Linux)
+            guard let collectionValue = collection.object(at: 0) as? NSObject else {
+                return false
+            }
+        #else
+            let collectionValue = collection.object(at: 0) as AnyObject
+        #endif
+        return collectionValue.isEqual(startingElement)
     }
 }
 

--- a/Sources/Nimble/Matchers/EndWith.swift
+++ b/Sources/Nimble/Matchers/EndWith.swift
@@ -29,8 +29,17 @@ public func endWith<S: Sequence, T: Equatable>(_ endingElement: T) -> NonNilMatc
 public func endWith(_ endingElement: Any) -> NonNilMatcherFunc<NMBOrderedCollection> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "end with <\(endingElement)>"
-        let collection = try actualExpression.evaluate()
-        return collection != nil && collection!.index(of: endingElement) == collection!.count - 1
+        guard let collection = try actualExpression.evaluate() else { return false }
+        guard collection.count > 0 else { return false }
+        #if os(Linux)
+            guard let collectionValue = collection.object(at: collection.count - 1) as? NSObject else {
+                return false
+            }
+        #else
+            let collectionValue = collection.object(at: collection.count - 1) as AnyObject
+        #endif
+
+        return collectionValue.isEqual(endingElement)
     }
 }
 
@@ -42,8 +51,7 @@ public func endWith(_ endingSubstring: String) -> NonNilMatcherFunc<String> {
     return NonNilMatcherFunc { actualExpression, failureMessage in
         failureMessage.postfixMessage = "end with <\(endingSubstring)>"
         if let collection = try actualExpression.evaluate() {
-            let range = collection.range(of: endingSubstring)
-            return range != nil && range!.upperBound == collection.endIndex
+            return collection.hasSuffix(endingSubstring)
         }
         return false
     }

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -58,12 +58,12 @@ extension NSDictionary : NMBCollection {}
 #if _runtime(_ObjC)
 /// Protocol for types that support beginWith(), endWith(), beEmpty() matchers
 @objc public protocol NMBOrderedCollection : NMBCollection {
-    @objc(indexOfObject:)
-    func index(of anObject: Any) -> Int
+    @objc(objectAtIndex:)
+    func object(at index: Int) -> Any
 }
 #else
 public protocol NMBOrderedCollection : NMBCollection {
-    func index(of anObject: Any) -> Int
+    func object(at index: Int) -> Any
 }
 #endif
 

--- a/Tests/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Tests/NimbleTests/Matchers/BeginWithTest.swift
@@ -17,6 +17,8 @@ final class BeginWithTest: XCTestCase, XCTestCaseProvider {
         expect("foobar").to(beginWith("foo"))
         expect("foobar").toNot(beginWith("oo"))
 
+        expect("foobarfoo").to(beginWith("foo"))
+
         expect(NSString(string: "foobar").description).to(beginWith("foo"))
         expect(NSString(string: "foobar").description).toNot(beginWith("oo"))
 

--- a/Tests/NimbleTests/Matchers/EndWithTest.swift
+++ b/Tests/NimbleTests/Matchers/EndWithTest.swift
@@ -13,9 +13,12 @@ final class EndWithTest: XCTestCase, XCTestCaseProvider {
     func testEndWithPositives() {
         expect([1, 2, 3]).to(endWith(3))
         expect([1, 2, 3]).toNot(endWith(2))
+        expect([]).toNot(endWith(1))
+        expect(["a", "b", "a"]).to(endWith("a"))
 
         expect("foobar").to(endWith("bar"))
         expect("foobar").toNot(endWith("oo"))
+        expect("foobarfoo").to(endWith("foo"))
 
         expect(NSString(string: "foobar").description).to(endWith("bar"))
         expect(NSString(string: "foobar").description).toNot(endWith("oo"))
@@ -23,6 +26,8 @@ final class EndWithTest: XCTestCase, XCTestCaseProvider {
 #if _runtime(_ObjC)
         expect(NSArray(array: ["a", "b"])).to(endWith("b"))
         expect(NSArray(array: ["a", "b"])).toNot(endWith("a"))
+        expect(NSArray(array: [])).toNot(endWith("a"))
+        expect(NSArray(array: ["a", "b", "a"])).to(endWith("a"))
 #endif
     }
 


### PR DESCRIPTION
when a NMBCollection or String repeats the subset specified in the expectation:

```swift
// bug:
expect("foobarfoo").to(endWith("foo")) // failed
expect(NSArray(array: [1, 2, 1])).to(endWith(1)) // failed
```

Fixes #296