### PR TITLE
Nimble numeric matchers support some c-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,8 @@ Nimble has full support for Objective-C. However, there are two things
 to keep in mind when using Nimble in Objective-C:
 
 1. All parameters passed to the `expect` function, as well as matcher
-   functions like `equal`, must be Objective-C objects:
+   functions like `equal`, must be Objective-C objects or can be converted into
+   an NSObject equivalent:
 
    ```objc
    // Objective-C
@@ -414,6 +415,17 @@ to keep in mind when using Nimble in Objective-C:
 
    expect(@(1 + 1)).to(equal(@2));
    expect(@"Hello world").to(contain(@"world"));
+
+   // Boxed as NSNumber*
+   expect(2).to(equal(2));
+   expect(1.2).to(beLessThan(2.0));
+   expect(true).to(beTruthy());
+
+   // Boxed as NSString *
+   expect("Hello world").to(equal("Hello world"));
+
+   // Boxed as NSRange
+   expect(NSMakeRange(1, 10)).to(equal(NSMakeRange(1, 10)));
    ```
 
 2. To make an expectation on an expression that does not return a value,
@@ -425,6 +437,27 @@ to keep in mind when using Nimble in Objective-C:
 
    expectAction(^{ [exception raise]; }).to(raiseException());
    ```
+
+The following types are currently boxed:
+
+ - **C Numeric types** are converted to `NSNumber *`
+ - `NSRange` is converted to `NSValue *`
+ - `char *` is converted to `NSString *`
+
+For the following matchers:
+
+- `equal`
+- `beGreaterThan`
+- `beGreaterThanOrEqual`
+- `beLessThan`
+- `beLessThanOrEqual`
+- `beCloseTo`
+- `beTrue`
+- `beFalse`
+- `beTruthy`
+- `beFalsy`
+
+If you would like to see more, [file an issue](https://github.com/Quick/Nimble/issues).
 
 ## Disabling Objective-C Shorthand
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ to keep in mind when using Nimble in Objective-C:
 
 1. All parameters passed to the `expect` function, as well as matcher
    functions like `equal`, must be Objective-C objects or can be converted into
-   an NSObject equivalent:
+   an `NSObject` equivalent:
 
    ```objc
    // Objective-C
@@ -438,7 +438,7 @@ to keep in mind when using Nimble in Objective-C:
    expectAction(^{ [exception raise]; }).to(raiseException());
    ```
 
-The following types are currently boxed:
+The following types are currently converted to an `NSObject` type:
 
  - **C Numeric types** are converted to `NSNumber *`
  - `NSRange` is converted to `NSValue *`

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ to keep in mind when using Nimble in Objective-C:
    expect(@(1 + 1)).to(equal(@2));
    expect(@"Hello world").to(contain(@"world"));
 
-   // Boxed as NSNumber*
+   // Boxed as NSNumber *
    expect(2).to(equal(2));
    expect(1.2).to(beLessThan(2.0));
    expect(true).to(beTruthy());

--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ For the following matchers:
 - `beFalse`
 - `beTruthy`
 - `beFalsy`
+- `haveCount`
 
 If you would like to see more, [file an issue](https://github.com/Quick/Nimble/issues).
 

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -33,7 +33,7 @@ public func <(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
 extension NMBObjCMatcher {
     public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let expr = actualExpression.cast { $0 as! NMBComparable? }
+            let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beLessThan(expected).matches(expr, failureMessage: failureMessage)
         }
     }

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -144,28 +144,28 @@ public func beFalsy<T: ExpressibleByBooleanLiteral & Equatable>() -> MatcherFunc
 extension NMBObjCMatcher {
     public class func beTruthyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
-            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
+            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beTruthy().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beFalsyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
-            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
+            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beFalsy().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beTrueMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
-            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
+            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beTrue().matches(expr, failureMessage: failureMessage)
         }
     }
 
     public class func beFalseMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false as Bool? }
+            let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beFalse().matches(expr, failureMessage: failureMessage)
         }
     }

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -6,48 +6,215 @@
 @protocol NMBMatcher;
 
 
+NS_ASSUME_NONNULL_BEGIN
+
+
+#define NIMBLE_OVERLOADABLE __attribute__((overloadable))
 #define NIMBLE_EXPORT FOUNDATION_EXPORT
+#define NIMBLE_EXPORT_INLINE FOUNDATION_STATIC_INLINE
+
+#define NIMBLE_VALUE_OF(VAL) ({ \
+    __typeof__((VAL)) val = (VAL); \
+    [NSValue valueWithBytes:&val objCType:@encode(__typeof__((VAL)))]; \
+})
 
 #ifdef NIMBLE_DISABLE_SHORT_SYNTAX
 #define NIMBLE_SHORT(PROTO, ORIGINAL)
+#define NIMBLE_SHORT_OVERLOADED(PROTO, ORIGINAL)
 #else
 #define NIMBLE_SHORT(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE PROTO { return (ORIGINAL); }
+#define NIMBLE_SHORT_OVERLOADED(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE NIMBLE_OVERLOADABLE PROTO { return (ORIGINAL); }
 #endif
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+
+
+#define DEFINE_NMB_EXPECT_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBExpectation *NMB_expect(TYPE(^actualBlock)(), NSString *file, NSUInteger line) { \
+            return NMB_expect(^id { return EXPR; }, file, line); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+
+    // overloaded dispatch for nils - expect(nil)
+    DEFINE_NMB_EXPECT_OVERLOAD(void*, nil)
+    DEFINE_NMB_EXPECT_OVERLOAD(NSRange, NIMBLE_VALUE_OF(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(int, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned int, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(float, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(double, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(long long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned long long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(char, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned char, @(actualBlock()))
+
+#undef DEFINE_NMB_EXPECT_OVERLOAD
+
+
+
 NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line);
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> equal(id expectedValue),
-             NMB_equal(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_haveCount(id expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> haveCount(id expectedValue),
-             NMB_haveCount(expectedValue));
 
-NIMBLE_EXPORT NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
-NIMBLE_SHORT(NMBObjCBeCloseToMatcher *beCloseTo(id expectedValue),
-             NMB_beCloseTo(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_equal(TYPE expectedValue) { \
+            return NMB_equal((EXPR)); \
+        } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> equal(TYPE expectedValue), NMB_equal(expectedValue));
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_equal(id expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> equal(id expectedValue) { return NMB_equal(expectedValue); }
+
+    DEFINE_OVERLOAD(NSRange, NIMBLE_VALUE_OF(expectedValue))
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_haveCount(TYPE expectedValue) { \
+            return NMB_haveCount((EXPR)); \
+        } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> haveCount(TYPE expectedValue), NMB_haveCount(expectedValue));
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_haveCount(id expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> haveCount(id expectedValue) {
+        return NMB_haveCount(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBObjCBeCloseToMatcher *NMB_beCloseTo(TYPE expectedValue) { \
+            return NMB_beCloseTo((NSNumber *)(EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBObjCBeCloseToMatcher *beCloseTo(TYPE expectedValue) { \
+            return NMB_beCloseTo(expectedValue); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    NMBObjCBeCloseToMatcher *beCloseTo(NSNumber *expectedValue) {
+        return NMB_beCloseTo(expectedValue);
+    }
+
+    // it would be better to only overload float & double, but zero becomes ambigious
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass);
-NIMBLE_SHORT(id<NMBMatcher> beAnInstanceOf(Class expectedClass),
-             NMB_beAnInstanceOf(expectedClass));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beAnInstanceOf(Class expectedClass) {
+    return NMB_beAnInstanceOf(expectedClass);
+}
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAKindOf(Class expectedClass);
-NIMBLE_SHORT(id<NMBMatcher> beAKindOf(Class expectedClass),
-             NMB_beAKindOf(expectedClass));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beAKindOf(Class expectedClass) {
+    return NMB_beAKindOf(expectedClass);
+}
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beginWith(id itemElementOrSubstring);
-NIMBLE_SHORT(id<NMBMatcher> beginWith(id itemElementOrSubstring),
-             NMB_beginWith(itemElementOrSubstring));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
+    return NMB_beginWith(itemElementOrSubstring);
+}
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beGreaterThan(NSNumber *expectedValue),
-             NMB_beGreaterThan(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beGreaterThan(TYPE expectedValue) { return NMB_beGreaterThan((EXPR)); } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beGreaterThan(TYPE expectedValue), NMB_beGreaterThan(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beGreaterThanOrEqualTo(NSNumber *expectedValue),
-             NMB_beGreaterThanOrEqualTo(expectedValue));
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beGreaterThan(NSNumber *expectedValue) {
+        return NMB_beGreaterThan(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beGreaterThanOrEqualTo(TYPE expectedValue) { \
+            return NMB_beGreaterThanOrEqualTo((EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> beGreaterThanOrEqualTo(TYPE expectedValue) { \
+            return NMB_beGreaterThanOrEqualTo(expectedValue); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beGreaterThanOrEqualTo(NSNumber *expectedValue) {
+        return NMB_beGreaterThanOrEqualTo(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance);
 NIMBLE_SHORT(id<NMBMatcher> beIdenticalTo(id expectedInstance),
@@ -57,13 +224,71 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance);
 NIMBLE_SHORT(id<NMBMatcher> be(id expectedInstance),
              NMB_be(expectedInstance));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beLessThan(NSNumber *expectedValue),
-             NMB_beLessThan(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beLessThanOrEqualTo(NSNumber *expectedValue),
-             NMB_beLessThanOrEqualTo(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beLessThan(TYPE expectedValue) { \
+            return NMB_beLessThan((EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> beLessThan(TYPE expectedValue) { \
+            return NMB_beLessThan(expectedValue); \
+        }
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beLessThan(NSNumber *expectedValue) {
+        return NMB_beLessThan(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+    id<NMBMatcher> NMB_beLessThanOrEqualTo(TYPE expectedValue) { \
+        return NMB_beLessThanOrEqualTo((EXPR)); \
+    } \
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+    id<NMBMatcher> beLessThanOrEqualTo(TYPE expectedValue) { \
+        return NMB_beLessThanOrEqualTo(expectedValue); \
+    }
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beLessThanOrEqualTo(NSNumber *expectedValue) {
+        return NMB_beLessThanOrEqualTo(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beTruthy(void);
 NIMBLE_SHORT(id<NMBMatcher> beTruthy(void),
@@ -133,8 +358,10 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 #define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
 #define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
+#undef NIMBLE_VALUE_OF
+
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
-#define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
+#define expect(...) NMB_expect(^{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
 #define expectAction(BLOCK) NMB_expectAction((BLOCK), @(__FILE__), __LINE__)
 #define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
 #define fail() failWithMessage(@"fail() always fails")
@@ -142,4 +369,7 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil
+
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
     DEFINE_NMB_EXPECT_OVERLOAD(unsigned long long, @(actualBlock()))
     DEFINE_NMB_EXPECT_OVERLOAD(char, @(actualBlock()))
     DEFINE_NMB_EXPECT_OVERLOAD(unsigned char, @(actualBlock()))
+    // bool doesn't get the compiler to dispatch to BOOL types, but using BOOL here seems to allow
+    // the compiler to dispatch to bool.
+    DEFINE_NMB_EXPECT_OVERLOAD(BOOL, @(actualBlock()))
 
 #undef DEFINE_NMB_EXPECT_OVERLOAD
 

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -53,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
     // bool doesn't get the compiler to dispatch to BOOL types, but using BOOL here seems to allow
     // the compiler to dispatch to bool.
     DEFINE_NMB_EXPECT_OVERLOAD(BOOL, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(char *, @(actualBlock()))
+
 
 #undef DEFINE_NMB_EXPECT_OVERLOAD
 
@@ -71,11 +73,13 @@ NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *f
 
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
-    id<NMBMatcher> NMB_equal(id expectedValue);
+    id<NMBMatcher> NMB_equal(__nullable id expectedValue);
 
-    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
-    id<NMBMatcher> equal(id expectedValue) { return NMB_equal(expectedValue); }
+    NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> equal(__nullable id expectedValue),
+                            NMB_equal(expectedValue));
 
+    // overloaded dispatch for nils - expect(nil)
+    DEFINE_OVERLOAD(void*__nullable, (id)nil)
     DEFINE_OVERLOAD(NSRange, NIMBLE_VALUE_OF(expectedValue))
     DEFINE_OVERLOAD(long, @(expectedValue))
     DEFINE_OVERLOAD(unsigned long, @(expectedValue))
@@ -87,6 +91,10 @@ NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *f
     DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
     DEFINE_OVERLOAD(char, @(expectedValue))
     DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+    // bool doesn't get the compiler to dispatch to BOOL types, but using BOOL here seems to allow
+    // the compiler to dispatch to bool.
+    DEFINE_OVERLOAD(BOOL, @(expectedValue))
+    DEFINE_OVERLOAD(char *, @(expectedValue))
 
 #undef DEFINE_OVERLOAD
 
@@ -96,16 +104,15 @@ NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *f
         id<NMBMatcher> NMB_haveCount(TYPE expectedValue) { \
             return NMB_haveCount((EXPR)); \
         } \
-        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> haveCount(TYPE expectedValue), NMB_haveCount(expectedValue));
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> haveCount(TYPE expectedValue), \
+            NMB_haveCount(expectedValue));
 
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
     id<NMBMatcher> NMB_haveCount(id expectedValue);
 
-    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
-    id<NMBMatcher> haveCount(id expectedValue) {
-        return NMB_haveCount(expectedValue);
-    }
+    NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> haveCount(id expectedValue),
+                            NMB_haveCount(expectedValue));
 
     DEFINE_OVERLOAD(long, @(expectedValue))
     DEFINE_OVERLOAD(unsigned long, @(expectedValue))
@@ -123,16 +130,12 @@ NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *f
         NMBObjCBeCloseToMatcher *NMB_beCloseTo(TYPE expectedValue) { \
             return NMB_beCloseTo((NSNumber *)(EXPR)); \
         } \
-        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-        NMBObjCBeCloseToMatcher *beCloseTo(TYPE expectedValue) { \
-            return NMB_beCloseTo(expectedValue); \
-        }
+        NIMBLE_SHORT_OVERLOADED(NMBObjCBeCloseToMatcher *beCloseTo(TYPE expectedValue), \
+            NMB_beCloseTo(expectedValue));
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
-    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
-    NMBObjCBeCloseToMatcher *beCloseTo(NSNumber *expectedValue) {
-        return NMB_beCloseTo(expectedValue);
-    }
+    NIMBLE_SHORT_OVERLOADED(NMBObjCBeCloseToMatcher *beCloseTo(NSNumber *expectedValue),
+                            NMB_beCloseTo(expectedValue));
 
     // it would be better to only overload float & double, but zero becomes ambigious
 
@@ -166,7 +169,9 @@ NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
 
 #define DEFINE_OVERLOAD(TYPE, EXPR) \
         NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-        id<NMBMatcher> NMB_beGreaterThan(TYPE expectedValue) { return NMB_beGreaterThan((EXPR)); } \
+        id<NMBMatcher> NMB_beGreaterThan(TYPE expectedValue) { \
+            return NMB_beGreaterThan((EXPR)); \
+        } \
         NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beGreaterThan(TYPE expectedValue), NMB_beGreaterThan(expectedValue));
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
@@ -193,10 +198,8 @@ NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
         id<NMBMatcher> NMB_beGreaterThanOrEqualTo(TYPE expectedValue) { \
             return NMB_beGreaterThanOrEqualTo((EXPR)); \
         } \
-        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-        id<NMBMatcher> beGreaterThanOrEqualTo(TYPE expectedValue) { \
-            return NMB_beGreaterThanOrEqualTo(expectedValue); \
-        }
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beGreaterThanOrEqualTo(TYPE expectedValue), \
+            NMB_beGreaterThanOrEqualTo(expectedValue));
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
     id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
@@ -217,6 +220,7 @@ NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
     DEFINE_OVERLOAD(char, @(expectedValue))
     DEFINE_OVERLOAD(unsigned char, @(expectedValue))
 
+
 #undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance);
@@ -233,11 +237,8 @@ NIMBLE_SHORT(id<NMBMatcher> be(id expectedInstance),
         id<NMBMatcher> NMB_beLessThan(TYPE expectedValue) { \
             return NMB_beLessThan((EXPR)); \
         } \
-        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-        id<NMBMatcher> beLessThan(TYPE expectedValue) { \
-            return NMB_beLessThan(expectedValue); \
-        }
-
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beLessThan(TYPE expectedValue), \
+            NMB_beLessThan(expectedValue));
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
     id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
@@ -266,10 +267,8 @@ NIMBLE_SHORT(id<NMBMatcher> be(id expectedInstance),
     id<NMBMatcher> NMB_beLessThanOrEqualTo(TYPE expectedValue) { \
         return NMB_beLessThanOrEqualTo((EXPR)); \
     } \
-    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-    id<NMBMatcher> beLessThanOrEqualTo(TYPE expectedValue) { \
-        return NMB_beLessThanOrEqualTo(expectedValue); \
-    }
+    NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beLessThanOrEqualTo(TYPE expectedValue), \
+        NMB_beLessThanOrEqualTo(expectedValue));
 
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
@@ -361,8 +360,6 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 #define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
 #define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
-#undef NIMBLE_VALUE_OF
-
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
 #define expect(...) NMB_expect(^{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
 #define expectAction(BLOCK) NMB_expectAction((BLOCK), @(__FILE__), __LINE__)
@@ -372,6 +369,8 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil
+
+#undef NIMBLE_VALUE_OF
 
 #endif
 

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -9,7 +9,11 @@ SWIFT_CLASS("_TtC6Nimble7NMBWait")
 
 @end
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line) {
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBExpectation *__nonnull NMB_expect(id __nullable(^actualBlock)(), NSString *__nonnull file, NSUInteger line) {
     return [[NMBExpectation alloc] initWithActualBlock:actualBlock
                                               negative:NO
                                                   file:file
@@ -35,7 +39,7 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beAKindOf(Class expectedClass) {
     return [NMBObjCMatcher beAKindOfMatcher:expectedClass];
 }
 
-NIMBLE_EXPORT NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beCloseToMatcher:expectedValue within:0.001];
 }
 
@@ -43,11 +47,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beginWith(id itemElementOrSubstring) {
     return [NMBObjCMatcher beginWithMatcher:itemElementOrSubstring];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue) {
     return [NMBObjCMatcher beGreaterThanMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beGreaterThanOrEqualToMatcher:expectedValue];
 }
 
@@ -59,11 +63,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance) {
     return [NMBObjCMatcher beIdenticalToMatcher:expectedInstance];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue) {
     return [NMBObjCMatcher beLessThanMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beLessThanOrEqualToMatcher:expectedValue];
 }
 
@@ -113,11 +117,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring) {
     return [NMBObjCMatcher endWithMatcher:itemElementOrSubstring];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_equal(id expectedValue) {
     return [NMBObjCMatcher equalMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_haveCount(id expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_haveCount(id expectedValue) {
     return [NMBObjCMatcher haveCountMatcher:expectedValue];
 }
 
@@ -148,3 +152,5 @@ NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger 
     [NMBWait untilFile:file line:line action:action];
   };
 }
+
+NS_ASSUME_NONNULL_END

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -117,7 +117,7 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring) {
     return [NMBObjCMatcher endWithMatcher:itemElementOrSubstring];
 }
 
-NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_equal(id expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_equal(__nullable id expectedValue) {
     return [NMBObjCMatcher equalMatcher:expectedValue];
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeCloseToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeCloseToTest.m
@@ -12,6 +12,11 @@
     expect(@1.2).to(beCloseTo(@2).within(10));
     expect(@2).toNot(beCloseTo(@1));
     expect(@1.00001).toNot(beCloseTo(@1).within(0.00000001));
+
+    expect(1.2).to(beCloseTo(1.2001));
+    expect(1.2).to(beCloseTo(2).within(10));
+    expect(2).toNot(beCloseTo(1));
+    expect(1.00001).toNot(beCloseTo(1).within(0.00000001));
 }
 
 - (void)testNegativeMatches {
@@ -20,6 +25,12 @@
     });
     expectFailureMessage(@"expected to not be close to <0> (within 0.001), got <0.0001>", ^{
         expect(@(0.0001)).toNot(beCloseTo(@0));
+    });
+    expectFailureMessage(@"expected to be close to <0> (within 0.001), got <1>", ^{
+        expect(1).to(beCloseTo(0));
+    });
+    expectFailureMessage(@"expected to not be close to <0> (within 0.001), got <0.0001>", ^{
+        expect(0.0001).toNot(beCloseTo(0));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeFalseTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeFalseTest.m
@@ -10,6 +10,14 @@
 - (void)testPositiveMatches {
     expect(@NO).to(beFalse());
     expect(@YES).toNot(beFalse());
+
+    expect(false).to(beFalse());
+    expect(true).toNot(beFalse());
+
+    expect(NO).to(beFalse());
+    expect(YES).toNot(beFalse());
+
+    expect(10).toNot(beFalse());
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +26,20 @@
     });
     expectNilFailureMessage(@"expected to not be false, got <nil>", ^{
         expect(nil).toNot(beFalse());
+    });
+
+    expectFailureMessage(@"expected to be false, got <1>", ^{
+        expect(true).to(beFalse());
+    });
+    expectFailureMessage(@"expected to not be false, got <0>", ^{
+        expect(false).toNot(beFalse());
+    });
+
+    expectFailureMessage(@"expected to be false, got <1>", ^{
+        expect(YES).to(beFalse());
+    });
+    expectFailureMessage(@"expected to not be false, got <0>", ^{
+        expect(NO).toNot(beFalse());
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeFalsyTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeFalsyTest.m
@@ -11,6 +11,15 @@
     expect(@NO).to(beFalsy());
     expect(@YES).toNot(beFalsy());
     expect(nil).to(beFalsy());
+
+    expect(true).toNot(beFalsy());
+    expect(false).to(beFalsy());
+
+    expect(YES).toNot(beFalsy());
+    expect(NO).to(beFalsy());
+
+    expect(10).toNot(beFalsy());
+    expect(0).to(beFalsy());
 }
 
 - (void)testNegativeMatches {
@@ -20,8 +29,29 @@
     expectFailureMessage(@"expected to be falsy, got <1>", ^{
         expect(@1).to(beFalsy());
     });
-    expectFailureMessage(@"expected to be truthy, got <0>", ^{
-        expect(@NO).to(beTruthy());
+    expectFailureMessage(@"expected to not be falsy, got <0>", ^{
+        expect(@NO).toNot(beFalsy());
+    });
+
+    expectFailureMessage(@"expected to be falsy, got <1>", ^{
+        expect(true).to(beFalsy());
+    });
+    expectFailureMessage(@"expected to not be falsy, got <0>", ^{
+        expect(false).toNot(beFalsy());
+    });
+
+    expectFailureMessage(@"expected to be falsy, got <1>", ^{
+        expect(YES).to(beFalsy());
+    });
+    expectFailureMessage(@"expected to not be falsy, got <0>", ^{
+        expect(NO).toNot(beFalsy());
+    });
+
+    expectFailureMessage(@"expected to be falsy, got <10>", ^{
+        expect(10).to(beFalsy());
+    });
+    expectFailureMessage(@"expected to not be falsy, got <0>", ^{
+        expect(0).toNot(beFalsy());
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beGreaterThanOrEqualTo(@2));
     expect(@2).toNot(beGreaterThanOrEqualTo(@3));
+    expect(2).to(beGreaterThanOrEqualTo(0));
+    expect(2).to(beGreaterThanOrEqualTo(2));
+    expect(2).toNot(beGreaterThanOrEqualTo(3));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,12 @@
     });
     expectFailureMessage(@"expected to not be greater than or equal to <1>, got <2>", ^{
         expect(@2).toNot(beGreaterThanOrEqualTo(@(1)));
+    });
+    expectFailureMessage(@"expected to be greater than or equal to <0>, got <-1>", ^{
+        expect(-1).to(beGreaterThanOrEqualTo(0));
+    });
+    expectFailureMessage(@"expected to not be greater than or equal to <1>, got <2>", ^{
+        expect(2).toNot(beGreaterThanOrEqualTo(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
@@ -10,6 +10,8 @@
 - (void)testPositiveMatches {
     expect(@2).to(beGreaterThan(@1));
     expect(@2).toNot(beGreaterThan(@2));
+    expect(@2).to(beGreaterThan(0));
+    expect(@2).toNot(beGreaterThan(2));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +20,12 @@
     });
     expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
         expect(@0).toNot(beGreaterThan(@(1)));
+    });
+    expectFailureMessage(@"expected to be greater than <0>, got <-1>", ^{
+        expect(-1).to(beGreaterThan(0));
+    });
+    expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
+        expect(0).toNot(beGreaterThan(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeIdenticalToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeIdenticalToTest.m
@@ -25,9 +25,12 @@
 
 - (void)testNilMatches {
     NSNull *obj = [NSNull null];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to be identical to nil, got nil", ^{
         expect(nil).to(beIdenticalTo(nil));
     });
+#pragma clang diagnostic pop
     expectNilFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got nil", obj]), ^{
         expect(nil).toNot(beIdenticalTo(obj));
     });
@@ -51,9 +54,12 @@
 
 - (void)testAliasNilMatches {
     NSNull *obj = [NSNull null];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to be identical to nil, got nil", ^{
         expect(nil).to(be(nil));
     });
+#pragma clang diagnostic pop
     expectNilFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got nil", obj]), ^{
         expect(nil).toNot(be(obj));
     });

--- a/Tests/NimbleTests/objc/ObjCBeLessThanOrEqualToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeLessThanOrEqualToTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beLessThanOrEqualTo(@2));
     expect(@2).toNot(beLessThanOrEqualTo(@1));
+    expect(2).to(beLessThanOrEqualTo(2));
+    expect(2).toNot(beLessThanOrEqualTo(1));
+    expect(2).toNot(beLessThanOrEqualTo(0));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,13 @@
     });
     expectFailureMessage(@"expected to not be less than or equal to <1>, got <1>", ^{
         expect(@1).toNot(beLessThanOrEqualTo(@1));
+    });
+
+    expectFailureMessage(@"expected to be less than or equal to <1>, got <2>", ^{
+        expect(2).to(beLessThanOrEqualTo(1));
+    });
+    expectFailureMessage(@"expected to not be less than or equal to <1>, got <1>", ^{
+        expect(1).toNot(beLessThanOrEqualTo(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beLessThan(@3));
     expect(@2).toNot(beLessThan(@2));
+    expect(2).to(beLessThan(3));
+    expect(2).toNot(beLessThan(2));
+    expect(2).toNot(beLessThan(0));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,12 @@
     });
     expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
         expect(@0).toNot(beLessThan(@1));
+    });
+    expectFailureMessage(@"expected to be less than <0>, got <-1>", ^{
+        expect(-1).to(beLessThan(0));
+    });
+    expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
+        expect(0).toNot(beLessThan(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeTrueTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeTrueTest.m
@@ -11,6 +11,12 @@
     expect(@YES).to(beTrue());
     expect(@NO).toNot(beTrue());
     expect(nil).toNot(beTrue());
+
+    expect(true).to(beTrue());
+    expect(false).toNot(beTrue());
+
+    expect(YES).to(beTrue());
+    expect(NO).toNot(beTrue());
 }
 
 - (void)testNegativeMatches {
@@ -19,6 +25,22 @@
     });
     expectFailureMessage(@"expected to be true, got <nil>", ^{
         expect(nil).to(beTrue());
+    });
+
+    expectFailureMessage(@"expected to be true, got <0>", ^{
+        expect(false).to(beTrue());
+    });
+
+    expectFailureMessage(@"expected to not be true, got <1>", ^{
+        expect(true).toNot(beTrue());
+    });
+
+    expectFailureMessage(@"expected to be true, got <0>", ^{
+        expect(NO).to(beTrue());
+    });
+
+    expectFailureMessage(@"expected to not be true, got <1>", ^{
+        expect(YES).toNot(beTrue());
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeTruthyTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeTruthyTest.m
@@ -11,6 +11,15 @@
     expect(@YES).to(beTruthy());
     expect(@NO).toNot(beTruthy());
     expect(nil).toNot(beTruthy());
+
+    expect(true).to(beTruthy());
+    expect(false).toNot(beTruthy());
+
+    expect(YES).to(beTruthy());
+    expect(NO).toNot(beTruthy());
+
+    expect(10).to(beTruthy());
+    expect(0).toNot(beTruthy());
 }
 
 - (void)testNegativeMatches {
@@ -22,6 +31,24 @@
     });
     expectFailureMessage(@"expected to be truthy, got <0>", ^{
         expect(@NO).to(beTruthy());
+    });
+    expectFailureMessage(@"expected to be truthy, got <0>", ^{
+        expect(false).to(beTruthy());
+    });
+    expectFailureMessage(@"expected to not be truthy, got <1>", ^{
+        expect(true).toNot(beTruthy());
+    });
+    expectFailureMessage(@"expected to be truthy, got <0>", ^{
+        expect(NO).to(beTruthy());
+    });
+    expectFailureMessage(@"expected to not be truthy, got <1>", ^{
+        expect(YES).toNot(beTruthy());
+    });
+    expectFailureMessage(@"expected to not be truthy, got <10>", ^{
+        expect(10).toNot(beTruthy());
+    });
+    expectFailureMessage(@"expected to be truthy, got <0>", ^{
+        expect(0).to(beTruthy());
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCEqualTest.m
+++ b/Tests/NimbleTests/objc/ObjCEqualTest.m
@@ -12,6 +12,29 @@
     expect(@1).toNot(equal(@2));
     expect(@1).notTo(equal(@2));
     expect(@"hello").to(equal(@"hello"));
+    expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 10)));
+    expect(NSMakeRange(0, 10)).toNot(equal(NSMakeRange(0, 5)));
+    expect((NSInteger)1).to(equal((NSInteger)1));
+    expect((NSInteger)1).toNot(equal((NSInteger)2));
+    expect((NSUInteger)1).to(equal((NSUInteger)1));
+    expect((NSUInteger)1).toNot(equal((NSUInteger)2));
+    expect(1).to(equal(1));
+    expect(1).toNot(equal(2));
+    expect(1.0).to(equal(1.0)); // Note: not recommended, use beCloseTo() instead
+    expect(1.0).toNot(equal(2.0)); // Note: not recommended, use beCloseTo() instead
+    expect((float)1.0).to(equal((float)1.0));  // Note: not recommended, use beCloseTo() instead
+    expect((float)1.0).toNot(equal((float)2.0));  // Note: not recommended, use beCloseTo() instead
+    expect((double)1.0).to(equal((double)1.0));  // Note: not recommended, use beCloseTo() instead
+    expect((double)1.0).toNot(equal((double)2.0));  // Note: not recommended, use beCloseTo() instead
+    expect((long long)1).to(equal((long long)1));
+    expect((long long)1).toNot(equal((long long)2));
+    expect((unsigned long long)1).to(equal((unsigned long long)1));
+    expect((unsigned long long)1).toNot(equal((unsigned long long)2));
+}
+
+- (void)testNimbleCurrentlyBoxesNumbersWhichAllowsImplicitTypeConversions {
+    expect(1).to(equal(1.0));
+    expect((long long)1).to(equal((unsigned long long)1));
 }
 
 - (void)testNegativeMatches {
@@ -21,15 +44,46 @@
     expectFailureMessage(@"expected to not equal <1>, got <1>", ^{
         expect(@1).toNot(equal(@1));
     });
+    expectFailureMessage(@"expected to equal <NSRange: {0, 5}>, got <NSRange: {0, 10}>", ^{
+        expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 5)));
+    });
+
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((NSInteger)1).to(equal((NSInteger)2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((NSUInteger)1).to(equal((NSUInteger)2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect(1).to(equal(2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect(1.0).to(equal(2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((float)1.0).to(equal((float)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((double)1.0).to(equal((double)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((long long)1.0).to(equal((long long)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((unsigned long long)1.0).to(equal((unsigned long long)2.0));
+    });
 }
 
 - (void)testNilMatches {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
         expect(nil).to(equal(nil));
     });
     expectNilFailureMessage(@"expected to not equal <nil>, got <nil>", ^{
         expect(nil).toNot(equal(nil));
     });
+#pragma clang diagnostic pop
 }
 
 @end

--- a/Tests/NimbleTests/objc/ObjCEqualTest.m
+++ b/Tests/NimbleTests/objc/ObjCEqualTest.m
@@ -12,12 +12,14 @@
     expect(@1).toNot(equal(@2));
     expect(@1).notTo(equal(@2));
     expect(@"hello").to(equal(@"hello"));
+    expect("hello").to(equal("hello"));
     expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 10)));
     expect(NSMakeRange(0, 10)).toNot(equal(NSMakeRange(0, 5)));
     expect((NSInteger)1).to(equal((NSInteger)1));
     expect((NSInteger)1).toNot(equal((NSInteger)2));
     expect((NSUInteger)1).to(equal((NSUInteger)1));
     expect((NSUInteger)1).toNot(equal((NSUInteger)2));
+    expect(0).to(equal(0));
     expect(1).to(equal(1));
     expect(1).toNot(equal(2));
     expect(1.0).to(equal(1.0)); // Note: not recommended, use beCloseTo() instead
@@ -43,6 +45,9 @@
     });
     expectFailureMessage(@"expected to not equal <1>, got <1>", ^{
         expect(@1).toNot(equal(@1));
+    });
+    expectFailureMessage(@"expected to not equal <foo>, got <bar>", ^{
+        expect("bar").toNot(equal("foo"));
     });
     expectFailureMessage(@"expected to equal <NSRange: {0, 5}>, got <NSRange: {0, 10}>", ^{
         expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 5)));
@@ -75,15 +80,15 @@
 }
 
 - (void)testNilMatches {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
+    expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
+        expect(NULL).to(equal(NULL));
+    });
     expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
         expect(nil).to(equal(nil));
     });
     expectNilFailureMessage(@"expected to not equal <nil>, got <nil>", ^{
         expect(nil).toNot(equal(nil));
     });
-#pragma clang diagnostic pop
 }
 
 @end

--- a/Tests/NimbleTests/objc/ObjCHaveCount.m
+++ b/Tests/NimbleTests/objc/ObjCHaveCount.m
@@ -14,6 +14,12 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
+    expect(@[@1, @2, @3]).to(haveCount(3));
+    expect(@[@1, @2, @3]).notTo(haveCount(1));
+
+    expect(@[]).to(haveCount(0));
+    expect(@[@1]).notTo(haveCount(0));
+
     expectFailureMessage(@"expected to have NSArray with count 1, got 3\nActual Value: (1, 2, 3)", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
@@ -22,11 +28,21 @@
         expect(@[@1, @2, @3]).notTo(haveCount(@3));
     });
 
+    expectFailureMessage(@"expected to have NSArray with count 1, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(@[@1, @2, @3]).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSArray with count 3, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(@[@1, @2, @3]).notTo(haveCount(3));
+    });
 }
 
 - (void)testHaveCountForNSDictionary {
     expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@3));
     expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@1));
+
+    expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(3));
+    expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSDictionary with count 1, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@1));
@@ -34,6 +50,14 @@
 
     expectFailureMessage(@"expected to not have NSDictionary with count 3, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@3));
+    });
+
+    expectFailureMessage(@"expected to have NSDictionary with count 1, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
+        expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSDictionary with count 3, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
+        expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(3));
     });
 }
 
@@ -46,6 +70,9 @@
     expect(table).to(haveCount(@3));
     expect(table).notTo(haveCount(@1));
 
+    expect(table).to(haveCount(3));
+    expect(table).notTo(haveCount(1));
+
     NSString *msg = [NSString stringWithFormat:
                      @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
                      [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
@@ -53,12 +80,26 @@
         expect(table).to(haveCount(@1));
     });
 
-
     msg = [NSString stringWithFormat:
            @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
            [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
     expectFailureMessage(msg, ^{
         expect(table).notTo(haveCount(@3));
+    });
+
+
+    msg = [NSString stringWithFormat:
+           @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
+           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+    expectFailureMessage(msg, ^{
+        expect(table).to(haveCount(1));
+    });
+
+    msg = [NSString stringWithFormat:
+           @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
+           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+    expectFailureMessage(msg, ^{
+        expect(table).notTo(haveCount(3));
     });
 }
 
@@ -67,6 +108,8 @@
 
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
+    expect(set).to(haveCount(3));
+    expect(set).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSSet with count 1, got 3\nActual Value: {(3,1,2)}", ^{
         expect(set).to(haveCount(@1));
@@ -75,6 +118,14 @@
     expectFailureMessage(@"expected to not have NSSet with count 3, got 3\nActual Value: {(3,1,2)}", ^{
         expect(set).notTo(haveCount(@3));
     });
+
+    expectFailureMessage(@"expected to have NSSet with count 1, got 3\nActual Value: {(3,1,2)}", ^{
+        expect(set).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSSet with count 3, got 3\nActual Value: {(3,1,2)}", ^{
+        expect(set).notTo(haveCount(3));
+    });
 }
 
 - (void)testHaveCountForNSIndexSet {
@@ -82,6 +133,8 @@
 
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
+    expect(set).to(haveCount(3));
+    expect(set).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSIndexSet with count 1, got 3\nActual Value: (1, 2, 3)", ^{
         expect(set).to(haveCount(@1));
@@ -89,6 +142,14 @@
 
     expectFailureMessage(@"expected to not have NSIndexSet with count 3, got 3\nActual Value: (1, 2, 3)", ^{
         expect(set).notTo(haveCount(@3));
+    });
+
+    expectFailureMessage(@"expected to have NSIndexSet with count 1, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(set).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSIndexSet with count 3, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(set).notTo(haveCount(3));
     });
 }
 
@@ -99,6 +160,14 @@
 
     expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFNumber", ^{
         expect(@1).to(haveCount(@6));
+    });
+
+    expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFConstantString", ^{
+        expect(@"string").to(haveCount(6));
+    });
+
+    expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFNumber", ^{
+        expect(@1).to(haveCount(6));
     });
 }
 


### PR DESCRIPTION
- Add (non-)nullability for Nimble's Objective-C Headers
- Convert assertion to optional

Example:

```objc
// objc
expect(2).to(equal(2));
expect(98.7).to(beCloseTo(98.7));
expect(2).to(beLessThan(100));
expect(@[@1, @2]).to(haveCount(2));
```

# TODO

- [x] Needs Documentation
- [x] Fix #113 
- [x] Fix #254