### PR TITLE
[gardening] Address redundant conformance warnings in Swift 4

### DIFF
--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -25,7 +25,7 @@ public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
 /// Values can support equal by supporting the Equatable protocol.
 ///
 /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T: Equatable, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
+public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
         if expectedValue == nil || actualValue == nil {
@@ -201,11 +201,11 @@ public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func ==<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func !=<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
 }
 

--- a/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -22,7 +22,7 @@ public protocol XCTestCaseNameProvider {
 
 public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
 
-extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
+extension XCTestCaseProvider {
     var allTestNames: [String] {
         return type(of: self).allTests.map({ name, _ in
             return name


### PR DESCRIPTION
The changes are still compatible with Swift 3.1.