### PR TITLE
Bring back NMBDoubleConvertible support for NSDate

### DIFF
--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -122,7 +122,7 @@ extension Date: TestOutputStringConvertible {
 
 extension NSDate: TestOutputStringConvertible {
     public var testDescription: String {
-        return dateFormatter.string(from: self as Date)
+        return dateFormatter.string(from: Date(timeIntervalSinceReferenceDate: self.timeIntervalSinceReferenceDate))
     }
 }
 

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -104,13 +104,23 @@ private let dateFormatter: DateFormatter = {
 
 extension Date: NMBDoubleConvertible {
     public var doubleValue: CDouble {
-        get {
-            return self.timeIntervalSinceReferenceDate
-        }
+        return self.timeIntervalSinceReferenceDate
+    }
+}
+
+extension NSDate: NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        return self.timeIntervalSinceReferenceDate
     }
 }
 
 extension Date: TestOutputStringConvertible {
+    public var testDescription: String {
+        return dateFormatter.string(from: self)
+    }
+}
+
+extension NSDate: TestOutputStringConvertible {
     public var testDescription: String {
         return dateFormatter.string(from: self as Date)
     }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -82,11 +82,18 @@ public class NimbleHelper : NSObject {
 }
 
 extension Date {
-    init(dateTimeString:String) {
+    init(dateTimeString: String) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         let date = dateFormatter.date(from: dateTimeString)!
         self.init(timeInterval:0, since:date)
+    }
+}
+
+extension NSDate {
+    convenience init(dateTimeString: String) {
+        let date = Date(dateTimeString: dateTimeString)
+        self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate)
     }
 }

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -68,11 +68,11 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testBeCloseToWithNSDate() {
-        expect(Date(dateTimeString: "2015-08-26 11:43:00") as NSDate).to(beCloseTo(Date(dateTimeString: "2015-08-26 11:43:05") as NSDate, within: 10))
+        expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
 
         failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
-            let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005) as NSDate
-            expect(Date(dateTimeString: "2015-08-26 11:43:00") as NSDate).toNot(beCloseTo(expectedDate, within: 0.004))
+            let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
         }
     }
 

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -9,6 +9,7 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
             ("testBeCloseToWithin", testBeCloseToWithin),
             ("testBeCloseToWithNSNumber", testBeCloseToWithNSNumber),
             ("testBeCloseToWithDate", testBeCloseToWithDate),
+            ("testBeCloseToWithNSDate", testBeCloseToWithNSDate),
             ("testBeCloseToOperator", testBeCloseToOperator),
             ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
             ("testPlusMinusOperator", testPlusMinusOperator),
@@ -61,12 +62,20 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(Date(dateTimeString: "2015-08-26 11:43:05"), within: 10))
         
         failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
         }
     }
-    
+
+    func testBeCloseToWithNSDate() {
+        expect(Date(dateTimeString: "2015-08-26 11:43:00") as NSDate).to(beCloseTo(Date(dateTimeString: "2015-08-26 11:43:05") as NSDate, within: 10))
+
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
+            let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005) as NSDate
+            expect(Date(dateTimeString: "2015-08-26 11:43:00") as NSDate).toNot(beCloseTo(expectedDate, within: 0.004))
+        }
+    }
+
     func testBeCloseToOperator() {
         expect(1.2) ≈ 1.2001
         expect(1.2 as CDouble) ≈ 1.2001
@@ -104,7 +113,6 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ Date(dateTimeString: "2015-08-26 11:43:00")
 
         failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.0001), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate
         }
@@ -115,12 +123,10 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) == (Date(dateTimeString: "2015-08-26 11:43:05"), 10)
 
         failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ (expectedDate, 0.006)
         }
         failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")) == (expectedDate, 0.006)
         }
@@ -131,12 +137,10 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) == Date(dateTimeString: "2015-08-26 11:43:05") ± 10
 
         failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate ± 0.006
         }
         failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
-
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
             expect(Date(dateTimeString: "2015-08-26 11:43:00")) == expectedDate ± 0.006
         }


### PR DESCRIPTION
`Date` struct and `NSDate` class are not the same type.