### PR TITLE
Add Dockerfile.test for linux testing

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,3 @@
+FROM swift:latest
+COPY . .
+CMD ./test swiftpm

--- a/test
+++ b/test
@@ -84,6 +84,11 @@ function test_swiftpm {
     run swift build && swift test
 }
 
+function test_swiftpm_docker {
+    run docker build -t nimble-tests -f Dockerfile.test --no-cache .
+    run docker run -it --privileged=true nimble-tests
+}
+
 function test() {
     test_ios
     test_tvos
@@ -93,6 +98,12 @@ function test() {
         test_swiftpm
     else
         echo "Not testing with the Swift Package Manager because swift-test is not installed"
+    fi
+
+    if which docker; then
+        test_swiftpm_docker
+    else
+        echo "Not testing linux in docker container since docker is not in PATH!"
     fi
 }
 
@@ -104,14 +115,15 @@ function help {
     echo "Usage: $0 COMMANDS"
     echo
     echo "COMMANDS:"
-    echo " clean        - Cleans the derived data directory of Xcode. Assumes default location"
-    echo " ios          - Runs the tests as an iOS device"
-    echo " tvos         - Runs the tests as an tvOS device"
-    echo " macos        - Runs the tests on macOS 10.10 (Yosemite and newer only)"
-    echo " podspec      - Runs pod lib lint against the podspec to detect breaking changes"
-    echo " all          - Runs the all tests of macos, ios and tvos"
-    echo " swiftpm      - Runs the tests built by the Swift Package Manager"
-    echo " help         - Displays this help"
+    echo " all             - Runs the all tests of macos, ios and tvos"
+    echo " clean           - Cleans the derived data directory of Xcode. Assumes default location"
+    echo " help            - Displays this help"
+    echo " ios             - Runs the tests as an iOS device"
+    echo " macos           - Runs the tests on macOS 10.10 (Yosemite and newer only)"
+    echo " podspec         - Runs pod lib lint against the podspec to detect breaking changes"
+    echo " swiftpm         - Runs the tests built by the Swift Package Manager"
+    echo " swiftpm_docker  - Runs the tests built by the Swift Package Manager in a docker linux container"
+    echo " tvos            - Runs the tests as an tvOS device"
     echo
     exit 1
 }
@@ -129,6 +141,7 @@ function main {
             test) test ;;
             all) test ;;
             swiftpm) test_swiftpm ;;
+            swiftpm_docker) test_swiftpm_docker ;;
             help) help ;;
         esac
     done


### PR DESCRIPTION
This allows macs to easily test Nimble under Linux inside a docker container. It doesn't affect CI since it actually runs a linux version of SPM.