### PR TITLE
Fixes expectation regression & failure bugs.

### DIFF
--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -2,6 +2,14 @@ import Foundation
 
 #if _runtime(_ObjC)
 
+fileprivate func from(objcPredicate: NMBPredicate) -> Predicate<NSObject> {
+    return Predicate { actualExpression in
+        let result = objcPredicate.satisfies(({ try! actualExpression.evaluate() }),
+                                             location: actualExpression.location)
+        return result.toSwift()
+    }
+}
+
 internal struct ObjCMatcherWrapper: Matcher {
     let matcher: NMBMatcher
 
@@ -49,29 +57,41 @@ public class NMBExpectation: NSObject {
 
     public var to: (NMBMatcher) -> Void {
         return ({ matcher in
-            self.expectValue.to(ObjCMatcherWrapper(matcher: matcher))
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.to(from(objcPredicate: pred))
+            } else {
+                self.expectValue.to(ObjCMatcherWrapper(matcher: matcher))
+            }
         })
     }
 
     public var toWithDescription: (NMBMatcher, String) -> Void {
         return ({ matcher, description in
-            self.expectValue.to(ObjCMatcherWrapper(matcher: matcher), description: description)
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.to(from(objcPredicate: pred), description: description)
+            } else {
+                self.expectValue.to(ObjCMatcherWrapper(matcher: matcher), description: description)
+            }
         })
     }
 
     public var toNot: (NMBMatcher) -> Void {
         return ({ matcher in
-            self.expectValue.toNot(
-                ObjCMatcherWrapper(matcher: matcher)
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toNot(from(objcPredicate: pred))
+            } else {
+                self.expectValue.toNot(ObjCMatcherWrapper(matcher: matcher))
+            }
         })
     }
 
     public var toNotWithDescription: (NMBMatcher, String) -> Void {
         return ({ matcher, description in
-            self.expectValue.toNot(
-                ObjCMatcherWrapper(matcher: matcher), description: description
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toNot(from(objcPredicate: pred), description: description)
+            } else {
+                self.expectValue.toNot(ObjCMatcherWrapper(matcher: matcher), description: description)
+            }
         })
     }
 
@@ -81,41 +101,73 @@ public class NMBExpectation: NSObject {
 
     public var toEventually: (NMBMatcher) -> Void {
         return ({ matcher in
-            self.expectValue.toEventually(
-                ObjCMatcherWrapper(matcher: matcher),
-                timeout: self._timeout,
-                description: nil
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toEventually(
+                    from(objcPredicate: pred),
+                    timeout: self._timeout,
+                    description: nil
+                )
+            } else {
+                self.expectValue.toEventually(
+                    ObjCMatcherWrapper(matcher: matcher),
+                    timeout: self._timeout,
+                    description: nil
+                )
+            }
         })
     }
 
     public var toEventuallyWithDescription: (NMBMatcher, String) -> Void {
         return ({ matcher, description in
-            self.expectValue.toEventually(
-                ObjCMatcherWrapper(matcher: matcher),
-                timeout: self._timeout,
-                description: description
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toEventually(
+                    from(objcPredicate: pred),
+                    timeout: self._timeout,
+                    description: description
+                )
+            } else {
+                self.expectValue.toEventually(
+                    ObjCMatcherWrapper(matcher: matcher),
+                    timeout: self._timeout,
+                    description: description
+                )
+            }
         })
     }
 
     public var toEventuallyNot: (NMBMatcher) -> Void {
         return ({ matcher in
-            self.expectValue.toEventuallyNot(
-                ObjCMatcherWrapper(matcher: matcher),
-                timeout: self._timeout,
-                description: nil
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toEventuallyNot(
+                    from(objcPredicate: pred),
+                    timeout: self._timeout,
+                    description: nil
+                )
+            } else {
+                self.expectValue.toEventuallyNot(
+                    ObjCMatcherWrapper(matcher: matcher),
+                    timeout: self._timeout,
+                    description: nil
+                )
+            }
         })
     }
 
     public var toEventuallyNotWithDescription: (NMBMatcher, String) -> Void {
         return ({ matcher, description in
-            self.expectValue.toEventuallyNot(
-                ObjCMatcherWrapper(matcher: matcher),
-                timeout: self._timeout,
-                description: description
-            )
+            if let pred = matcher as? NMBPredicate {
+                self.expectValue.toEventuallyNot(
+                    from(objcPredicate: pred),
+                    timeout: self._timeout,
+                    description: description
+                )
+            } else {
+                self.expectValue.toEventuallyNot(
+                    ObjCMatcherWrapper(matcher: matcher),
+                    timeout: self._timeout,
+                    description: description
+                )
+            }
         })
     }
 

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -202,3 +202,58 @@ extension FailureMessage {
         return msg
     }
 }
+
+#if _runtime(_ObjC)
+
+@objc public class NMBExpectationMessage: NSObject {
+    private let msg: ExpectationMessage
+
+    internal init(swift msg: ExpectationMessage) {
+        self.msg = msg
+    }
+
+    public init(expectedTo message: String) {
+        self.msg = .expectedTo(message)
+    }
+    public init(expectedActualValueTo message: String) {
+        self.msg = .expectedActualValueTo(message)
+    }
+
+    public init(expectedActualValueTo message: String, customActualValue actual: String) {
+        self.msg = .expectedCustomValueTo(message, actual)
+    }
+
+    public init(fail message: String) {
+        self.msg = .fail(message)
+    }
+
+    public init(prepend message: String, child: NMBExpectationMessage) {
+        self.msg = .prepends(message, child.msg)
+    }
+
+    public init(appendedMessage message: String, child: NMBExpectationMessage) {
+        self.msg = .appends(child.msg, message)
+    }
+
+    public init(prependedMessage message: String, child: NMBExpectationMessage) {
+        self.msg = .prepends(message, child.msg)
+    }
+
+    public init(details message: String, child: NMBExpectationMessage) {
+        self.msg = .details(child.msg, message)
+    }
+
+    public func appendedBeNilHint() -> NMBExpectationMessage {
+        return NMBExpectationMessage(swift: msg.appendedBeNilHint())
+    }
+
+    public func toSwift() -> ExpectationMessage { return self.msg }
+}
+
+extension ExpectationMessage {
+    func toObjectiveC() -> NMBExpectationMessage {
+        return NMBExpectationMessage(swift: self)
+    }
+}
+
+#endif

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public indirect enum ExpectationMessage {
     // --- Primary Expectations ---
     /// includes actual value in output ("expected to <message>, got <actual>")
@@ -205,7 +207,7 @@ extension FailureMessage {
 
 #if _runtime(_ObjC)
 
-@objc public class NMBExpectationMessage: NSObject {
+public class NMBExpectationMessage: NSObject {
     private let msg: ExpectationMessage
 
     internal init(swift msg: ExpectationMessage) {

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -43,8 +43,8 @@ public indirect enum ExpectationMessage {
             return msg
         case let .prepends(_, expectation):
             return expectation.expectedMessage
-        case let .appends(expectation, _):
-            return expectation.expectedMessage
+        case let .appends(expectation, msg):
+            return "\(expectation.expectedMessage)\(msg)"
         case let .details(expectation, _):
             return expectation.expectedMessage
         }
@@ -177,7 +177,7 @@ public indirect enum ExpectationMessage {
 }
 
 extension FailureMessage {
-    var toExpectationMessage: ExpectationMessage {
+    internal func toExpectationMessage() -> ExpectationMessage {
         let defaultMsg = FailureMessage()
         if expected != defaultMsg.expected || _stringValueOverride != nil {
             return .fail(stringValue)

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -168,28 +168,10 @@ public indirect enum ExpectationMessage {
             }
         case let .appends(expectation, msg):
             expectation.update(failureMessage: failureMessage)
-            if failureMessage.hasOverriddenStringValue {
-                failureMessage.stringValue += "\(msg)"
-            } else {
-                if failureMessage.actualValue != nil {
-                    failureMessage.postfixActual += msg
-                } else {
-                    failureMessage.postfixMessage += msg
-                }
-            }
+            failureMessage.appendMessage(msg)
         case let .details(expectation, msg):
             expectation.update(failureMessage: failureMessage)
-            if failureMessage.hasOverriddenStringValue {
-                if let desc = failureMessage.userDescription {
-                    failureMessage.stringValue = "\(desc)\n\(failureMessage.stringValue)"
-                }
-                failureMessage.stringValue += "\n\(msg)"
-            } else {
-                if let desc = failureMessage.userDescription {
-                    failureMessage.userDescription = desc
-                }
-                failureMessage.extendedMessage = msg
-            }
+            failureMessage.appendDetails(msg)
         }
     }
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -65,4 +65,28 @@ public class FailureMessage: NSObject {
 
         return value
     }
+
+    internal func appendMessage(_ msg: String) {
+        if hasOverriddenStringValue {
+            stringValue += "\(msg)"
+        } else if actualValue != nil {
+            postfixActual += msg
+        } else {
+            postfixMessage += msg
+        }
+    }
+
+    internal func appendDetails(_ msg: String) {
+        if hasOverriddenStringValue {
+            if let desc = userDescription {
+                stringValue = "\(desc)\n\(stringValue)"
+            }
+            stringValue += "\n\(msg)"
+        } else {
+            if let desc = userDescription {
+                userDescription = desc
+            }
+            extendedMessage = msg
+        }
+    }
 }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -90,7 +90,7 @@ extension NMBObjCMatcher {
                 return NMBPredicateResult(
                     status: NMBPredicateStatus.fail,
                     message: NMBExpectationMessage(
-                        fail: "allPass can only be used with types which implement NSFastEnumeration (NSArray, NSSet, ...) of NSObjects, got <\(actualValue?.description ?? "nil")>"
+                        fail: "allPass can only be used with types which implement NSFastEnumeration (NSArray, NSSet, ...), and whose elements subclass NSObject, got <\(actualValue?.description ?? "nil")>"
                     )
                 )
             }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -106,7 +106,7 @@ extension NMBObjCMatcher {
                         failureMessage: failureMessage,
                         location: expr.location
                     )
-                    let expectationMsg = failureMessage.toExpectationMessage
+                    let expectationMsg = failureMessage.toExpectationMessage()
                     return PredicateResult(
                         bool: result,
                         message: expectationMsg

--- a/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
+++ b/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
@@ -23,7 +23,7 @@ fileprivate func async<T>(style: ExpectationStyle, predicate: Predicate<T>, time
         }
         switch result {
         case .completed: return lastPredicateResult!
-        case .timedOut: return PredicateResult(status: .doesNotMatch, message: lastPredicateResult!.message)
+        case .timedOut: return PredicateResult(status: .fail, message: lastPredicateResult!.message)
         case let .errorThrown(error):
             return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
         case let .raisedException(exception):

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -33,11 +33,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
         } else {
             actualString = "<nil>"
         }
-#if _runtime(_ObjC)
-    let matches = instance != nil && instance!.isMember(of: expectedClass)
-#else
-    let matches = instance != nil && type(of: instance!) == expectedClass
-#endif
+        let matches = instance != nil && type(of: instance!) == expectedClass
         return PredicateResult(
             status: PredicateStatus(bool: matches),
             message: .expectedCustomValueTo(errorMessage, actualString)

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -33,7 +33,11 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
         } else {
             actualString = "<nil>"
         }
-        let matches = instance != nil && type(of: instance!) == expectedClass
+        #if _runtime(_ObjC)
+            let matches = instance != nil && instance!.isMember(of: expectedClass)
+        #else
+            let matches = instance != nil && type(of: instance!) == expectedClass
+        #endif
         return PredicateResult(
             status: PredicateStatus(bool: matches),
             message: .expectedCustomValueTo(errorMessage, actualString)

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -68,7 +68,6 @@ extension NMBObjCMatcher {
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()
 
-
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value as NMBCollection }), location: location)
                 return try! beEmpty().satisfies(expr).toObjectiveC()

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -63,22 +63,30 @@ public func beEmpty() -> Predicate<NMBCollection> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beEmptyMatcher() -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    public class func beEmptyMatcher() -> NMBPredicate {
+        return NMBPredicate { actualExpression in
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()
-            failureMessage.postfixMessage = "be empty"
+
+
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value as NMBCollection }), location: location)
-                return try! beEmpty().matches(expr, failureMessage: failureMessage)
+                return try! beEmpty().satisfies(expr).toObjectiveC()
             } else if let value = actualValue as? NSString {
                 let expr = Expression(expression: ({ value as String }), location: location)
-                return try! beEmpty().matches(expr, failureMessage: failureMessage)
+                return try! beEmpty().satisfies(expr).toObjectiveC()
             } else if let actualValue = actualValue {
-                failureMessage.postfixMessage = "be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings)"
-                failureMessage.actualValue = "\(String(describing: type(of: actualValue))) type"
+                let badTypeErrorMsg = "be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings)"
+                return NMBPredicateResult(
+                    status: NMBPredicateStatus.fail,
+                    message: NMBExpectationMessage(expectedActualValueTo: badTypeErrorMsg,
+                                                   customActualValue: "\(String(describing: type(of: actualValue))) type")
+                )
             }
-            return false
+            return NMBPredicateResult(
+                status: NMBPredicateStatus.fail,
+                message: NMBExpectationMessage(expectedActualValueTo: "be empty").appendedBeNilHint()
+            )
         }
     }
 }

--- a/Sources/Nimble/Matchers/MatchError.swift
+++ b/Sources/Nimble/Matchers/MatchError.swift
@@ -37,7 +37,6 @@ public func matchError<T: Error & Equatable>(_ error: T) -> Predicate<Error> {
     }.requireNonNil
 }
 
-
 /// A Nimble matcher that succeeds when the actual expression evaluates to an
 /// error of the specified type
 public func matchError<T: Error>(_ errorType: T.Type) -> Predicate<Error> {
@@ -46,7 +45,7 @@ public func matchError<T: Error>(_ errorType: T.Type) -> Predicate<Error> {
 
         setFailureMessageForError(failureMessage, postfixMessageVerb: "match", actualError: actualError, errorType: errorType)
         var matches = false
-        if let _ = actualError as? T {
+        if actualError as? T != nil {
             matches = true
         }
         return matches

--- a/Sources/Nimble/Matchers/MatchError.swift
+++ b/Sources/Nimble/Matchers/MatchError.swift
@@ -10,9 +10,33 @@ public func matchError<T: Error>(_ error: T) -> Predicate<Error> {
         let actualError: Error? = try actualExpression.evaluate()
 
         setFailureMessageForError(failureMessage, postfixMessageVerb: "match", actualError: actualError, error: error)
-        return errorMatchesNonNilFieldsOrClosure(actualError, error: error)
+        var matches = false
+        if let actualError = actualError, errorMatchesExpectedError(actualError, expectedError: error) {
+            matches = true
+        }
+        return matches
     }.requireNonNil
 }
+
+/// A Nimble matcher that succeeds when the actual expression evaluates to an
+/// error from the specified case.
+///
+/// Errors are tried to be compared by their implementation of Equatable,
+/// otherwise they fallback to comparision by _domain and _code.
+public func matchError<T: Error & Equatable>(_ error: T) -> Predicate<Error> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+        let actualError: Error? = try actualExpression.evaluate()
+
+        setFailureMessageForError(failureMessage, postfixMessageVerb: "match", actualError: actualError, error: error)
+
+        var matches = false
+        if let actualError = actualError as? T, error == actualError {
+            matches = true
+        }
+        return matches
+    }.requireNonNil
+}
+
 
 /// A Nimble matcher that succeeds when the actual expression evaluates to an
 /// error of the specified type
@@ -21,6 +45,10 @@ public func matchError<T: Error>(_ errorType: T.Type) -> Predicate<Error> {
         let actualError: Error? = try actualExpression.evaluate()
 
         setFailureMessageForError(failureMessage, postfixMessageVerb: "match", actualError: actualError, errorType: errorType)
-        return errorMatchesNonNilFieldsOrClosure(actualError, errorType: errorType)
+        var matches = false
+        if let _ = actualError as? T {
+            matches = true
+        }
+        return matches
     }.requireNonNil
 }

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -44,7 +44,7 @@ public func postNotifications<T>(
     -> Predicate<Any>
     where T: Matcher, T.ValueType == [Notification]
 {
-    let _ = mainThread // Force lazy-loading of this value
+    _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center)
     collector.startObserving()
     var once: Bool = false

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -174,7 +174,7 @@ extension Predicate: Matcher {
             let result = try matcher(actual, failureMessage, true)
             return PredicateResult(
                 status: PredicateStatus(bool: result),
-                message: failureMessage.toExpectationMessage
+                message: failureMessage.toExpectationMessage()
             )
         }
     }
@@ -187,7 +187,7 @@ extension Predicate: Matcher {
             let result = try matcher(actual, failureMessage)
             return PredicateResult(
                 status: PredicateStatus(bool: result),
-                message: failureMessage.toExpectationMessage
+                message: failureMessage.toExpectationMessage()
             )
         }
 

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -1,5 +1,6 @@
 // New Matcher API
 //
+import Foundation
 
 /// A Predicate is part of the new matcher API that provides assertions to expectations.
 ///
@@ -243,7 +244,7 @@ extension Predicate {
 #if _runtime(_ObjC)
 public typealias PredicateBlock = (_ actualExpression: Expression<NSObject>) -> NMBPredicateResult
 
-@objc public class NMBPredicate: NSObject {
+public class NMBPredicate: NSObject {
     private let predicate: PredicateBlock
 
     public init(predicate: @escaping PredicateBlock) {
@@ -270,7 +271,7 @@ extension NMBPredicate: NMBMatcher {
     }
 }
 
-@objc final public class NMBPredicateResult: NSObject {
+final public class NMBPredicateResult: NSObject {
     public var status: NMBPredicateStatus
     public var message: NMBExpectationMessage
 
@@ -296,7 +297,7 @@ extension PredicateResult {
     }
 }
 
-@objc final public class NMBPredicateStatus: NSObject {
+final public class NMBPredicateStatus: NSObject {
     private let status: Int
     private init(status: Int) {
         self.status = status

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -38,7 +38,7 @@ internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
                 if result.toBoolean(expectation: .toMatch) {
                     matches = true
                 }
-                postfixMessages.append(result.message.expectedMessage)
+                postfixMessages.append("{\(result.message.expectedMessage)}")
             }
 
             var msg: ExpectationMessage
@@ -74,24 +74,33 @@ public func || <T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> Predicate<T> 
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func satisfyAnyOfMatcher(_ matchers: [NMBObjCMatcher]) -> NMBObjCMatcher {
-        return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
+    public class func satisfyAnyOfMatcher(_ matchers: [NMBMatcher]) -> NMBPredicate {
+        return NMBPredicate { actualExpression in
             if matchers.isEmpty {
-                failureMessage.stringValue = "satisfyAnyOf must be called with at least one matcher"
-                return false
+                return NMBPredicateResult(
+                    status: NMBPredicateStatus.fail,
+                    message: NMBExpectationMessage(
+                        fail: "satisfyAnyOf must be called with at least one matcher"
+                    )
+                )
             }
 
-            var elementEvaluators = [NonNilMatcherFunc<NSObject>]()
+            var elementEvaluators = [Predicate<NSObject>]()
             for matcher in matchers {
-                let elementEvaluator: (Expression<NSObject>, FailureMessage) -> Bool = {
-                    expression, failureMessage in
-                    return matcher.matches({try! expression.evaluate()}, failureMessage: failureMessage, location: actualExpression.location)
+                let elementEvaluator = Predicate<NSObject> { expression in
+                    if let predicate = matcher as? NMBPredicate {
+                        return predicate.satisfies({ try! expression.evaluate() }, location: actualExpression.location).toSwift()
+                    } else {
+                        let failureMessage = FailureMessage()
+                        let success = matcher.matches({ try! expression.evaluate() }, failureMessage: failureMessage, location: actualExpression.location)
+                        return PredicateResult(bool: success, message: failureMessage.toExpectationMessage())
+                    }
                 }
 
-                elementEvaluators.append(NonNilMatcherFunc(elementEvaluator))
+                elementEvaluators.append(elementEvaluator)
             }
 
-            return try! satisfyAnyOf(elementEvaluators).matches(actualExpression, failureMessage: failureMessage)
+            return try! satisfyAnyOf(elementEvaluators).satisfies(actualExpression).toObjectiveC()
         }
     }
 }

--- a/Sources/Nimble/Matchers/ThrowError.swift
+++ b/Sources/Nimble/Matchers/ThrowError.swift
@@ -31,7 +31,6 @@ public func throwError() -> Predicate<Any> {
     }
 }
 
-
 /// A Nimble matcher that succeeds when the actual expression throws an
 /// error of the specified type or from the specified case.
 ///
@@ -70,7 +69,6 @@ public func throwError<T: Error>(_ error: T, closure: ((Error) -> Void)? = nil) 
         return matches
     }
 }
-
 
 /// A Nimble matcher that succeeds when the actual expression throws an
 /// error of the specified type or from the specified case.
@@ -111,7 +109,6 @@ public func throwError<T: Error & Equatable>(_ error: T, closure: ((T) -> Void)?
         return matches
     }
 }
-
 
 /// A Nimble matcher that succeeds when the actual expression throws an
 /// error of the specified type or from the specified case.
@@ -171,7 +168,6 @@ public func throwError<T: Error>(
         return matches
     }
 }
-
 
 /// A Nimble matcher that succeeds when the actual expression throws any
 /// error or when the passed closures' arbitrary custom matching succeeds.

--- a/Sources/Nimble/Matchers/ThrowError.swift
+++ b/Sources/Nimble/Matchers/ThrowError.swift
@@ -11,22 +11,201 @@ import Foundation
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func throwError<T: Error>(
-    _ error: T? = nil,
-    errorType: T.Type? = nil,
-    closure: ((T) -> Void)? = nil) -> Predicate<Any> {
-        return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+public func throwError() -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
-            var actualError: Error?
-            do {
-                _ = try actualExpression.evaluate()
-            } catch let catchedError {
-                actualError = catchedError
-            }
-
-            setFailureMessageForError(failureMessage, actualError: actualError, error: error, errorType: errorType, closure: closure)
-            return errorMatchesNonNilFieldsOrClosure(actualError, error: error, errorType: errorType, closure: closure)
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
         }
+
+        failureMessage.postfixMessage = "throw any error"
+        if let actualError = actualError {
+            failureMessage.actualValue = "<\(actualError)>"
+        } else {
+            failureMessage.actualValue = "no error"
+        }
+        return actualError != nil
+    }
+}
+
+
+/// A Nimble matcher that succeeds when the actual expression throws an
+/// error of the specified type or from the specified case.
+///
+/// Errors are tried to be compared by their implementation of Equatable,
+/// otherwise they fallback to comparision by _domain and _code.
+///
+/// Alternatively, you can pass a closure to do any arbitrary custom matching
+/// to the thrown error. The closure only gets called when an error was thrown.
+///
+/// nil arguments indicates that the matcher should not attempt to match against
+/// that parameter.
+public func throwError<T: Error>(_ error: T, closure: ((Error) -> Void)? = nil) -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
+        }
+
+        setFailureMessageForError(failureMessage, actualError: actualError, error: error, errorType: nil, closure: closure)
+        var matches = false
+        if let actualError = actualError, errorMatchesExpectedError(actualError, expectedError: error) {
+            matches = true
+            if let closure = closure {
+                let assertions = gatherFailingExpectations {
+                    closure(actualError)
+                }
+                let messages = assertions.map { $0.message }
+                if messages.count > 0 {
+                    matches = false
+                }
+            }
+        }
+        return matches
+    }
+}
+
+
+/// A Nimble matcher that succeeds when the actual expression throws an
+/// error of the specified type or from the specified case.
+///
+/// Errors are tried to be compared by their implementation of Equatable,
+/// otherwise they fallback to comparision by _domain and _code.
+///
+/// Alternatively, you can pass a closure to do any arbitrary custom matching
+/// to the thrown error. The closure only gets called when an error was thrown.
+///
+/// nil arguments indicates that the matcher should not attempt to match against
+/// that parameter.
+public func throwError<T: Error & Equatable>(_ error: T, closure: ((T) -> Void)? = nil) -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
+        }
+
+        setFailureMessageForError(failureMessage, actualError: actualError, error: error, errorType: nil, closure: closure)
+        var matches = false
+        if let actualError = actualError as? T, error == actualError {
+            matches = true
+
+            if let closure = closure {
+                let assertions = gatherFailingExpectations {
+                    closure(actualError)
+                }
+                let messages = assertions.map { $0.message }
+                if messages.count > 0 {
+                    matches = false
+                }
+            }
+        }
+        return matches
+    }
+}
+
+
+/// A Nimble matcher that succeeds when the actual expression throws an
+/// error of the specified type or from the specified case.
+///
+/// Errors are tried to be compared by their implementation of Equatable,
+/// otherwise they fallback to comparision by _domain and _code.
+///
+/// Alternatively, you can pass a closure to do any arbitrary custom matching
+/// to the thrown error. The closure only gets called when an error was thrown.
+///
+/// nil arguments indicates that the matcher should not attempt to match against
+/// that parameter.
+public func throwError<T: Error>(
+    errorType: T.Type,
+    closure: ((T) -> Void)? = nil) -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
+        }
+
+        setFailureMessageForError(failureMessage, actualError: actualError, error: nil, errorType: errorType, closure: closure)
+        var matches = false
+        if let actualError = actualError {
+            matches = true
+            if let actualError = actualError as? T {
+                if let closure = closure {
+                    let assertions = gatherFailingExpectations {
+                        closure(actualError)
+                    }
+                    let messages = assertions.map { $0.message }
+                    if messages.count > 0 {
+                        matches = false
+                    }
+                }
+            } else {
+                matches = (actualError is T)
+                // The closure expects another ErrorProtocol as argument, so this
+                // is _supposed_ to fail, so that it becomes more obvious.
+                if let closure = closure {
+                    let assertions = gatherExpectations {
+                        if let actual = actualError as? T {
+                            closure(actual)
+                        }
+                    }
+                    let messages = assertions.map { $0.message }
+                    if messages.count > 0 {
+                        matches = false
+                    }
+                }
+            }
+        }
+
+        return matches
+    }
+}
+
+
+/// A Nimble matcher that succeeds when the actual expression throws any
+/// error or when the passed closures' arbitrary custom matching succeeds.
+///
+/// This duplication to it's generic adequate is required to allow to receive
+/// values of the existential type `Error` in the closure.
+///
+/// The closure only gets called when an error was thrown.
+public func throwError(closure: @escaping ((Error) -> Void)) -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
+        }
+
+        setFailureMessageForError(failureMessage, actualError: actualError, closure: closure)
+
+        var matches = false
+        if let actualError = actualError {
+            matches = true
+
+            let assertions = gatherFailingExpectations {
+                closure(actualError)
+            }
+            let messages = assertions.map { $0.message }
+            if messages.count > 0 {
+                matches = false
+            }
+        }
+        return matches
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual expression throws any
@@ -36,18 +215,30 @@ public func throwError<T: Error>(
 /// values of the existential type `Error` in the closure.
 ///
 /// The closure only gets called when an error was thrown.
-public func throwError(
-    closure: ((Error) -> Void)? = nil) -> Predicate<Any> {
-        return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+public func throwError<T: Error>(closure: @escaping ((T) -> Void)) -> Predicate<Any> {
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
-            var actualError: Error?
-            do {
-                _ = try actualExpression.evaluate()
-            } catch let catchedError {
-                actualError = catchedError
-            }
-
-            setFailureMessageForError(failureMessage, actualError: actualError, closure: closure)
-            return errorMatchesNonNilFieldsOrClosure(actualError, closure: closure)
+        var actualError: Error?
+        do {
+            _ = try actualExpression.evaluate()
+        } catch let catchedError {
+            actualError = catchedError
         }
+
+        setFailureMessageForError(failureMessage, actualError: actualError, closure: closure)
+
+        var matches = false
+        if let actualError = actualError as? T {
+            matches = true
+
+            let assertions = gatherFailingExpectations {
+                closure(actualError)
+            }
+            let messages = assertions.map { $0.message }
+            if messages.count > 0 {
+                matches = false
+            }
+        }
+        return matches
+    }
 }

--- a/Sources/Nimble/Utils/Errors.swift
+++ b/Sources/Nimble/Utils/Errors.swift
@@ -37,62 +37,6 @@ internal func errorMatchesExpectedError<T: Error>(
         && actualError._code   == expectedError._code
 }
 
-internal func errorMatchesExpectedError<T: Error>(
-    _ actualError: Error,
-    expectedError: T) -> Bool
-    where T: Equatable {
-    if let actualError = actualError as? T {
-        return actualError == expectedError
-    }
-    return false
-}
-
-internal func errorMatchesNonNilFieldsOrClosure<T: Error>(
-    _ actualError: Error?,
-    error: T? = nil,
-    errorType: T.Type? = nil,
-    closure: ((T) -> Void)? = nil) -> Bool {
-    var matches = false
-
-    if let actualError = actualError {
-        matches = true
-
-        if let error = error {
-            if !errorMatchesExpectedError(actualError, expectedError: error) {
-                matches = false
-            }
-        }
-        if let actualError = actualError as? T {
-            if let closure = closure {
-                let assertions = gatherFailingExpectations {
-                    closure(actualError as T)
-                }
-                let messages = assertions.map { $0.message }
-                if messages.count > 0 {
-                    matches = false
-                }
-            }
-        } else if errorType != nil {
-            matches = (actualError is T)
-            // The closure expects another ErrorProtocol as argument, so this
-            // is _supposed_ to fail, so that it becomes more obvious.
-            if let closure = closure {
-                let assertions = gatherExpectations {
-                    if let actual = actualError as? T {
-                        closure(actual)
-                    }
-                }
-                let messages = assertions.map { $0.message }
-                if messages.count > 0 {
-                    matches = false
-                }
-            }
-        }
-    }
-
-    return matches
-}
-
 // Non-generic
 
 internal func setFailureMessageForError(
@@ -112,26 +56,4 @@ internal func setFailureMessageForError(
     } else {
         failureMessage.actualValue = "no error"
     }
-}
-
-internal func errorMatchesNonNilFieldsOrClosure(
-    _ actualError: Error?,
-    closure: ((Error) -> Void)?) -> Bool {
-    var matches = false
-
-    if let actualError = actualError {
-        matches = true
-
-        if let closure = closure {
-            let assertions = gatherFailingExpectations {
-                closure(actualError)
-            }
-            let messages = assertions.map { $0.message }
-            if messages.count > 0 {
-                matches = false
-            }
-        }
-    }
-
-    return matches
 }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -14,12 +14,10 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
         var lastFailure: AssertionRecord?
         var foundFailureMessage = false
 
-        for assertion in recorder.assertions {
-            if assertion.message.stringValue == msg && !assertion.success {
-                lastFailure = assertion
-                foundFailureMessage = true
-                break
-            }
+        for assertion in recorder.assertions where assertion.message.stringValue == msg && !assertion.success {
+            lastFailure = assertion
+            foundFailureMessage = true
+            break
         }
 
         if foundFailureMessage {

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -15,8 +15,8 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
         var foundFailureMessage = false
 
         for assertion in recorder.assertions {
-            lastFailure = assertion
-            if assertion.message.stringValue == msg {
+            if assertion.message.stringValue == msg && !assertion.success {
+                lastFailure = assertion
                 foundFailureMessage = true
                 break
             }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -35,7 +35,9 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
         if let lastFailure = lastFailure {
             message = "Got failure message: \"\(lastFailure.message.stringValue)\", but expected \"\(msg)\""
         } else {
-            message = "expected failure message, but got none"
+            let knownFailures = recorder.assertions.filter { !$0.success }.map { $0.message.stringValue }
+            let knownFailuresJoined = knownFailures.joined(separator: ", ")
+            message = "Did not get expected error message, got (\(knownFailuresJoined))"
         }
         NimbleAssertionHandler.assert(false,
                                       message: FailureMessage(stringValue: message),
@@ -57,12 +59,12 @@ func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, li
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
-    func deferToMainQueue(action: @escaping () -> Void) {
-        DispatchQueue.main.async {
-            Thread.sleep(forTimeInterval: 0.01)
-            action()
-        }
+func deferToMainQueue(action: @escaping () -> Void) {
+    DispatchQueue.main.async {
+        Thread.sleep(forTimeInterval: 0.01)
+        action()
     }
+}
 
 public class NimbleHelper: NSObject {
     public class func expectFailureMessage(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -37,7 +37,7 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
         } else {
             let knownFailures = recorder.assertions.filter { !$0.success }.map { $0.message.stringValue }
             let knownFailuresJoined = knownFailures.joined(separator: ", ")
-            message = "Did not get expected error message, got (\(knownFailuresJoined))"
+            message = "Expected error message (\(msg)), got (\(knownFailuresJoined))\n\nAssertions Received:\n\(recorder.assertions)"
         }
         NimbleAssertionHandler.assert(false,
                                       message: FailureMessage(stringValue: message),

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -57,8 +57,8 @@ final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to be an instance of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(value:1)).to(beAnInstanceOf(NSString.self))
         }
-        failsWithErrorMessage("expected to be an instance of NSNumber, got <\(numberTypeName) instance>") {
-            expect(NSNumber(value:1)).to(beAnInstanceOf(NSNumber.self))
+        failsWithErrorMessage("expected to not be an instance of \(numberTypeName), got <\(numberTypeName) instance>") {
+            expect(NSNumber(value:1)).toNot(beAnInstanceOf(type(of: NSNumber(value:1))))
         }
     }
 

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -57,8 +57,8 @@ final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to be an instance of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(value:1)).to(beAnInstanceOf(NSString.self))
         }
-        failsWithErrorMessage("expected to not be an instance of NSNumber, got <\(numberTypeName) instance>") {
-            expect(NSNumber(value:1)).toNot(beAnInstanceOf(NSNumber.self))
+        failsWithErrorMessage("expected to be an instance of NSNumber, got <\(numberTypeName) instance>") {
+            expect(NSNumber(value:1)).to(beAnInstanceOf(NSNumber.self))
         }
     }
 

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -53,26 +53,26 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(CGFloat(1.2)).to(beCloseTo(1.2001))
         expect(CGFloat(1.2)).to(beCloseTo(CGFloat(1.2001)))
 
-        failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <1.2>") {
-            expect(CGFloat(1.2)).to(beCloseTo(1.2001, within: 1.0))
+        failsWithErrorMessage("expected to not be close to <1.2001> (within 1), got <1.2>") {
+            expect(CGFloat(1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
     }
 
     func testBeCloseToWithDate() {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(Date(dateTimeString: "2015-08-26 11:43:05"), within: 10))
 
-        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(Date(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
+            expect(Date(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.006))
         }
     }
 
     func testBeCloseToWithNSDate() {
         expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(NSDate(dateTimeString: "2015-08-26 11:43:05"), within: 10))
 
-        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to not be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = NSDate(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.004))
+            expect(NSDate(dateTimeString: "2015-08-26 11:43:00")).toNot(beCloseTo(expectedDate, within: 0.006))
         }
     }
 
@@ -122,13 +122,13 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ (Date(dateTimeString: "2015-08-26 11:43:05"), 10)
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) == (Date(dateTimeString: "2015-08-26 11:43:05"), 10)
 
-        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ (expectedDate, 0.006)
+            expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ (expectedDate, 0.004)
         }
-        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(Date(dateTimeString: "2015-08-26 11:43:00")) == (expectedDate, 0.006)
+            expect(Date(dateTimeString: "2015-08-26 11:43:00")) == (expectedDate, 0.004)
         }
     }
 
@@ -136,13 +136,13 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ Date(dateTimeString: "2015-08-26 11:43:05") ± 10
         expect(Date(dateTimeString: "2015-08-26 11:43:00")) == Date(dateTimeString: "2015-08-26 11:43:05") ± 10
 
-        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate ± 0.006
+            expect(Date(dateTimeString: "2015-08-26 11:43:00")) ≈ expectedDate ± 0.004
         }
-        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.006), got <2015-08-26 11:43:00.0000>") {
+        failsWithErrorMessage("expected to be close to <2015-08-26 11:43:00.0050> (within 0.004), got <2015-08-26 11:43:00.0000>") {
             let expectedDate = Date(dateTimeString: "2015-08-26 11:43:00").addingTimeInterval(0.005)
-            expect(Date(dateTimeString: "2015-08-26 11:43:00")) == expectedDate ± 0.006
+            expect(Date(dateTimeString: "2015-08-26 11:43:00")) == expectedDate ± 0.004
         }
     }
 

--- a/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -35,7 +35,7 @@ final class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
 
     func testBeIdenticalToNegativeMessage() {
         let value1 = NSArray(array: [])
-        let value2 = NSArray(array: [])
+        let value2 = value1
         let message = "expected to not be identical to \(identityAsString(value2)), got \(identityAsString(value1))"
         failsWithErrorMessage(message) {
             expect(value1).toNot(beIdenticalTo(value2))
@@ -59,8 +59,8 @@ final class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
         #endif
 
         let value1 = NSArray(array: [])
-        let value2 = NSArray(array: [])
-        let message = "expected to not be identical to \(identityAsString(value2)), got \(identityAsString(value1))"
+        let value2 = value1
+        let message = "expected to not be identical to \(identityAsString(value1)), got \(identityAsString(value2))"
         failsWithErrorMessage(message) {
             expect(value1).toNot(be(value2))
         }

--- a/Tests/NimbleTests/Matchers/ContainTest.swift
+++ b/Tests/NimbleTests/Matchers/ContainTest.swift
@@ -71,8 +71,8 @@ final class ContainTest: XCTestCase, XCTestCaseProvider {
             expect(["a", "b", "c"]).to(contain("a", "bar"))
         }
 
-        failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
-            expect(["a", "b", "c"]).toNot(contain("bar", "b"))
+        failsWithErrorMessage("expected to not contain <b, a>, got <[a, b, c]>") {
+            expect(["a", "b", "c"]).toNot(contain("b", "a"))
         }
     }
 
@@ -88,8 +88,8 @@ final class ContainTest: XCTestCase, XCTestCaseProvider {
             expect(["a", "b", "c"]).to(contain(["a", "bar"]))
         }
 
-        failsWithErrorMessage("expected to not contain <bar, b>, got <[a, b, c]>") {
-            expect(["a", "b", "c"]).toNot(contain(["bar", "b"]))
+        failsWithErrorMessage("expected to not contain <b, a>, got <[a, b, c]>") {
+            expect(["a", "b", "c"]).toNot(contain(["b", "a"]))
         }
     }
 }

--- a/Tests/NimbleTests/Matchers/MatchErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchErrorTest.swift
@@ -27,6 +27,7 @@ final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
         expect(NimbleError.laugh).toNot(matchError(NimbleError.cry))
         expect(NimbleError.laugh as Error).toNot(matchError(NimbleError.cry))
         expect(NimbleError.laugh).toNot(matchError(EquatableError.self))
+        expect(EquatableError.parameterized(x: 1)).toNot(matchError(EquatableError.parameterized(x: 2)))
     }
 
     func testMatchNSErrorPositive() {

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -49,6 +49,7 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
         expect { throw NimbleError.laugh }.to(throwError(NimbleError.laugh))
         expect { throw NimbleError.laugh }.to(throwError(errorType: NimbleError.self))
         expect { throw EquatableError.parameterized(x: 1) }.to(throwError(EquatableError.parameterized(x: 1)))
+        expect { throw EquatableError.parameterized(x: 1) }.toNot(throwError(EquatableError.parameterized(x: 2)))
     }
 
     func testPositiveMatchesWithClosures() {

--- a/Tests/NimbleTests/objc/ObjCBeEmptyTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeEmptyTest.m
@@ -57,10 +57,10 @@
     expectFailureMessage(@"expected to not be empty, got <{}>", ^{
         expect(@{}).toNot(beEmpty());
     });
-    expectFailureMessage(@"expected to not be empty, got <{}>", ^{
+    expectFailureMessage(@"expected to not be empty, got <{()}>", ^{
         expect([NSSet set]).toNot(beEmpty());
     });
-    expectFailureMessage(@"expected to not be empty, got <(1)>", ^{
+    expectFailureMessage(@"expected to not be empty, got <()>", ^{
         expect([NSIndexSet indexSet]).toNot(beEmpty());
     });
     expectFailureMessage(@"expected to not be empty, got <NSHashTable {}>", ^{

--- a/Tests/NimbleTests/objc/ObjCBeEmptyTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeEmptyTest.m
@@ -57,11 +57,11 @@
     expectFailureMessage(@"expected to not be empty, got <{}>", ^{
         expect(@{}).toNot(beEmpty());
     });
-    expectFailureMessage(@"expected to not be empty, got <{(1)}>", ^{
-        expect([NSSet setWithObject:@1]).toNot(beEmpty());
+    expectFailureMessage(@"expected to not be empty, got <{}>", ^{
+        expect([NSSet set]).toNot(beEmpty());
     });
     expectFailureMessage(@"expected to not be empty, got <(1)>", ^{
-        expect([NSIndexSet indexSetWithIndex:1]).toNot(beEmpty());
+        expect([NSIndexSet indexSet]).toNot(beEmpty());
     });
     expectFailureMessage(@"expected to not be empty, got <NSHashTable {}>", ^{
         expect([NSHashTable hashTableWithOptions:NSPointerFunctionsStrongMemory]).toNot(beEmpty());

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
@@ -19,14 +19,14 @@
     expectFailureMessage(@"expected to be greater than <0>, got <-1>", ^{
         expect(@(-1)).to(beGreaterThan(@(0)));
     });
-    expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
-        expect(@0).toNot(beGreaterThan(@(1)));
+    expectFailureMessage(@"expected to not be greater than <1>, got <2>", ^{
+        expect(@2).toNot(beGreaterThan(@(1)));
     });
     expectFailureMessage(@"expected to be greater than <0>, got <-1>", ^{
         expect(-1).to(beGreaterThan(0));
     });
-    expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
-        expect(0).toNot(beGreaterThan(1));
+    expectFailureMessage(@"expected to not be greater than <1>, got <2>", ^{
+        expect(2).toNot(beGreaterThan(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
@@ -16,14 +16,14 @@
 }
 
 - (void)testNegativeMatches {
-    expectFailureMessage(@"expected to be less than <0>, got <-1>", ^{
-        expect(@(-1)).to(beLessThan(@0));
+    expectFailureMessage(@"expected to be less than <0>, got <1>", ^{
+        expect(@(1)).to(beLessThan(@0));
     });
     expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
         expect(@0).toNot(beLessThan(@1));
     });
-    expectFailureMessage(@"expected to be less than <0>, got <-1>", ^{
-        expect(-1).to(beLessThan(0));
+    expectFailureMessage(@"expected to be less than <0>, got <1>", ^{
+        expect(1).to(beLessThan(0));
     });
     expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
         expect(0).toNot(beLessThan(1));

--- a/Tests/NimbleTests/objc/ObjCContainTest.m
+++ b/Tests/NimbleTests/objc/ObjCContainTest.m
@@ -59,8 +59,8 @@
         expect(@[@"a", @"b", @"c"]).to(contain(@"a", @"bar"));
     });
 
-    expectFailureMessage(@"expected to not contain <Optional(bar), Optional(b)>, got <(a, b, c)>", ^{
-        expect(@[@"a", @"b", @"c"]).toNot(contain(@"bar", @"b"));
+    expectFailureMessage(@"expected to not contain <Optional(a), Optional(b)>, got <(a, b, c)>", ^{
+        expect(@[@"a", @"b", @"c"]).toNot(contain(@"a", @"b"));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCEqualTest.m
+++ b/Tests/NimbleTests/objc/ObjCEqualTest.m
@@ -46,8 +46,8 @@
     expectFailureMessage(@"expected to not equal <1>, got <1>", ^{
         expect(@1).toNot(equal(@1));
     });
-    expectFailureMessage(@"expected to not equal <foo>, got <bar>", ^{
-        expect("bar").toNot(equal("foo"));
+    expectFailureMessage(@"expected to not equal <bar>, got <bar>", ^{
+        expect("bar").toNot(equal("bar"));
     });
     expectFailureMessage(@"expected to equal <NSRange: {0, 5}>, got <NSRange: {0, 10}>", ^{
         expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 5)));

--- a/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
+++ b/Tests/NimbleTests/objc/ObjCRaiseExceptionTest.m
@@ -100,7 +100,7 @@
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  satisfyingBlock(^(NSException *exception) {
-            expect(exception.name).to(equal(NSInvalidArgumentException));
+            expect(exception.name).toNot(equal(NSInvalidArgumentException));
         }));
     });
 


### PR DESCRIPTION
 - Fix regression where `expect(nil as [String]?).toEventuallyNot(beNil())` fails. (Closes #424)
 - Fix bug in Nimble's internal failure checker: `failsWithErrorMessage`. (Closes #425). Shout out to @chamander for finding the bug.
 - Fix `Error` failing to dispatch to `Equatable` equality checking (instead of `NSError`).

What's left:

Fix the failure cases that the `failsWithErrorMessage` fix reveals in `NMBObjCMatcher`. `NMBObjCMatcher` will need the same trinary behavior that `Predicate` has.