### PR TITLE
NSEC_PER_SEC is in CDispatch on non-Darwin platforms

### DIFF
--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -3,7 +3,7 @@ import Dispatch
 import Foundation
 
 #if !_runtime(_ObjC)
-    private let NSEC_PER_SEC: CUnsignedLongLong = 1000000000
+    import CDispatch
 #endif
 
 private let timeoutLeeway = DispatchTimeInterval.milliseconds(1)


### PR DESCRIPTION
- https://github.com/apple/swift-corelibs-libdispatch/blob/swift-3.0-RELEASE/dispatch/time.h#L38-L53
- https://github.com/apple/swift-corelibs-libdispatch/blob/swift-3.0-RELEASE/dispatch/generic/module.modulemap#L12-L18

See https://github.com/Quick/Nimble/pull/342#discussion_r80475762 for the details.