### PR TITLE
Disable large_tuple swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
   - function_parameter_count
   - force_cast
   - type_name
+  - large_tuple
 
 included:
   - Sources


### PR DESCRIPTION
Just an update to .swiftlint.yml disabling `large_tuple` rule to avoid failing build at https://github.com/Quick/Nimble/blob/c7873bc0b540dfce7e38aebc81737a56b16a4f03/Sources/Lib/CwlPreconditionTesting/CwlPreconditionTesting/CwlDarwinDefinitions.swift#L58