### PR TITLE
Fix matchError succeeding on any Error type given.

### DIFF
--- a/Sources/Nimble/Utils/Errors.swift
+++ b/Sources/Nimble/Utils/Errors.swift
@@ -77,14 +77,21 @@ internal func errorMatchesNonNilFieldsOrClosure<T: Error>(
                     matches = false
                 }
             }
-        } else if errorType != nil && closure != nil {
+        } else if errorType != nil {
+            matches = (actualError is T)
             // The closure expects another ErrorProtocol as argument, so this
             // is _supposed_ to fail, so that it becomes more obvious.
-            let assertions = gatherExpectations {
-                expect(actualError is T).to(equal(true))
+            if let closure = closure {
+                let assertions = gatherExpectations {
+                    if let actual = actualError as? T {
+                        closure(actual)
+                    }
+                }
+                let messages = assertions.map { $0.message }
+                if messages.count > 0 {
+                    matches = false
+                }
             }
-            precondition(assertions.map { $0.message }.count > 0)
-            matches = false
         }
     }
 

--- a/Tests/NimbleTests/Matchers/MatchErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchErrorTest.swift
@@ -26,6 +26,7 @@ final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
     func testMatchErrorNegative() {
         expect(NimbleError.laugh).toNot(matchError(NimbleError.cry))
         expect(NimbleError.laugh as Error).toNot(matchError(NimbleError.cry))
+        expect(NimbleError.laugh).toNot(matchError(EquatableError.self))
     }
 
     func testMatchNSErrorPositive() {
@@ -63,6 +64,10 @@ final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
     func testMatchNegativeMessage() {
         failsWithErrorMessage("expected to not match error <laugh>, got <laugh>") {
             expect(NimbleError.laugh).toNot(matchError(NimbleError.laugh))
+        }
+
+        failsWithErrorMessage("expected to match error from type <EquatableError>, got <laugh>") {
+            expect(NimbleError.laugh).to(matchError(EquatableError.self))
         }
     }
 


### PR DESCRIPTION
Previous:

```swift
enum Foo: Error {
    case Value
}

enum Bar: Error { }

expect(Foo.Value).to(matchError(Bar.self)) // passed
```

incorrectly passes because of a missed error handling case.

Fixes #324