### PR TITLE
Alternative implementation of #372

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -35,16 +35,7 @@ class NimbleXCTestUnavailableHandler: AssertionHandler {
     }
 }
 
-#if _runtime(_ObjC)
-
-#if SWIFT_PACKAGE
-    extension XCTestObservationCenter {
-        override open class func initialize() {
-            self.shared().addTestObserver(CurrentTestCaseTracker.sharedInstance)
-        }
-    }
-#endif
-
+#if !SWIFT_PACKAGE
 /// Helper class providing access to the currently executing XCTestCase instance, if any
 @objc final internal class CurrentTestCaseTracker: NSObject, XCTestObservation {
     @objc static let sharedInstance = CurrentTestCaseTracker()
@@ -71,7 +62,9 @@ func isXCTestAvailable() -> Bool {
 }
 
 private func recordFailure(_ message: String, location: SourceLocation) {
-#if _runtime(_ObjC)
+#if SWIFT_PACKAGE
+    XCTFail("\(message)", file: location.file, line: location.line)
+#else
     if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase {
         testCase.recordFailure(withDescription: message, inFile: location.file, atLine: location.line, expected: true)
     } else {
@@ -79,7 +72,5 @@ private func recordFailure(_ message: String, location: SourceLocation) {
         "The failure was:\n\"\(message)\"\nIt occurred at: \(location.file):\(location.line)"
         NSException(name: .internalInconsistencyException, reason: msg, userInfo: nil).raise()
     }
-#else
-    XCTFail("\(message)\n", file: location.file, line: location.line)
 #endif
 }

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -70,12 +70,12 @@ internal class NMBWait: NSObject {
             }
     }
 
-    #if _runtime(_ObjC)
-    @objc(untilFile:line:action:)
+    #if SWIFT_PACKAGE
     internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }
     #else
+    @objc(untilFile:line:action:)
     internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) -> Void {
         until(timeout: 1, file: file, line: line, action: action)
     }

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -5,10 +5,10 @@ import Foundation
 // stdlib, and because recent versions of the XCTest overlay require `StaticString`
 // when calling `XCTFail`. Under the Objective-C runtime (i.e. building on Mac), we
 // have to use `String` instead because StaticString can't be generated from Objective-C
-#if _runtime(_ObjC)
-public typealias FileString = String
-#else
+#if SWIFT_PACKAGE
 public typealias FileString = StaticString
+#else
+public typealias FileString = String
 #endif
 
 public final class SourceLocation: NSObject {


### PR DESCRIPTION
Avoid using +initialize to add `CurrentTestCaseTracker.sharedInstance` as a test observer when used with SwiftPM on macOS. With SwiftPM, let's consistently use `XCTFail` instead of `XCTestObservation` and `XCTestCase.recordFailure` for recording failures.

Background: Using +initialize in Swift will be warned in Swift 3.1 and prohibited in Swift 4 as seen in https://github.com/apple/swift/pull/6865 and https://github.com/apple/swift/pull/6866.

See also #372 and #367.