### PR TITLE
Add support for Swift-only types to type checking matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ expect(ocean.isClean).toEventually(beTruthy())
 - [Some Background: Expressing Outcomes Using Assertions in XCTest](#some-background-expressing-outcomes-using-assertions-in-xctest)
 - [Nimble: Expectations Using `expect(...).to`](#nimble-expectations-using-expectto)
   - [Custom Failure Messages](#custom-failure-messages)
-  - [Type Checking](#type-checking)
+  - [Type Safety](#type-safety)
   - [Operator Overloads](#operator-overloads)
   - [Lazily Computed Values](#lazily-computed-values)
   - [C Primitives](#c-primitives)
@@ -31,6 +31,7 @@ expect(ocean.isClean).toEventually(beTruthy())
   - [Objective-C Support](#objective-c-support)
   - [Disabling Objective-C Shorthand](#disabling-objective-c-shorthand)
 - [Built-in Matcher Functions](#built-in-matcher-functions)
+  - [Type Checking](#type-checking)
   - [Equivalence](#equivalence)
   - [Identity](#identity)
   - [Comparisons](#comparisons)
@@ -164,7 +165,7 @@ expect(@(1+1)).toWithDescription(equal(@3), @"Make sure libKindergartenMath is l
 // expected to equal <3.0000>, got <2.0000>
 ```
 
-## Type Checking
+## Type Safety
 
 Nimble makes sure you don't compare two types that don't match:
 
@@ -488,6 +489,42 @@ NMB_expect(^{ return seagull.squawk; }, __FILE__, __LINE__).to(NMB_equal(@"Squee
 # Built-in Matcher Functions
 
 Nimble includes a wide variety of matcher functions.
+
+## Type checking
+
+Nimble supports checking the type membership of any kind of object, whether
+Objective-C conformant or not:
+
+```swift
+// Swift 
+
+protocol SomeProtocol{}
+class SomeClassConformingToProtocol: SomeProtocol{}
+struct SomeStructConformingToProtocol: SomeProtocol{}
+
+// The following tests pass
+expect(1).to(beKindOf(Int.self))
+expect("turtle").to(beKindOf(String.self))
+
+let classObject = SomeClassConformingToProtocol()
+expect(classObject).to(beKindOf(SomeProtocol.self))
+expect(classObject).to(beKindOf(SomeClassConformingToProtocol.self))
+expect(classObject).toNot(beKindOf(SomeStructConformingToProtocol.self))
+
+let structObject = SomeStructConformingToProtocol()
+expect(structObject).to(beKindOf(SomeProtocol.self))
+expect(structObject).to(beKindOf(SomeStructConformingToProtocol.self))
+expect(structObject).toNot(beKindOf(SomeClassConformingToProtocol.self))
+```
+
+```objc
+// Objective-C
+
+// The following tests pass
+NSMutableArray *array = [NSMutableArray array];
+expect(array).to(beAKindOf([NSArray class]));
+expect(@1).toNot(beAKindOf([NSNull class]));
+```
 
 ## Equivalence
 

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ NMB_expect(^{ return seagull.squawk; }, __FILE__, __LINE__).to(NMB_equal(@"Squee
 
 Nimble includes a wide variety of matcher functions.
 
-## Type checking
+## Type Checking
 
 Nimble supports checking the type membership of any kind of object, whether
 Objective-C conformant or not:
@@ -525,6 +525,31 @@ NSMutableArray *array = [NSMutableArray array];
 expect(array).to(beAKindOf([NSArray class]));
 expect(@1).toNot(beAKindOf([NSNull class]));
 ```
+
+Objects can be tested for their exact types using the `beAnInstanceOf` matcher:
+```swift
+// Swift 
+
+protocol SomeProtocol{}
+class SomeClassConformingToProtocol: SomeProtocol{}
+struct SomeStructConformingToProtocol: SomeProtocol{}
+
+// Unlike the 'beKindOf' matcher, the 'beAnInstanceOf' matcher only 
+// passes if the object is the EXACT type requested. The following
+// tests pass -- note its behavior when working in an inheritance hierarchy. 
+expect(1).to(beAnInstanceOf(Int.self))
+expect("turtle").to(beAnInstanceOf(String.self))
+
+let classObject = SomeClassConformingToProtocol()
+expect(classObject).toNot(beAnInstanceOf(SomeProtocol.self))
+expect(classObject).to(beAnInstanceOf(SomeClassConformingToProtocol.self))
+expect(classObject).toNot(beAnInstanceOf(SomeStructConformingToProtocol.self))
+
+let structObject = SomeStructConformingToProtocol()
+expect(structObject).toNot(beAnInstanceOf(SomeProtocol.self))
+expect(structObject).to(beAnInstanceOf(SomeStructConformingToProtocol.self))
+expect(structObject).toNot(beAnInstanceOf(SomeClassConformingToProtocol.self))
+````
 
 ## Equivalence
 

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-#if _runtime(_ObjC)
-
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
 public func beAKindOf<T>(_ expectedType: T.Type) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in
@@ -44,5 +42,3 @@ extension NMBObjCMatcher {
         }
     }
 }
-
-#endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -2,13 +2,23 @@ import Foundation
 
 #if _runtime(_ObjC)
 
-// A Nimble matcher that catches attempts to use beAKindOf with non Objective-C types
-public func beAKindOf(_ expectedClass: Any) -> NonNilMatcherFunc<Any> {
+/// A Nimble matcher that succeeds when the actual value is an instance of the given class.
+public func beAKindOf<T>(_ expectedType: T.Type) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in
-        failureMessage.stringValue = "beAKindOf only works on Objective-C types since"
-            + " the Swift compiler will automatically type check Swift-only types."
-            + " This expectation is redundant."
-        return false
+        failureMessage.postfixMessage = "be a kind of \(String(describing: expectedType))"
+        let instance = try actualExpression.evaluate()
+        guard let validInstance = instance else {
+            failureMessage.actualValue = "<nil>"
+            return false
+        }
+
+        failureMessage.actualValue = "<\(String(describing: type(of: validInstance))) instance>"
+
+        guard validInstance is T else {
+            return false
+        }
+
+        return true
     }
 }
 

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -20,6 +20,8 @@ public func beAKindOf<T>(_ expectedType: T.Type) -> NonNilMatcherFunc<Any> {
     }
 }
 
+#if _runtime(_ObjC)
+
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
 /// @see beAnInstanceOf if you want to match against the exact class
 public func beAKindOf(_ expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> {
@@ -35,7 +37,6 @@ public func beAKindOf(_ expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> 
     }
 }
 
-#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beAKindOfMatcher(_ expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -44,4 +44,5 @@ extension NMBObjCMatcher {
         }
     }
 }
+
 #endif

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -35,6 +35,7 @@ public func beAKindOf(_ expectedClass: AnyClass) -> NonNilMatcherFunc<NSObject> 
     }
 }
 
+#if _runtime(_ObjC)
 extension NMBObjCMatcher {
     public class func beAKindOfMatcher(_ expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
@@ -42,3 +43,4 @@ extension NMBObjCMatcher {
         }
     }
 }
+#endif

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -1,11 +1,21 @@
 import Foundation
 
-// A Nimble matcher that catches attempts to use beAnInstanceOf with non Objective-C types
-public func beAnInstanceOf(_ expectedClass: Any) -> NonNilMatcherFunc<Any> {
+/// A Nimble matcher that succeeds when the actual value is an _exact_ instance of the given class.
+public func beAnInstanceOf<T>(_ expectedType: T.Type) -> NonNilMatcherFunc<Any> {
     return NonNilMatcherFunc {actualExpression, failureMessage in
-        failureMessage.stringValue = "beAnInstanceOf only works on Objective-C types since"
-            + " the Swift compiler will automatically type check Swift-only types."
-            + " This expectation is redundant."
+        failureMessage.postfixMessage = "be an instance of \(String(describing: expectedType))"
+        let instance = try actualExpression.evaluate()
+        guard let validInstance = instance else {
+            failureMessage.actualValue = "<nil>"
+            return false
+        }
+
+        failureMessage.actualValue = "<\(String(describing: type(of: validInstance))) instance>"
+
+        if type(of: validInstance) == expectedType {
+            return true
+        }
+
         return false
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,7 +10,7 @@ XCTMain([
 
     // Matchers
     testCase(AllPassTest.allTests),
-    // testCase(BeAKindOfTest.allTests),
+    testCase(BeAKindOfSwiftTest.allTests),
     testCase(BeAnInstanceOfTest.allTests),
     testCase(BeCloseToTest.allTests),
     testCase(BeginWithTest.allTests),

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -1,8 +1,6 @@
 import XCTest
 import Nimble
 
-#if _runtime(_ObjC)
-
 fileprivate class TestNull : NSNull {}
 fileprivate protocol TestProtocol {}
 fileprivate class TestClassConformingToProtocol: TestProtocol{}
@@ -77,4 +75,3 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
-#endif

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import Nimble
 

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -1,10 +1,10 @@
 import XCTest
 import Nimble
 
-fileprivate class TestNull : NSNull {}
+fileprivate class TestNull: NSNull {}
 fileprivate protocol TestProtocol {}
-fileprivate class TestClassConformingToProtocol: TestProtocol{}
-fileprivate struct TestStructConformingToProtocol: TestProtocol{}
+fileprivate class TestClassConformingToProtocol: TestProtocol {}
+fileprivate struct TestStructConformingToProtocol: TestProtocol {}
 
 final class BeAKindOfSwiftTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAKindOfSwiftTest) -> () throws -> Void)] {
@@ -54,6 +54,7 @@ final class BeAKindOfSwiftTest: XCTestCase, XCTestCaseProvider {
 }
 
 #if _runtime(_ObjC)
+
 final class BeAKindOfObjCTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAKindOfObjCTest) -> () throws -> Void)] {
         return [
@@ -83,4 +84,5 @@ final class BeAKindOfObjCTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+
 #endif

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -3,10 +3,10 @@ import Nimble
 
 #if _runtime(_ObjC)
 
-class TestNull : NSNull {}
-protocol TestProtocol {}
-class TestClassConformingToProtocol: TestProtocol{}
-struct TestStructConformingToProtocol: TestProtocol{}
+class KindOfTestNull : NSNull {}
+protocol KindOfTestProtocol {}
+class KindOfTestClassConformingToProtocol: KindOfTestProtocol{}
+struct KindOfTestStructConformingToProtocol: KindOfTestProtocol{}
 
 final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAKindOfTest) -> () throws -> Void)] {
@@ -19,7 +19,7 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testPositiveMatch() {
-        expect(TestNull()).to(beAKindOf(NSNull.self))
+        expect(KindOfTestNull()).to(beAKindOf(NSNull.self))
         expect(NSObject()).to(beAKindOf(NSObject.self))
         expect(NSNumber(value:1)).toNot(beAKindOf(NSDate.self))
     }
@@ -28,7 +28,7 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         expect(1).to(beAKindOf(Int.self))
         expect(1).toNot(beAKindOf(String.self))
         expect("turtle string").to(beAKindOf(String.self))
-        expect("turtle string").toNot(beAKindOf(TestClassConformingToProtocol.self))
+        expect("turtle string").toNot(beAKindOf(KindOfTestClassConformingToProtocol.self))
 
         enum TestEnum {
             case one, two
@@ -36,15 +36,15 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
 
         expect(TestEnum.one).to(beAKindOf(TestEnum.self))
 
-        let testProtocolClass = TestClassConformingToProtocol()
-        expect(testProtocolClass).to(beAKindOf(TestClassConformingToProtocol.self))
-        expect(testProtocolClass).to(beAKindOf(TestProtocol.self))
-        expect(testProtocolClass).toNot(beAKindOf(TestStructConformingToProtocol.self))
+        let testProtocolClass = KindOfTestClassConformingToProtocol()
+        expect(testProtocolClass).to(beAKindOf(KindOfTestClassConformingToProtocol.self))
+        expect(testProtocolClass).to(beAKindOf(KindOfTestProtocol.self))
+        expect(testProtocolClass).toNot(beAKindOf(KindOfTestStructConformingToProtocol.self))
 
-        let testProtocolStruct = TestStructConformingToProtocol()
-        expect(testProtocolStruct).to(beAKindOf(TestStructConformingToProtocol.self))
-        expect(testProtocolStruct).to(beAKindOf(TestProtocol.self))
-        expect(testProtocolStruct).toNot(beAKindOf(TestClassConformingToProtocol.self))
+        let testProtocolStruct = KindOfTestStructConformingToProtocol()
+        expect(testProtocolStruct).to(beAKindOf(KindOfTestStructConformingToProtocol.self))
+        expect(testProtocolStruct).to(beAKindOf(KindOfTestProtocol.self))
+        expect(testProtocolStruct).toNot(beAKindOf(KindOfTestClassConformingToProtocol.self))
     }
 
     func testFailureMessages() {
@@ -67,9 +67,9 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
             expect(1).toNot(beAKindOf(Int.self))
         }
 
-        let testClass = TestClassConformingToProtocol()
-        failsWithErrorMessage("expected to not be a kind of TestProtocol, got <TestClassConformingToProtocol instance>") {
-            expect(testClass).toNot(beAKindOf(TestProtocol.self))
+        let testClass = KindOfTestClassConformingToProtocol()
+        failsWithErrorMessage("expected to not be a kind of KindOfTestProtocol, got <KindOfTestClassConformingToProtocol instance>") {
+            expect(testClass).toNot(beAKindOf(KindOfTestProtocol.self))
         }
 
         failsWithErrorMessage("expected to be a kind of String, got <Int instance>") {

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -3,10 +3,10 @@ import Nimble
 
 #if _runtime(_ObjC)
 
-class KindOfTestNull : NSNull {}
-protocol KindOfTestProtocol {}
-class KindOfTestClassConformingToProtocol: KindOfTestProtocol{}
-struct KindOfTestStructConformingToProtocol: KindOfTestProtocol{}
+fileprivate class TestNull : NSNull {}
+fileprivate protocol TestProtocol {}
+fileprivate class TestClassConformingToProtocol: TestProtocol{}
+fileprivate struct TestStructConformingToProtocol: TestProtocol{}
 
 final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAKindOfTest) -> () throws -> Void)] {
@@ -19,7 +19,7 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testPositiveMatch() {
-        expect(KindOfTestNull()).to(beAKindOf(NSNull.self))
+        expect(TestNull()).to(beAKindOf(NSNull.self))
         expect(NSObject()).to(beAKindOf(NSObject.self))
         expect(NSNumber(value:1)).toNot(beAKindOf(NSDate.self))
     }
@@ -28,7 +28,7 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         expect(1).to(beAKindOf(Int.self))
         expect(1).toNot(beAKindOf(String.self))
         expect("turtle string").to(beAKindOf(String.self))
-        expect("turtle string").toNot(beAKindOf(KindOfTestClassConformingToProtocol.self))
+        expect("turtle string").toNot(beAKindOf(TestClassConformingToProtocol.self))
 
         enum TestEnum {
             case one, two
@@ -36,15 +36,15 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
 
         expect(TestEnum.one).to(beAKindOf(TestEnum.self))
 
-        let testProtocolClass = KindOfTestClassConformingToProtocol()
-        expect(testProtocolClass).to(beAKindOf(KindOfTestClassConformingToProtocol.self))
-        expect(testProtocolClass).to(beAKindOf(KindOfTestProtocol.self))
-        expect(testProtocolClass).toNot(beAKindOf(KindOfTestStructConformingToProtocol.self))
+        let testProtocolClass = TestClassConformingToProtocol()
+        expect(testProtocolClass).to(beAKindOf(TestClassConformingToProtocol.self))
+        expect(testProtocolClass).to(beAKindOf(TestProtocol.self))
+        expect(testProtocolClass).toNot(beAKindOf(TestStructConformingToProtocol.self))
 
-        let testProtocolStruct = KindOfTestStructConformingToProtocol()
-        expect(testProtocolStruct).to(beAKindOf(KindOfTestStructConformingToProtocol.self))
-        expect(testProtocolStruct).to(beAKindOf(KindOfTestProtocol.self))
-        expect(testProtocolStruct).toNot(beAKindOf(KindOfTestClassConformingToProtocol.self))
+        let testProtocolStruct = TestStructConformingToProtocol()
+        expect(testProtocolStruct).to(beAKindOf(TestStructConformingToProtocol.self))
+        expect(testProtocolStruct).to(beAKindOf(TestProtocol.self))
+        expect(testProtocolStruct).toNot(beAKindOf(TestClassConformingToProtocol.self))
     }
 
     func testFailureMessages() {
@@ -67,9 +67,9 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
             expect(1).toNot(beAKindOf(Int.self))
         }
 
-        let testClass = KindOfTestClassConformingToProtocol()
-        failsWithErrorMessage("expected to not be a kind of KindOfTestProtocol, got <KindOfTestClassConformingToProtocol instance>") {
-            expect(testClass).toNot(beAKindOf(KindOfTestProtocol.self))
+        let testClass = TestClassConformingToProtocol()
+        failsWithErrorMessage("expected to not be a kind of \(String(describing: TestProtocol.self)), got <\(String(describing: TestClassConformingToProtocol.self)) instance>") {
+            expect(testClass).toNot(beAKindOf(TestProtocol.self))
         }
 
         failsWithErrorMessage("expected to be a kind of String, got <Int instance>") {

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -6,23 +6,15 @@ fileprivate protocol TestProtocol {}
 fileprivate class TestClassConformingToProtocol: TestProtocol{}
 fileprivate struct TestStructConformingToProtocol: TestProtocol{}
 
-final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeAKindOfTest) -> () throws -> Void)] {
+final class BeAKindOfSwiftTest: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (BeAKindOfSwiftTest) -> () throws -> Void)] {
         return [
             ("testPositiveMatch", testPositiveMatch),
-            ("testPositiveMatchSwiftTypes", testPositiveMatchSwiftTypes),
             ("testFailureMessages", testFailureMessages),
-            ("testFailureMessagesSwiftTypes", testFailureMessagesSwiftTypes)
         ]
     }
 
     func testPositiveMatch() {
-        expect(TestNull()).to(beAKindOf(NSNull.self))
-        expect(NSObject()).to(beAKindOf(NSObject.self))
-        expect(NSNumber(value:1)).toNot(beAKindOf(NSDate.self))
-    }
-
-    func testPositiveMatchSwiftTypes() {
         expect(1).to(beAKindOf(Int.self))
         expect(1).toNot(beAKindOf(String.self))
         expect("turtle string").to(beAKindOf(String.self))
@@ -46,21 +38,6 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testFailureMessages() {
-        failsWithErrorMessageForNil("expected to not be a kind of NSNull, got <nil>") {
-            expect(nil as NSNull?).toNot(beAKindOf(NSNull.self))
-        }
-        failsWithErrorMessageForNil("expected to be a kind of NSString, got <nil>") {
-            expect(nil as NSString?).to(beAKindOf(NSString.self))
-        }
-        failsWithErrorMessage("expected to be a kind of NSString, got <__NSCFNumber instance>") {
-            expect(NSNumber(value:1)).to(beAKindOf(NSString.self))
-        }
-        failsWithErrorMessage("expected to not be a kind of NSNumber, got <__NSCFNumber instance>") {
-            expect(NSNumber(value:1)).toNot(beAKindOf(NSNumber.self))
-        }
-    }
-
-    func testFailureMessagesSwiftTypes() {
         failsWithErrorMessage("expected to not be a kind of Int, got <Int instance>") {
             expect(1).toNot(beAKindOf(Int.self))
         }
@@ -75,3 +52,35 @@ final class BeAKindOfTest: XCTestCase, XCTestCaseProvider {
         }
     }
 }
+
+#if _runtime(_ObjC)
+final class BeAKindOfObjCTest: XCTestCase, XCTestCaseProvider {
+    static var allTests: [(String, (BeAKindOfObjCTest) -> () throws -> Void)] {
+        return [
+            ("testPositiveMatch", testPositiveMatch),
+            ("testFailureMessages", testFailureMessages),
+        ]
+    }
+
+    func testPositiveMatch() {
+        expect(TestNull()).to(beAKindOf(NSNull.self))
+        expect(NSObject()).to(beAKindOf(NSObject.self))
+        expect(NSNumber(value:1)).toNot(beAKindOf(NSDate.self))
+    }
+
+    func testFailureMessages() {
+        failsWithErrorMessageForNil("expected to not be a kind of NSNull, got <nil>") {
+            expect(nil as NSNull?).toNot(beAKindOf(NSNull.self))
+        }
+        failsWithErrorMessageForNil("expected to be a kind of NSString, got <nil>") {
+            expect(nil as NSString?).to(beAKindOf(NSString.self))
+        }
+        failsWithErrorMessage("expected to be a kind of NSString, got <__NSCFNumber instance>") {
+            expect(NSNumber(value:1)).to(beAKindOf(NSString.self))
+        }
+        failsWithErrorMessage("expected to not be a kind of NSNumber, got <__NSCFNumber instance>") {
+            expect(NSNumber(value:1)).toNot(beAKindOf(NSNumber.self))
+        }
+    }
+}
+#endif

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -2,9 +2,9 @@ import Foundation
 import XCTest
 import Nimble
 
-protocol InstanceOfTestProtocol {}
-class InstanceOfTestClassConformingToProtocol: InstanceOfTestProtocol{}
-struct InstanceOfTestStructConformingToProtocol: InstanceOfTestProtocol{}
+fileprivate protocol TestProtocol {}
+fileprivate class TestClassConformingToProtocol: TestProtocol{}
+fileprivate struct TestStructConformingToProtocol: TestProtocol{}
 
 final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAnInstanceOfTest) -> () throws -> Void)] {
@@ -31,15 +31,15 @@ final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
 
         expect(TestEnum.one).to(beAnInstanceOf(TestEnum.self))
 
-        let testProtocolClass = InstanceOfTestClassConformingToProtocol()
-        expect(testProtocolClass).to(beAnInstanceOf(InstanceOfTestClassConformingToProtocol.self))
-        expect(testProtocolClass).toNot(beAnInstanceOf(InstanceOfTestProtocol.self))
-        expect(testProtocolClass).toNot(beAnInstanceOf(InstanceOfTestStructConformingToProtocol.self))
+        let testProtocolClass = TestClassConformingToProtocol()
+        expect(testProtocolClass).to(beAnInstanceOf(TestClassConformingToProtocol.self))
+        expect(testProtocolClass).toNot(beAnInstanceOf(TestProtocol.self))
+        expect(testProtocolClass).toNot(beAnInstanceOf(TestStructConformingToProtocol.self))
 
-        let testProtocolStruct = InstanceOfTestStructConformingToProtocol()
-        expect(testProtocolStruct).to(beAnInstanceOf(InstanceOfTestStructConformingToProtocol.self))
-        expect(testProtocolStruct).toNot(beAnInstanceOf(InstanceOfTestProtocol.self))
-        expect(testProtocolStruct).toNot(beAnInstanceOf(InstanceOfTestClassConformingToProtocol.self))
+        let testProtocolStruct = TestStructConformingToProtocol()
+        expect(testProtocolStruct).to(beAnInstanceOf(TestStructConformingToProtocol.self))
+        expect(testProtocolStruct).toNot(beAnInstanceOf(TestProtocol.self))
+        expect(testProtocolStruct).toNot(beAnInstanceOf(TestClassConformingToProtocol.self))
     }
 
     func testFailureMessages() {
@@ -67,9 +67,9 @@ final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
             expect(1).toNot(beAnInstanceOf(Int.self))
         }
 
-        let testClass = InstanceOfTestClassConformingToProtocol()
-        failsWithErrorMessage("expected to be an instance of InstanceOfTestProtocol, got <InstanceOfTestClassConformingToProtocol instance>") {
-            expect(testClass).to(beAnInstanceOf(InstanceOfTestProtocol.self))
+        let testClass = TestClassConformingToProtocol()
+        failsWithErrorMessage("expected to be an instance of \(String(describing: TestProtocol.self)), got <\(String(describing: TestClassConformingToProtocol.self)) instance>") {
+            expect(testClass).to(beAnInstanceOf(TestProtocol.self))
         }
 
         failsWithErrorMessage("expected to be an instance of String, got <Int instance>") {

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -2,18 +2,44 @@ import Foundation
 import XCTest
 import Nimble
 
+protocol InstanceOfTestProtocol {}
+class InstanceOfTestClassConformingToProtocol: InstanceOfTestProtocol{}
+struct InstanceOfTestStructConformingToProtocol: InstanceOfTestProtocol{}
+
 final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAnInstanceOfTest) -> () throws -> Void)] {
         return [
             ("testPositiveMatch", testPositiveMatch),
+            ("testPositiveMatchSwiftTypes", testPositiveMatchSwiftTypes),
             ("testFailureMessages", testFailureMessages),
-            ("testSwiftTypesFailureMessages", testSwiftTypesFailureMessages),
+            ("testFailureMessagesSwiftTypes", testFailureMessagesSwiftTypes),
         ]
     }
 
     func testPositiveMatch() {
         expect(NSNull()).to(beAnInstanceOf(NSNull.self))
         expect(NSNumber(value:1)).toNot(beAnInstanceOf(NSDate.self))
+    }
+
+    func testPositiveMatchSwiftTypes() {
+        expect(1).to(beAnInstanceOf(Int.self))
+        expect("test").to(beAnInstanceOf(String.self))
+
+        enum TestEnum {
+            case one, two
+        }
+
+        expect(TestEnum.one).to(beAnInstanceOf(TestEnum.self))
+
+        let testProtocolClass = InstanceOfTestClassConformingToProtocol()
+        expect(testProtocolClass).to(beAnInstanceOf(InstanceOfTestClassConformingToProtocol.self))
+        expect(testProtocolClass).toNot(beAnInstanceOf(InstanceOfTestProtocol.self))
+        expect(testProtocolClass).toNot(beAnInstanceOf(InstanceOfTestStructConformingToProtocol.self))
+
+        let testProtocolStruct = InstanceOfTestStructConformingToProtocol()
+        expect(testProtocolStruct).to(beAnInstanceOf(InstanceOfTestStructConformingToProtocol.self))
+        expect(testProtocolStruct).toNot(beAnInstanceOf(InstanceOfTestProtocol.self))
+        expect(testProtocolStruct).toNot(beAnInstanceOf(InstanceOfTestClassConformingToProtocol.self))
     }
 
     func testFailureMessages() {
@@ -35,24 +61,19 @@ final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
             expect(NSNumber(value:1)).toNot(beAnInstanceOf(NSNumber.self))
         }
     }
-    
-    func testSwiftTypesFailureMessages() {
-        enum TestEnum {
-            case one, two
+
+    func testFailureMessagesSwiftTypes() {
+        failsWithErrorMessage("expected to not be an instance of Int, got <Int instance>") {
+            expect(1).toNot(beAnInstanceOf(Int.self))
         }
 
-        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
-            + " will automatically type check Swift-only types. This expectation is redundant.") {
-            expect(1).to(beAnInstanceOf(Int.self))
+        let testClass = InstanceOfTestClassConformingToProtocol()
+        failsWithErrorMessage("expected to be an instance of InstanceOfTestProtocol, got <InstanceOfTestClassConformingToProtocol instance>") {
+            expect(testClass).to(beAnInstanceOf(InstanceOfTestProtocol.self))
         }
-        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
-            + " will automatically type check Swift-only types. This expectation is redundant.") {
-            expect("test").to(beAnInstanceOf(String.self))
-        }
-        failsWithErrorMessage("beAnInstanceOf only works on Objective-C types since the Swift compiler"
-            + " will automatically type check Swift-only types. This expectation is redundant.") {
-            expect(TestEnum.one).to(beAnInstanceOf(TestEnum.self))
+
+        failsWithErrorMessage("expected to be an instance of String, got <Int instance>") {
+            expect(1).to(beAnInstanceOf(String.self))
         }
     }
-    
 }

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -3,8 +3,8 @@ import XCTest
 import Nimble
 
 fileprivate protocol TestProtocol {}
-fileprivate class TestClassConformingToProtocol: TestProtocol{}
-fileprivate struct TestStructConformingToProtocol: TestProtocol{}
+fileprivate class TestClassConformingToProtocol: TestProtocol {}
+fileprivate struct TestStructConformingToProtocol: TestProtocol {}
 
 final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (BeAnInstanceOfTest) -> () throws -> Void)] {


### PR DESCRIPTION
This PR aims to address #365. 

There was some talk in the discussion on the Issue page about some warnings produced by the compiler in the past. I have some concern that maybe my testing of this feature did not hit whatever situation they were talking about. 

Feedback on this will be appreciated! 