### PR TITLE
Test in Swift 3 compatibility mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode8
+osx_image: xcode8.3
 language: generic
 matrix:
   include:

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1352,13 +1352,7 @@
 				1FD8CD381968AB07008ED995 /* Expression.swift in Sources */,
 				1FD8CD3A1968AB07008ED995 /* FailureMessage.swift in Sources */,
 				472FD1351B9E085700C7B8DA /* HaveCount.swift in Sources */,
-				9630C0301C6D139F000693EE /* CwlDarwinDefinitions.swift in Sources */,
 				1FA0C4001E30B14500623165 /* Predicate.swift in Sources */,
-				9630C0231C6D0B82000693EE /* mach_excServer.c in Sources */,
-				9630C01F1C6D0B2F000693EE /* CwlCatchException.swift in Sources */,
-				9630C0131C6D0B18000693EE /* CwlCatchBadInstruction.swift in Sources */,
-				9630C01C1C6D0B2F000693EE /* CwlCatchException.m in Sources */,
-				9630C02C1C6D125F000693EE /* CwlBadInstructionException.swift in Sources */,
 				964CFEFD1C4FF48900513336 /* ThrowAssertion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1794,6 +1788,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 3";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -1842,6 +1837,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 3";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:3.0
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Nimble",
     exclude: [
-      "Sources/Lib",
-      "Sources/NimbleObjectiveC",
-      "Tests/NimbleTests/objc",
+        "Sources/Lib",
+        "Sources/NimbleObjectiveC",
+        "Tests/NimbleTests/objc",
     ]
 )

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -73,7 +73,7 @@ extension NMBObjCMatcher {
 
             var collectionIsUsable = true
             if let value = actualValue as? NSFastEnumeration {
-                let generator = NSFastEnumerationIterator(value)
+                var generator = NSFastEnumerationIterator(value)
                 while let obj = generator.next() {
                     if let nsObject = obj as? NSObject {
                         nsObjects.append(nsObject)

--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -38,7 +38,7 @@ public func containElementSatisfying<S: Sequence, T>(_ predicate: @escaping ((T)
                     return false
                 }
 
-                let iterator = NSFastEnumerationIterator(enumeration)
+                var iterator = NSFastEnumerationIterator(enumeration)
                 while let item = iterator.next() {
                     guard let object = item as? NSObject else {
                         continue


### PR DESCRIPTION
~~I think it would be ideal to add Nimble to the Swift 3 source compatibility suite. This PR should hopefully demonstrate that Nimble _doesn't_ compile in Swift 3 compatibility mode. The two issues I've noticed:~~

- ~~`NSFastEnumerationIterator` is a struct now, not a class~~
- ~~The overload rules appear to have changed, and the tests don't compile due to ambiguous matcher overloads~~

~~I haven't deeply investigated the [requirements](https://swift.org/source-compatibility/#adding-projects) for the source compatibility suite, but I wanted to kick of the discussion.~~

---

**Update!**

Turns it's only a very minor change required to get `-swift-version 3` working! I'm still not quick sure if we should merge with this change because of the warning under Swift 3, but I'm now successfully consuming Nimble from a Swift 4 project.