### PR TITLE
[SwiftPM] Add the `CurrentTestCaseTracker` instance to `XCTestObservationCenter` on macOS (Objective-C runtime)

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -36,7 +36,16 @@ class NimbleXCTestUnavailableHandler : AssertionHandler {
 }
 
 #if _runtime(_ObjC)
-    /// Helper class providing access to the currently executing XCTestCase instance, if any
+
+#if SWIFT_PACKAGE
+    extension XCTestObservationCenter {
+        override open class func initialize() {
+            self.shared().addTestObserver(CurrentTestCaseTracker.sharedInstance)
+        }
+    }
+#endif
+
+/// Helper class providing access to the currently executing XCTestCase instance, if any
 @objc final internal class CurrentTestCaseTracker: NSObject, XCTestObservation {
     @objc static let sharedInstance = CurrentTestCaseTracker()
 


### PR DESCRIPTION
Fixes #367:

```shell
$ swift test
Compile Swift Module 'Nimble' (46 sources)
Compile Swift Module 'Nimble367Tests' (1 sources)
Compile Swift Module 'Nimble367Test' (1 sources)
Linking ./.build/debug/Nimble367TestPackageTests.xctest/Contents/MacOS/Nimble367TestPackageTests
Test Suite 'All tests' started at 2016-11-22 19:36:08.191
Test Suite 'Nimble367TestPackageTests.xctest' started at 2016-11-22 19:36:08.191
Test Suite 'Test' started at 2016-11-22 19:36:08.191
Test Case '-[Nimble367Tests.Test testNimble]' started.
/Users/ikesyo/Desktop/Nimble367Test/Tests/Nimble367Tests/test.swift:7: error: -[Nimble367Tests.Test testNimble] : expected to equal <2>, got <1>

Test Case '-[Nimble367Tests.Test testNimble]' failed (0.004 seconds).
Test Suite 'Test' failed at 2016-11-22 19:36:08.196.
	 Executed 1 test, with 1 failure (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'Nimble367TestPackageTests.xctest' failed at 2016-11-22 19:36:08.196.
	 Executed 1 test, with 1 failure (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'All tests' failed at 2016-11-22 19:36:08.196.
	 Executed 1 test, with 1 failure (0 unexpected) in 0.004 (0.005) seconds
```

The cause is that an `XCTestObservation` instance is not added to `XCTestObservationCenter` using `addTestObserver` when used with SwiftPM.