### PR TITLE
Update succeed() matcher to return Predicate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,14 +1247,14 @@ also check out the tips below.
 
 `PredicateResult` is the return struct that `Predicate` return to indicate
 success and failure. A `PredicateResult` is made up of two values:
-`Satisfiability` and `ExpectationMessage`.
+`PredicateStatus` and `ExpectationMessage`.
 
-Instead of a boolean, `Satisfiability` captures a trinary set of values:
+Instead of a boolean, `PredicateStatus` captures a trinary set of values:
 
 ```swift
 // Swift
 
-public enum Satisfiability {
+public enum PredicateStatus {
 // The predicate "passes" with the given expression
 // eg - expect(1).to(equal(1))
 case matches
@@ -1314,11 +1314,11 @@ public func beNil<T>() -> Predicate<T> {
 	// Predicate.simpleNilable(..) automatically generates ExpectationMessage for
 	// us based on the string we provide to it. Also, the 'Nilable' postfix indicates
 	// that this Predicate supports matching against nil actualExpressions, instead of
-	// always resulting in a Satisfiability.fail result -- which is true for
+	// always resulting in a PredicateStatus.fail result -- which is true for
 	// Predicate.simple(..)
     return Predicate.simpleNilable("be nil") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        return Satisfiability(bool: actualValue == nil)
+        return PredicateStatus(bool: actualValue == nil)
     }
 }
 ```
@@ -1342,7 +1342,7 @@ against the one provided to the matcher function, and passes if they are the sam
 
 public func haveDescription(description: String) -> Predicate<Printable?> {
   return Predicate.simple("have description") { actual in
-    return Satisfiability(bool: actual.evaluate().description == description)
+    return PredicateStatus(bool: actual.evaluate().description == description)
   }
 }
 ```

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -12,6 +12,9 @@ public indirect enum ExpectationMessage {
     // --- Composite Expectations ---
     // Generally, you'll want the methods, appended(message:) and appended(details:) instead.
 
+    /// Not Fully Implemented Yet.
+    case prepends(/* Prepended Message */ String, ExpectationMessage)
+
     /// appends after an existing message ("<expectation> (use beNil() to match nils)")
     case appends(ExpectationMessage, /* Appended Message */ String)
 
@@ -38,6 +41,8 @@ public indirect enum ExpectationMessage {
             return msg
         case let .expectedCustomValueTo(msg, _):
             return msg
+        case let .prepends(_, expectation):
+            return expectation.expectedMessage
         case let .appends(expectation, _):
             return expectation.expectedMessage
         case let .details(expectation, _):
@@ -48,7 +53,7 @@ public indirect enum ExpectationMessage {
     /// Appends a message after the primary expectation message
     public func appended(message: String) -> ExpectationMessage {
         switch self {
-        case .fail, .expectedTo, .expectedActualValueTo, .expectedCustomValueTo, .appends:
+        case .fail, .expectedTo, .expectedActualValueTo, .expectedCustomValueTo, .appends, .prepends:
             return .appends(self, message)
         case let .details(expectation, msg):
             return .details(expectation.appended(message: message), msg)
@@ -70,6 +75,8 @@ public indirect enum ExpectationMessage {
         switch self {
         case .fail, .expectedTo, .expectedActualValueTo, .expectedCustomValueTo:
             return f(self)
+        case let .prepends(msg, expectation):
+            return .prepends(msg, expectation.visitLeafs(f))
         case let .appends(expectation, msg):
             return .appends(expectation.visitLeafs(f), msg)
         case let .details(expectation, msg):
@@ -98,7 +105,7 @@ public indirect enum ExpectationMessage {
     }
 
     /// Prepends a message by modifying the primary expectation
-    public func prepended(message: String) -> ExpectationMessage {
+    public func prepended(expectation: String) -> ExpectationMessage {
         func walk(_ msg: ExpectationMessage) -> ExpectationMessage {
             switch msg {
             case let .expectedTo(msg):
@@ -107,6 +114,19 @@ public indirect enum ExpectationMessage {
                 return .expectedActualValueTo(message + msg)
             case let .expectedCustomValueTo(msg, actual):
                 return .expectedCustomValueTo(message + msg, actual)
+            default:
+                return msg.visitLeafs(walk)
+            }
+        }
+        return visitLeafs(walk)
+    }
+
+    // TODO: test & verify correct behavior
+    internal func prepended(message: String) -> ExpectationMessage {
+        func walk(_ msg: ExpectationMessage) -> ExpectationMessage {
+            switch msg {
+            case .expectedTo, .expectedActualValueTo, .expectedCustomValueTo:
+                return .prepends(message, msg)
             default:
                 return msg.visitLeafs(walk)
             }
@@ -147,17 +167,28 @@ public indirect enum ExpectationMessage {
             failureMessage.actualValue = actual
         case let .appends(expectation, msg):
             expectation.update(failureMessage: failureMessage)
-            if failureMessage.actualValue != nil {
-                failureMessage.postfixActual += msg
+            if failureMessage.hasOverriddenStringValue {
+                failureMessage.stringValue += "\(msg)"
             } else {
-                failureMessage.postfixMessage += msg
+                if failureMessage.actualValue != nil {
+                    failureMessage.postfixActual += msg
+                } else {
+                    failureMessage.postfixMessage += msg
+                }
             }
         case let .details(expectation, msg):
             expectation.update(failureMessage: failureMessage)
-            if let desc = failureMessage.userDescription {
-                failureMessage.userDescription = desc
+            if failureMessage.hasOverriddenStringValue {
+                if let desc = failureMessage.userDescription {
+                    failureMessage.stringValue = "\(desc)\n\(failureMessage.stringValue)"
+                }
+                failureMessage.stringValue += "\n\(msg)"
+            } else {
+                if let desc = failureMessage.userDescription {
+                    failureMessage.userDescription = desc
+                }
+                failureMessage.extendedMessage = msg
             }
-            failureMessage.extendedMessage = msg
         }
     }
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -29,6 +29,9 @@ public class FailureMessage: NSObject {
     }
 
     internal var _stringValueOverride: String?
+    internal var hasOverriddenStringValue: Bool {
+        return _stringValueOverride != nil
+    }
 
     public override init() {
     }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -4,7 +4,7 @@ public func allPass<T, U>
     (_ passFunc: @escaping (T?) throws -> Bool) -> Predicate<U>
     where U: Sequence, T == U.Iterator.Element {
         let matcher = Predicate.simpleNilable("pass a condition") { actualExpression in
-            return Satisfiability(bool: try passFunc(try actualExpression.evaluate()))
+            return PredicateStatus(bool: try passFunc(try actualExpression.evaluate()))
         }
         return createPredicate(matcher)
 }
@@ -13,7 +13,7 @@ public func allPass<T, U>
     (_ passName: String, _ passFunc: @escaping (T?) throws -> Bool) -> Predicate<U>
     where U: Sequence, T == U.Iterator.Element {
         let matcher = Predicate.simpleNilable(passName) { actualExpression in
-            return Satisfiability(bool: try passFunc(try actualExpression.evaluate()))
+            return PredicateStatus(bool: try passFunc(try actualExpression.evaluate()))
         }
         return createPredicate(matcher)
 }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -44,7 +44,7 @@ private func createPredicate<S>(_ elementMatcher: Predicate<S.Iterator.Element>)
                     expression: {currentElement}, location: actualExpression.location)
                 let predicateResult = try elementMatcher.satisfies(exp)
                 if predicateResult.status == .matches {
-                    failure = predicateResult.message.prepended(message: "all ")
+                    failure = predicateResult.message.prepended(expectation: "all ")
                 } else {
                     failure = predicateResult.message
                         .replacedExpectation({ .expectedTo($0.expectedMessage) })

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -36,11 +36,11 @@ public func beAKindOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
 public func beAKindOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
     return Predicate.define { actualExpression in
         let message: ExpectationMessage
-        let status: Satisfiability
+        let status: PredicateStatus
 
         let instance = try actualExpression.evaluate()
         if let validInstance = instance {
-            status = Satisfiability(bool: instance != nil && instance!.isKind(of: expectedClass))
+            status = PredicateStatus(bool: instance != nil && instance!.isKind(of: expectedClass))
             message = .expectedCustomValueTo(
                 matcherMessage(forClass: expectedClass),
                 "<\(String(describing: type(of: validInstance))) instance>"

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -15,7 +15,7 @@ public func beAnInstanceOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
         let actualString = "<\(String(describing: type(of: validInstance))) instance>"
 
         return PredicateResult(
-            status: Satisfiability(bool: type(of: validInstance) == expectedType),
+            status: PredicateStatus(bool: type(of: validInstance) == expectedType),
             message: .expectedCustomValueTo(errorMessage, actualString)
         )
     }
@@ -39,7 +39,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
     let matches = instance != nil && type(of: instance!) == expectedClass
 #endif
         return PredicateResult(
-            status: Satisfiability(bool: matches),
+            status: PredicateStatus(bool: matches),
             message: .expectedCustomValueTo(errorMessage, actualString)
         )
     }

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -9,7 +9,7 @@ public func beEmpty<S: Sequence>() -> Predicate<S> {
             return .fail
         }
         var generator = actualSeq!.makeIterator()
-        return Satisfiability(bool: generator.next() == nil)
+        return PredicateStatus(bool: generator.next() == nil)
     }
 }
 
@@ -18,7 +18,7 @@ public func beEmpty<S: Sequence>() -> Predicate<S> {
 public func beEmpty() -> Predicate<String> {
     return Predicate.simple("be empty") { actualExpression in
         let actualString = try actualExpression.evaluate()
-        return Satisfiability(bool: actualString == nil || NSString(string: actualString!).length  == 0)
+        return PredicateStatus(bool: actualString == nil || NSString(string: actualString!).length  == 0)
     }
 }
 
@@ -27,7 +27,7 @@ public func beEmpty() -> Predicate<String> {
 public func beEmpty() -> Predicate<NSString> {
     return Predicate.simple("be empty") { actualExpression in
         let actualString = try actualExpression.evaluate()
-        return Satisfiability(bool: actualString == nil || actualString!.length == 0)
+        return PredicateStatus(bool: actualString == nil || actualString!.length == 0)
     }
 }
 
@@ -39,7 +39,7 @@ public func beEmpty() -> Predicate<NSString> {
 public func beEmpty() -> Predicate<NSDictionary> {
 	return Predicate.simple("be empty") { actualExpression in
 		let actualDictionary = try actualExpression.evaluate()
-        return Satisfiability(bool: actualDictionary == nil || actualDictionary!.count == 0)
+        return PredicateStatus(bool: actualDictionary == nil || actualDictionary!.count == 0)
 	}
 }
 
@@ -48,7 +48,7 @@ public func beEmpty() -> Predicate<NSDictionary> {
 public func beEmpty() -> Predicate<NSArray> {
 	return Predicate.simple("be empty") { actualExpression in
 		let actualArray = try actualExpression.evaluate()
-        return Satisfiability(bool: actualArray == nil || actualArray!.count == 0)
+        return PredicateStatus(bool: actualArray == nil || actualArray!.count == 0)
 	}
 }
 
@@ -57,7 +57,7 @@ public func beEmpty() -> Predicate<NSArray> {
 public func beEmpty() -> Predicate<NMBCollection> {
     return Predicate.simple("be empty") { actualExpression in
         let actual = try actualExpression.evaluate()
-        return Satisfiability(bool: actual == nil || actual!.count == 0)
+        return PredicateStatus(bool: actual == nil || actual!.count == 0)
     }
 }
 

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -5,7 +5,7 @@ public func beGreaterThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
     let errorMessage = "be greater than <\(stringify(expectedValue))>"
     return Predicate.simple(errorMessage) { actualExpression in
         if let actual = try actualExpression.evaluate(), let expected = expectedValue {
-            return Satisfiability(bool: actual > expected)
+            return PredicateStatus(bool: actual > expected)
         }
         return .fail
     }

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -105,12 +105,12 @@ public func beTruthy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<
             // - https://bugs.swift.org/browse/SR-2290
             // - https://github.com/norio-nomura/Nimble/pull/5#issuecomment-237835873
             if let number = actualValue as? NSNumber {
-                return Satisfiability(bool: number.boolValue == true)
+                return PredicateStatus(bool: number.boolValue == true)
             }
 
-            return Satisfiability(bool: actualValue == (true as T))
+            return PredicateStatus(bool: actualValue == (true as T))
         }
-        return Satisfiability(bool: actualValue != nil)
+        return PredicateStatus(bool: actualValue != nil)
     }
 }
 
@@ -125,12 +125,12 @@ public func beFalsy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<T
             // - https://bugs.swift.org/browse/SR-2290
             // - https://github.com/norio-nomura/Nimble/pull/5#issuecomment-237835873
             if let number = actualValue as? NSNumber {
-                return Satisfiability(bool: number.boolValue == false)
+                return PredicateStatus(bool: number.boolValue == false)
             }
 
-            return Satisfiability(bool: actualValue == (false as T))
+            return PredicateStatus(bool: actualValue == (false as T))
         }
-        return Satisfiability(bool: actualValue == nil)
+        return PredicateStatus(bool: actualValue == nil)
     }
 }
 

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -4,7 +4,7 @@ import Foundation
 public func beNil<T>() -> Predicate<T> {
     return Predicate.simpleNilable("be nil") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        return Satisfiability(bool: actualValue == nil)
+        return PredicateStatus(bool: actualValue == nil)
     }
 }
 

--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -7,7 +7,7 @@ public func beginWith<S: Sequence, T: Equatable>(_ startingElement: T) -> Predic
     return Predicate.simple("begin with <\(startingElement)>") { actualExpression in
         if let actualValue = try actualExpression.evaluate() {
             var actualGenerator = actualValue.makeIterator()
-            return Satisfiability(bool: actualGenerator.next() == startingElement)
+            return PredicateStatus(bool: actualGenerator.next() == startingElement)
         }
         return .fail
     }
@@ -26,7 +26,7 @@ public func beginWith(_ startingElement: Any) -> Predicate<NMBOrderedCollection>
         #else
             let collectionValue = collection.object(at: 0) as AnyObject
         #endif
-        return Satisfiability(bool: collectionValue.isEqual(startingElement))
+        return PredicateStatus(bool: collectionValue.isEqual(startingElement))
     }
 }
 
@@ -36,7 +36,7 @@ public func beginWith(_ startingSubstring: String) -> Predicate<String> {
     return Predicate.simple("begin with <\(startingSubstring)>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
             let range = actual.range(of: startingSubstring)
-            return Satisfiability(bool: range != nil && range!.lowerBound == actual.startIndex)
+            return PredicateStatus(bool: range != nil && range!.lowerBound == actual.startIndex)
         }
         return .fail
     }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -17,7 +17,7 @@ public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
             }
             return PredicateResult(status: .fail, message: msg)
         }
-        return PredicateResult(status: Satisfiability(bool: matches), message: msg)
+        return PredicateResult(status: PredicateStatus(bool: matches), message: msg)
     }
 }
 
@@ -38,7 +38,7 @@ public func equal<T: Equatable, C: Equatable>(_ expectedValue: [T: C]?) -> Predi
             return PredicateResult(status: .fail, message: msg)
         }
         return PredicateResult(
-            status: Satisfiability(bool: expectedValue! == actualValue!),
+            status: PredicateStatus(bool: expectedValue! == actualValue!),
             message: msg
         )
     }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -54,7 +54,7 @@ internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
             }
 
             return PredicateResult(
-                status: Satisfiability(bool: matches),
+                status: PredicateStatus(bool: matches),
                 message: msg
             )
         }.requireNonNil

--- a/Sources/Nimble/Matchers/ToSucceed.swift
+++ b/Sources/Nimble/Matchers/ToSucceed.swift
@@ -18,17 +18,17 @@ public func succeed() -> Predicate<() -> ToSucceedResult> {
     return Predicate.define { actualExpression in
         let optActual = try actualExpression.evaluate()
         guard let actual = optActual else {
-            return Satisfiability(status: .fail, message: .fail("expected a closure, got <nil>"))
+            return PredicateResult(status: .fail, message: .fail("expected a closure, got <nil>"))
         }
 
         switch actual() {
         case .succeeded:
-            return Satisfiability(
+            return PredicateResult(
                 bool: true,
                 message: .expectedCustomValueTo("succeed", "<succeeded>")
             )
         case .failed(let reason):
-            return Satisfiability(
+            return PredicateResult(
                 bool: false,
                 message: .expectedCustomValueTo("succeed", "<failed> because <\(reason)>")
             )

--- a/Sources/Nimble/Matchers/ToSucceed.swift
+++ b/Sources/Nimble/Matchers/ToSucceed.swift
@@ -14,26 +14,24 @@ public enum ToSucceedResult {
  Return `.succeeded` when the validation succeeds.
  Return `.failed` with a failure reason when the validation fails.
  */
-public func succeed() -> NonNilMatcherFunc<() -> ToSucceedResult> {
-    return NonNilMatcherFunc { actualExpression, failureMessage in
+public func succeed() -> Predicate<() -> ToSucceedResult> {
+    return Predicate.define { actualExpression in
         let optActual = try actualExpression.evaluate()
-        guard let actual = optActual  else {
-            failureMessage.to = "a"
-            failureMessage.postfixMessage = "closure"
-            failureMessage.postfixActual = " (use beNil() to match nils)"
-            return false
+        guard let actual = optActual else {
+            return Satisfiability(status: .fail, message: .fail("expected a closure, got <nil>"))
         }
 
-        let result = actual()
-        failureMessage.postfixMessage = "succeed"
-
-        switch result {
+        switch actual() {
         case .succeeded:
-            failureMessage.actualValue = "<succeeded>"
-            return true
+            return Satisfiability(
+                bool: true,
+                message: .expectedCustomValueTo("succeed", "<succeeded>")
+            )
         case .failed(let reason):
-            failureMessage.actualValue = "<failed> because <\(reason)>"
-            return false
+            return Satisfiability(
+                bool: false,
+                message: .expectedCustomValueTo("succeed", "<failed> because <\(reason)>")
+            )
         }
     }
 }

--- a/Tests/NimbleTests/Matchers/ToSucceedTest.swift
+++ b/Tests/NimbleTests/Matchers/ToSucceedTest.swift
@@ -17,7 +17,7 @@ final class ToSucceedTest: XCTestCase, XCTestCaseProvider {
             return .failed(reason: "")
         }).toNot(succeed())
 
-        failsWithErrorMessage("expected a closure, got <nil> (use beNil() to match nils)") {
+        failsWithErrorMessageForNil("expected a closure, got <nil>") {
             expect(nil as (() -> ToSucceedResult)?).to(succeed())
         }
 


### PR DESCRIPTION
In prep for Nimble v7 release. Also includes:

 - Rename `Satisfiability` to `PredicateStatus`
 - Add placeholder `.prepends` to `ExpectationMessage` for future use.