### PR TITLE
Fix documentation parameter name warning

### DIFF
--- a/Sources/NimbleObjectiveC/NMBStringify.h
+++ b/Sources/NimbleObjectiveC/NMBStringify.h
@@ -4,7 +4,7 @@
  * Returns a string appropriate for displaying in test output
  * from the provided value.
  *
- * @param value A value that will show up in a test's output.
+ * @param anyObject A value that will show up in a test's output.
  *
  * @return The string that is returned can be
  *     customized per type by conforming a type to the `TestOutputStringConvertible`


### PR DESCRIPTION
Minor issue in the documentation:
- Parameter `value` is not matching `anyObject`

