### PR TITLE
Fix string constant declaration

### DIFF
--- a/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
+++ b/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
@@ -141,7 +141,7 @@
                                                            userInfo:@{@"key": @"value"}];
     NSString *outerFailureMessage;
 
-    NSString const *innerFailureMessage = @"expected to equal <foo>, got <NSInvalidArgumentException>";
+    NSString *const innerFailureMessage = @"expected to equal <foo>, got <NSInvalidArgumentException>";
     outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[AnyHashable(\"key\"): value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().


### PR DESCRIPTION
This change fixes warning:
`warning: object of type 'const NSString *' is not compatible with array element type 'NSString *' [-Wobjc-literal-conversion]`.