### PR TITLE
Make Nimble SwiftLint compatible #370

### DIFF
--- a/Sources/Lib/CwlPreconditionTesting/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/Lib/CwlPreconditionTesting/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -71,7 +71,7 @@ import Foundation
 		var behaviors = execTypesCountTuple<exception_behavior_t>()
 		var flavors = execTypesCountTuple<thread_state_flavor_t>()
 		var currentExceptionPort: mach_port_t = 0
-		var handlerThread: pthread_t? = nil
+		var handlerThread: pthread_t?
 
 		mutating func withUnsafeMutablePointers<R>(in block: (UnsafeMutablePointer<exception_mask_t>, UnsafeMutablePointer<mach_port_t>, UnsafeMutablePointer<exception_behavior_t>, UnsafeMutablePointer<thread_state_flavor_t>) -> R) -> R {
 			return masks.pointer { masksPtr in

--- a/Sources/Lib/CwlPreconditionTesting/CwlPreconditionTesting/CwlCatchBadInstructionPOSIX.swift
+++ b/Sources/Lib/CwlPreconditionTesting/CwlPreconditionTesting/CwlCatchBadInstructionPOSIX.swift
@@ -40,7 +40,7 @@ private func triggerLongJmp() {
 	longjmp(&env.0, 1)
 }
 
-private func sigIllHandler(code: Int32, info: UnsafeMutablePointer<__siginfo>?, uap: UnsafeMutableRawPointer?) -> Void {
+private func sigIllHandler(code: Int32, info: UnsafeMutablePointer<__siginfo>?, uap: UnsafeMutableRawPointer?) {
 	guard let context = uap?.assumingMemoryBound(to: ucontext64_t.self) else { return }
 
 	// 1. Decrement the stack pointer

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -15,7 +15,7 @@ internal class NMBWait: NSObject {
         timeout: TimeInterval,
         file: FileString = #file,
         line: UInt = #line,
-        action: @escaping (@escaping () -> Void) -> Void) -> Void {
+        action: @escaping (@escaping () -> Void) -> Void) {
             return throwableUntil(timeout: timeout, file: file, line: line) { done in
                 action(done)
             }
@@ -26,7 +26,7 @@ internal class NMBWait: NSObject {
         timeout: TimeInterval,
         file: FileString = #file,
         line: UInt = #line,
-        action: @escaping (@escaping () -> Void) throws -> Void) -> Void {
+        action: @escaping (@escaping () -> Void) throws -> Void) {
             let awaiter = NimbleEnvironment.activeInstance.awaiter
             let leeway = timeout / 2.0
             let result = awaiter.performBlock { (done: @escaping (ErrorResult) -> Void) throws -> Void in
@@ -71,12 +71,12 @@ internal class NMBWait: NSObject {
     }
 
     #if SWIFT_PACKAGE
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) -> Void {
+    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
     #else
     @objc(untilFile:line:action:)
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) -> Void {
+    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
     #endif
@@ -93,6 +93,6 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: TimeInterv
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-public func waitUntil(timeout: TimeInterval = 1, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) -> Void {
+public func waitUntil(timeout: TimeInterval = 1, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -12,8 +12,8 @@ public class FailureMessage: NSObject {
     /// An optional message that will be appended as a new line and provides additional details
     /// about the failure. This message will only be visible in the issue navigator / in logs but
     /// not directly in the source editor since only a single line is presented there.
-    public var extendedMessage: String? = nil
-    public var userDescription: String? = nil
+    public var extendedMessage: String?
+    public var userDescription: String?
 
     public var stringValue: String {
         get {

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -27,7 +27,7 @@ internal protocol WaitLock {
 }
 
 internal class AssertionWaitLock: WaitLock {
-    private var currentWaiter: WaitingInfo? = nil
+    private var currentWaiter: WaitingInfo?
     init() { }
 
     func acquireWaitingLock(_ fnName: String, file: FileString, line: UInt) {

--- a/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -51,7 +51,7 @@ final class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
     func testBeAlias() {
         let value = NSDate()
         expect(value).to(be(value))
-        expect(NSNumber(value:1)).toNot(be(NSString(stringLiteral: "turtles")))
+        expect(NSNumber(value:1)).toNot(be(NSString(stringLiteral: "turtles"))) // swiftlint:disable:this compiler_protocol_init
         #if _runtime(_ObjC)
             expect([1]).toNot(be([1]))
         #else


### PR DESCRIPTION
When building the project in Carthage with swiftlint installed, there are 11 warnings issued that trip the build, as reported on the #370 and using the current version available by using Carthage.

This PR solves all but one by amending the code to correct the offending issues.

The last one is fixed by adding a specific disable. This was choosen due to lack of deep knowledge of the finner details of the codebase and the fact that the affected code is underway changes on future PR that are currently WIP.

No behavior of the code was changed.

