### PR TITLE
beGreaterThan become to support double and float with ObjC.

### DIFF
--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -186,6 +186,8 @@ NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
     DEFINE_OVERLOAD(unsigned long, @(expectedValue))
     DEFINE_OVERLOAD(int, @(expectedValue))
     DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
     DEFINE_OVERLOAD(long long, @(expectedValue))
     DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
     DEFINE_OVERLOAD(char, @(expectedValue))

--- a/Tests/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -41,6 +41,10 @@ final class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
         expect(1) >= 0
         expect(NSNumber(value:1)) >= 1
         expect(NSNumber(value:1)) >= NSNumber(value:1)
+        expect(2.5) >= 2.5
+        expect(2.5) >= 2
+        expect(Float(2.5)) >= Float(2.5)
+        expect(Float(2.5)) >= 2
 
         failsWithErrorMessage("expected to be greater than or equal to <2>, got <1>") {
             expect(1) >= 2

--- a/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -42,6 +42,9 @@ final class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
 #else
         expect(NSNumber(value:1)) > 0 as NSNumber
 #endif
+        expect(2.5) > 1.5
+        expect(Float(2.5)) > Float(1.5)
+
         failsWithErrorMessage("expected to be greater than <2>, got <1>") {
             expect(1) > 2
             return

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
@@ -13,6 +13,8 @@
     expect(2).to(beGreaterThanOrEqualTo(0));
     expect(2).to(beGreaterThanOrEqualTo(2));
     expect(2).toNot(beGreaterThanOrEqualTo(3));
+    expect(2.5).to(beGreaterThanOrEqualTo(2));
+    expect(2.5).to(beGreaterThanOrEqualTo(2.5));
 }
 
 - (void)testNegativeMatches {

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
@@ -12,6 +12,7 @@
     expect(@2).toNot(beGreaterThan(@2));
     expect(@2).to(beGreaterThan(0));
     expect(@2).toNot(beGreaterThan(2));
+    expect(2.5).to(beGreaterThan(1.5));
 }
 
 - (void)testNegativeMatches {


### PR DESCRIPTION
 - What behavior was changed?
 - What code was refactored / updated to support this change?
   - beGreaterThan become to support double and float with ObjC.
 - What issues are related to this PR? Or why was this change introduced?
   - Because I thought it was a lost to a simple mistake.

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

