### PR TITLE
Xcode 9 Support (Swift 3.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ matrix:
     - os: osx
       env: TYPE=macos
     - os: osx
+      env: TYPE=macos
+      osx_image: xcode9
+    - os: osx
       env: TYPE=swiftpm
+    - os: osx
+      env: TYPE=swiftpm
+      osx_image: xcode9
     - os: linux
       dist: trusty
       sudo: required

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -164,7 +164,6 @@
 		1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
 		1F5DF1861BDCA0F500C3A531 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EC19FE43C200E9D9FE /* Match.swift */; };
-		1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
 		1F5DF18B1BDCA0F500C3A531 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD251968AB07008ED995 /* Functional.swift */; };
@@ -296,8 +295,6 @@
 		1FD8CD591968AB07008ED995 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1B1968AB07008ED995 /* EndWith.swift */; };
 		1FD8CD5A1968AB07008ED995 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
 		1FD8CD5B1968AB07008ED995 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
-		1FD8CD5C1968AB07008ED995 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
-        1FD8CD5D1968AB07008ED995 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1FD8CD5F1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1FD8CD6A1968AB07008ED995 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Async.swift */; };
@@ -386,6 +383,9 @@
 		CD79C9B51D2CC848004B6F9A /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		CD79C9B61D2CC848004B6F9A /* ObjCAllPassTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */; };
 		CD79C9B71D2CC848004B6F9A /* ObjCSatisfyAnyOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */; };
+		CDD80B831F2030790002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
+		CDD80B841F20307A0002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
+		CDD80B851F20307B0002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		DA9E8C821A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DA9E8C831A414BB9002633C2 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */; };
 		DD72EC641A93874A002F7651 /* AllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD72EC631A93874A002F7651 /* AllPassTest.swift */; };
@@ -1332,6 +1332,7 @@
 				1F12BEE01E7791B9006952EC /* CwlCatchException.m in Sources */,
 				AE7ADE451C80BF8000B94CD3 /* MatchError.swift in Sources */,
 				1FC494AA1C29CBA40010975C /* NimbleEnvironment.swift in Sources */,
+				CDD80B841F20307A0002CD65 /* MatcherProtocols.swift in Sources */,
 				1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */,
 				1FD8CD561968AB07008ED995 /* Contain.swift in Sources */,
 				1FD8CD481968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
@@ -1345,7 +1346,6 @@
 				1FD8CD521968AB07008ED995 /* BeNil.swift in Sources */,
 				1FD8CD6A1968AB07008ED995 /* Async.swift in Sources */,
 				1FD8CD581968AB07008ED995 /* EndWith.swift in Sources */,
-				1FD8CD5C1968AB07008ED995 /* MatcherProtocols.swift in Sources */,
 				1FD8CD341968AB07008ED995 /* DSL.swift in Sources */,
 				1F12BEDD1E7791B9006952EC /* CwlCatchException.swift in Sources */,
 				7B5358BE1C38479700A23FAA /* SatisfyAnyOf.swift in Sources */,
@@ -1432,7 +1432,6 @@
 				1F5DF1791BDCA0F500C3A531 /* BeCloseTo.swift in Sources */,
 				1F5DF16C1BDCA0F500C3A531 /* AssertionRecorder.swift in Sources */,
 				1F1871D71CA89EEF00A34BF2 /* NMBExceptionCapture.m in Sources */,
-				1F5DF1881BDCA0F500C3A531 /* MatcherProtocols.swift in Sources */,
 				1F5DF16E1BDCA0F500C3A531 /* NimbleXCTestHandler.swift in Sources */,
 				7A6AB2C61E7F628A00A2F694 /* ToSucceed.swift in Sources */,
 				1F5DF1751BDCA0F500C3A531 /* FailureMessage.swift in Sources */,
@@ -1478,6 +1477,7 @@
 				1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */,
 				1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */,
 				1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */,
+				CDD80B851F20307B0002CD65 /* MatcherProtocols.swift in Sources */,
 				1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */,
 				7B5358C01C38479700A23FAA /* SatisfyAnyOf.swift in Sources */,
 				7B13BA0C1DD361D300C9098C /* ContainElementSatisfying.swift in Sources */,
@@ -1598,6 +1598,7 @@
 				AE7ADE461C80BF8000B94CD3 /* MatchError.swift in Sources */,
 				1FC494AB1C29CBA40010975C /* NimbleEnvironment.swift in Sources */,
 				1FD8CD5F1968AB07008ED995 /* RaisesException.swift in Sources */,
+				CDD80B831F2030790002CD65 /* MatcherProtocols.swift in Sources */,
 				1FD8CD571968AB07008ED995 /* Contain.swift in Sources */,
 				7A0A26231E7F52360092A34E /* ToSucceed.swift in Sources */,
 				1FD8CD491968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
@@ -1612,7 +1613,6 @@
 				1FD8CD6B1968AB07008ED995 /* Async.swift in Sources */,
 				964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */,
 				1FD8CD591968AB07008ED995 /* EndWith.swift in Sources */,
-				1FD8CD5D1968AB07008ED995 /* MatcherProtocols.swift in Sources */,
 				1FD8CD351968AB07008ED995 /* DSL.swift in Sources */,
 				7B5358BF1C38479700A23FAA /* SatisfyAnyOf.swift in Sources */,
 				1F12BE9B1E778F70006952EC /* CwlDarwinDefinitions.swift in Sources */,

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 		1FD8CD5A1968AB07008ED995 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
 		1FD8CD5B1968AB07008ED995 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
 		1FD8CD5C1968AB07008ED995 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
-		1FD8CD5D1968AB07008ED995 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
+        1FD8CD5D1968AB07008ED995 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1FD8CD5F1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1FD8CD6A1968AB07008ED995 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Async.swift */; };
@@ -1170,33 +1170,33 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Jeff Hui";
 				TargetAttributes = {
 					1F1A74281940169200FFFC47 = {
 						CreatedOnToolsVersion = 6.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					1F1A74331940169200FFFC47 = {
 						CreatedOnToolsVersion = 6.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = 1F1A74281940169200FFFC47;
 					};
 					1F5DF1541BDCA0CE00C3A531 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					1F5DF15D1BDCA0CE00C3A531 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					1F925EAC195C0D6300ED456B = {
 						CreatedOnToolsVersion = 6.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					1F925EB6195C0D6300ED456B = {
 						CreatedOnToolsVersion = 6.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = 1F925EAC195C0D6300ED456B;
 					};
 					A8F2B2541E79A4AB005BDD17 = {
@@ -1751,14 +1751,20 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1808,14 +1814,20 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0900"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -46,6 +47,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-macOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0900"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -46,6 +47,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/Lib/CwlPreconditionTesting/CwlCatchExceptionSupport/CwlCatchException.m
+++ b/Sources/Lib/CwlPreconditionTesting/CwlCatchExceptionSupport/CwlCatchException.m
@@ -23,7 +23,7 @@
 #if !SWIFT_PACKAGE && NON_SWIFT_PACKAGE
 __attribute__((visibility("hidden")))
 #endif
-NSException* catchExceptionOfKind(Class __nonnull type, __attribute__((noescape)) void (^ __nonnull inBlock)()) {
+NSException* catchExceptionOfKind(Class __nonnull type, __attribute__((noescape)) void (^ __nonnull inBlock)(void)) {
 	@try {
 		inBlock();
 	} @catch (NSException *exception) {

--- a/Sources/Lib/CwlPreconditionTesting/CwlCatchExceptionSupport/include/CwlCatchException.h
+++ b/Sources/Lib/CwlPreconditionTesting/CwlCatchExceptionSupport/include/CwlCatchException.h
@@ -29,4 +29,5 @@ FOUNDATION_EXPORT const unsigned char CwlCatchExceptionVersionString[];
 #if !SWIFT_PACKAGE && NON_SWIFT_PACKAGE
 __attribute__((visibility("hidden")))
 #endif
-NSException* __nullable catchExceptionOfKind(Class __nonnull type, __attribute__((noescape)) void (^ __nonnull inBlock)());
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, __attribute__((noescape)) void (^ __nonnull inBlock)(void));
+

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -36,7 +36,7 @@ public class NMBExpectation: NSObject {
     internal let _line: UInt
     internal var _timeout: TimeInterval = 1.0
 
-    public init(actualBlock: @escaping () -> NSObject!, negative: Bool, file: FileString, line: UInt) {
+    @objc public init(actualBlock: @escaping () -> NSObject!, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock
         self._negative = negative
         self._file = file
@@ -175,7 +175,7 @@ public class NMBExpectation: NSObject {
 
     public var toNotEventuallyWithDescription: (NMBMatcher, String) -> Void { return toEventuallyNotWithDescription }
 
-    public class func failWithMessage(_ message: String, file: FileString, line: UInt) {
+    @objc public class func failWithMessage(_ message: String, file: FileString, line: UInt) {
         fail(message, location: SourceLocation(file: file, line: line))
     }
 }

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -36,7 +36,7 @@ public class NMBExpectation: NSObject {
     internal let _line: UInt
     internal var _timeout: TimeInterval = 1.0
 
-    @objc public init(actualBlock: @escaping () -> NSObject!, negative: Bool, file: FileString, line: UInt) {
+    public init(actualBlock: @escaping () -> NSObject!, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock
         self._negative = negative
         self._file = file
@@ -175,7 +175,7 @@ public class NMBExpectation: NSObject {
 
     public var toNotEventuallyWithDescription: (NMBMatcher, String) -> Void { return toEventuallyNotWithDescription }
 
-    @objc public class func failWithMessage(_ message: String, file: FileString, line: UInt) {
+    public class func failWithMessage(_ message: String, file: FileString, line: UInt) {
         fail(message, location: SourceLocation(file: file, line: line))
     }
 }

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
 fileprivate func from(objcPredicate: NMBPredicate) -> Predicate<NSObject> {
     return Predicate { actualExpression in

--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -66,7 +66,12 @@ private func recordFailure(_ message: String, location: SourceLocation) {
     XCTFail("\(message)", file: location.file, line: location.line)
 #else
     if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase {
-        testCase.recordFailure(withDescription: message, inFile: location.file, atLine: location.line, expected: true)
+        #if swift(>=4)
+        let line = Int(location.line)
+        #else
+        let line = location.line
+        #endif
+        testCase.recordFailure(withDescription: message, inFile: location.file, atLine: line, expected: true)
     } else {
         let msg = "Attempted to report a test failure to XCTest while no test case was running. " +
         "The failure was:\n\"\(message)\"\nIt occurred at: \(location.file):\(location.line)"

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -65,7 +65,7 @@ private func createPredicate<S>(_ elementMatcher: Predicate<S.Iterator.Element>)
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func allPassMatcher(_ matcher: NMBMatcher) -> NMBPredicate {
+    @objc public class func allPassMatcher(_ matcher: NMBMatcher) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -58,7 +58,7 @@ public func beAKindOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
 }
 
 extension NMBObjCMatcher {
-    public class func beAKindOfMatcher(_ expected: AnyClass) -> NMBMatcher {
+    @objc public class func beAKindOfMatcher(_ expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             return try! beAKindOf(expected).matches(actualExpression, failureMessage: failureMessage)
         }

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -47,7 +47,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beAnInstanceOfMatcher(_ expected: AnyClass) -> NMBMatcher {
+    @objc public class func beAnInstanceOfMatcher(_ expected: AnyClass) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             return try! beAnInstanceOf(expected).matches(actualExpression, failureMessage: failureMessage)
         }

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal let DefaultDelta = 0.0001
+public let DefaultDelta = 0.0001
 
 internal func isCloseTo(_ actualValue: NMBDoubleConvertible?,
                         expectedValue: NMBDoubleConvertible,
@@ -69,7 +69,7 @@ public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
 }
 
 extension NMBObjCMatcher {
-    public class func beCloseToMatcher(_ expected: NSNumber, within: CDouble) -> NMBObjCBeCloseToMatcher {
+    @objc public class func beCloseToMatcher(_ expected: NSNumber, within: CDouble) -> NMBObjCBeCloseToMatcher {
         return NMBObjCBeCloseToMatcher(expected: expected, within: within)
     }
 }

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -63,7 +63,7 @@ public func beEmpty() -> Predicate<NMBCollection> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beEmptyMatcher() -> NMBPredicate {
+    @objc public class func beEmptyMatcher() -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -31,7 +31,7 @@ public func > (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beGreaterThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
+    @objc public class func beGreaterThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beGreaterThan(expected).matches(expr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -34,7 +34,7 @@ public func >=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beGreaterThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
+    @objc public class func beGreaterThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beGreaterThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -36,7 +36,7 @@ public func be(_ expected: Any?) -> Predicate<Any> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBObjCMatcher {
+    @objc public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let aExpr = actualExpression.cast { $0 as Any? }
             return try! beIdenticalTo(expected).matches(aExpr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -31,7 +31,7 @@ public func < (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
+    @objc public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beLessThan(expected).matches(expr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -32,7 +32,7 @@ public func <=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beLessThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
+    @objc public class func beLessThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil:false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beLessThanOrEqualTo(expected).matches(expr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -136,28 +136,28 @@ public func beFalsy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<T
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beTruthyMatcher() -> NMBObjCMatcher {
+    @objc public class func beTruthyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beTruthy().matches(expr, failureMessage: failureMessage)
         }
     }
 
-    public class func beFalsyMatcher() -> NMBObjCMatcher {
+    @objc public class func beFalsyMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beFalsy().matches(expr, failureMessage: failureMessage)
         }
     }
 
-    public class func beTrueMatcher() -> NMBObjCMatcher {
+    @objc public class func beTrueMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beTrue().matches(expr, failureMessage: failureMessage)
         }
     }
 
-    public class func beFalseMatcher() -> NMBObjCMatcher {
+    @objc public class func beFalseMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
             return try! beFalse().matches(expr, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -10,7 +10,7 @@ public func beNil<T>() -> Predicate<T> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beNilMatcher() -> NMBObjCMatcher {
+    @objc public class func beNilMatcher() -> NMBObjCMatcher {
         return NMBObjCMatcher { actualExpression, failureMessage in
             return try! beNil().matches(actualExpression, failureMessage: failureMessage)
         }

--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -44,7 +44,7 @@ public func beginWith(_ startingSubstring: String) -> Predicate<String> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func beginWithMatcher(_ expected: Any) -> NMBObjCMatcher {
+    @objc public class func beginWithMatcher(_ expected: Any) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let actual = try! actualExpression.evaluate()
             if (actual as? String) != nil {

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -69,7 +69,7 @@ public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func containMatcher(_ expected: [NSObject]) -> NMBObjCMatcher {
+    @objc public class func containMatcher(_ expected: [NSObject]) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()

--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -27,7 +27,7 @@ public func containElementSatisfying<S: Sequence, T>(_ predicate: @escaping ((T)
 
 #if _runtime(_ObjC)
     extension NMBObjCMatcher {
-        public class func containElementSatisfyingMatcher(_ predicate: @escaping ((NSObject) -> Bool)) -> NMBObjCMatcher {
+        @objc public class func containElementSatisfyingMatcher(_ predicate: @escaping ((NSObject) -> Bool)) -> NMBObjCMatcher {
             return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
                 let value = try! actualExpression.evaluate()
                 guard let enumeration = value as? NSFastEnumeration else {

--- a/Sources/Nimble/Matchers/EndWith.swift
+++ b/Sources/Nimble/Matchers/EndWith.swift
@@ -56,7 +56,7 @@ public func endWith(_ endingSubstring: String) -> Predicate<String> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func endWithMatcher(_ expected: Any) -> NMBObjCMatcher {
+    @objc public class func endWithMatcher(_ expected: Any) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let actual = try! actualExpression.evaluate()
             if (actual as? String) != nil {

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -25,7 +25,7 @@ public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
 /// Values can support equal by supporting the Equatable protocol.
 ///
 /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T: Equatable, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
+public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
         if expectedValue == nil || actualValue == nil {
@@ -201,17 +201,17 @@ public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func ==<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func !=<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
 }
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func equalMatcher(_ expected: NSObject) -> NMBMatcher {
+    @objc public class func equalMatcher(_ expected: NSObject) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             return try! equal(expected).matches(actualExpression, failureMessage: failureMessage)
         }

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -39,7 +39,7 @@ public func haveCount(_ expectedValue: Int) -> Predicate<NMBCollection> {
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func haveCountMatcher(_ expected: NSNumber) -> NMBObjCMatcher {
+    @objc public class func haveCountMatcher(_ expected: NSNumber) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let location = actualExpression.location
             let actualValue = try! actualExpression.evaluate()

--- a/Sources/Nimble/Matchers/Match.swift
+++ b/Sources/Nimble/Matchers/Match.swift
@@ -19,7 +19,7 @@ public func match(_ expectedValue: String?) -> Predicate<String> {
 #if _runtime(_ObjC)
 
 extension NMBObjCMatcher {
-    public class func matchMatcher(_ expected: NSString) -> NMBMatcher {
+    @objc public class func matchMatcher(_ expected: NSString) -> NMBMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
             let actual = actualExpression.cast { $0 as? String }
             return try! match(expected.description).matches(actual, failureMessage: failureMessage)

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -5,7 +5,7 @@ import Foundation
 #endif
 
 /// Implement this protocol to implement a custom matcher for Swift
-@available(*, deprecated, message: "Use to Predicate instead")
+@available(*, deprecated, message: "Use Predicate instead")
 public protocol Matcher {
     associatedtype ValueType
     func matches(_ actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -36,7 +36,7 @@ internal class NotificationCollector {
 
 private let mainThread = pthread_self()
 
-let notificationCenterDefault = NotificationCenter.default
+public let notificationCenterDefault = NotificationCenter.default
 
 public func postNotifications<T>(
     _ notificationsMatcher: T,

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -36,11 +36,9 @@ internal class NotificationCollector {
 
 private let mainThread = pthread_self()
 
-public let notificationCenterDefault = NotificationCenter.default
-
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = notificationCenterDefault)
+    fromNotificationCenter center: NotificationCenter = .default)
     -> Predicate<Any>
     where T: Matcher, T.ValueType == [Notification]
 {

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -176,7 +176,7 @@ public class NMBObjCRaiseExceptionMatcher: NSObject, NMBMatcher {
 }
 
 extension NMBObjCMatcher {
-    public class func raiseExceptionMatcher() -> NMBObjCRaiseExceptionMatcher {
+    @objc public class func raiseExceptionMatcher() -> NMBObjCRaiseExceptionMatcher {
         return NMBObjCRaiseExceptionMatcher(name: nil, reason: nil, userInfo: nil, block: nil)
     }
 }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -74,7 +74,7 @@ public func || <T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> Predicate<T> 
 
 #if _runtime(_ObjC)
 extension NMBObjCMatcher {
-    public class func satisfyAnyOfMatcher(_ matchers: [NMBMatcher]) -> NMBPredicate {
+    @objc public class func satisfyAnyOfMatcher(_ matchers: [NMBMatcher]) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             if matchers.isEmpty {
                 return NMBPredicateResult(

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -30,12 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define DEFINE_NMB_EXPECT_OVERLOAD(TYPE, EXPR) \
         NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
-        NMBExpectation *NMB_expect(TYPE(^actualBlock)(), NSString *file, NSUInteger line) { \
+        NMBExpectation *NMB_expect(TYPE(^actualBlock)(void), NSString *file, NSUInteger line) { \
             return NMB_expect(^id { return EXPR; }, file, line); \
         }
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
-    NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+NMBExpectation *NMB_expect(id(^actualBlock)(void), NSString *file, NSUInteger line);
 
     // overloaded dispatch for nils - expect(nil)
     DEFINE_NMB_EXPECT_OVERLOAD(void*, nil)
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 
-NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(void), NSString *file, NSUInteger line);
 
 
 

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
     NIMBLE_EXPORT NIMBLE_OVERLOADABLE
-NMBExpectation *NMB_expect(id(^actualBlock)(void), NSString *file, NSUInteger line);
+    NMBExpectation *NMB_expect(id(^actualBlock)(void), NSString *file, NSUInteger line);
 
     // overloaded dispatch for nils - expect(nil)
     DEFINE_NMB_EXPECT_OVERLOAD(void*, nil)

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -4,8 +4,8 @@
 SWIFT_CLASS("_TtC6Nimble7NMBWait")
 @interface NMBWait : NSObject
 
-+ (void)untilTimeout:(NSTimeInterval)timeout file:(NSString *)file line:(NSUInteger)line action:(void(^)())action;
-+ (void)untilFile:(NSString *)file line:(NSUInteger)line action:(void(^)())action;
++ (void)untilTimeout:(NSTimeInterval)timeout file:(NSString *)file line:(NSUInteger)line action:(void (^ _Nonnull)(void (^ _Nonnull)(void)))action;
++ (void)untilFile:(NSString *)file line:(NSUInteger)line action:(void (^ _Nonnull)(void (^ _Nonnull)(void)))action;
 
 @end
 
@@ -13,14 +13,14 @@ SWIFT_CLASS("_TtC6Nimble7NMBWait")
 NS_ASSUME_NONNULL_BEGIN
 
 
-NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBExpectation *__nonnull NMB_expect(id __nullable(^actualBlock)(), NSString *__nonnull file, NSUInteger line) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBExpectation *__nonnull NMB_expect(id __nullable(^actualBlock)(void), NSString *__nonnull file, NSUInteger line) {
     return [[NMBExpectation alloc] initWithActualBlock:actualBlock
                                               negative:NO
                                                   file:file
                                                   line:line];
 }
 
-NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line) {
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(void), NSString *file, NSUInteger line) {
     return NMB_expect(^id{
         actualBlock();
         return nil;
@@ -146,13 +146,13 @@ NIMBLE_EXPORT NMBObjCRaiseExceptionMatcher *NMB_raiseException() {
 }
 
 NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line) {
-    return ^(NSTimeInterval timeout, void (^action)(void (^)(void))) {
+    return ^(NSTimeInterval timeout, void (^ _Nonnull action)(void (^ _Nonnull)(void))) {
         [NMBWait untilTimeout:timeout file:file line:line action:action];
     };
 }
 
 NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line) {
-  return ^(void (^action)(void (^)(void))) {
+  return ^(void (^ _Nonnull action)(void (^ _Nonnull)(void))) {
     [NMBWait untilFile:file line:line action:action];
   };
 }

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.h
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.h
@@ -3,8 +3,8 @@
 
 @interface NMBExceptionCapture : NSObject
 
-- (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)())finally;
-- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)())unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
+- (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)(void))finally;
+- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
 
 @end
 

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.m
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.m
@@ -2,12 +2,12 @@
 
 @interface NMBExceptionCapture ()
 @property (nonatomic, copy) void(^ _Nullable handler)(NSException * _Nullable);
-@property (nonatomic, copy) void(^ _Nullable finally)();
+@property (nonatomic, copy) void(^ _Nullable finally)(void);
 @end
 
 @implementation NMBExceptionCapture
 
-- (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)())finally {
+- (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)(void))finally {
     self = [super init];
     if (self) {
         self.handler = handler;
@@ -16,7 +16,7 @@
     return self;
 }
 
-- (void)tryBlock:(void(^ _Nonnull)())unsafeBlock {
+- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock {
     @try {
         unsafeBlock();
     }

--- a/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -22,7 +22,7 @@ public protocol XCTestCaseNameProvider {
 
 public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
 
-extension XCTestCaseProvider where Self: XCTestCaseProviderStatic {
+extension XCTestCaseProvider {
     var allTestNames: [String] {
         return type(of: self).allTests.map({ name, _ in
             return name


### PR DESCRIPTION
 - What behavior was changed?

Adds @objc specifiers where required since inference of this is now deprecated.

Default values now match the scope where they are used.
Fixed a few new warnings and errors mostly related to Obj-C and blocks definitions.

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:


 - What code was refactored / updated to support this change?

Various files.

 - What issues are related to this PR? Or why was this change introduced?

To support Xcode 9

---

The project fully compiles however Tests are currently broken due to ambiguous method lookups. It seems to be affecting most matchers where the underlying type `T` is a `Sequence`.

I am creating this PR to get help in debugging the underlying issue with the tests as I haven't been able to get them working.

---

**This PR should not be merged until everything is fixed and probably not before Xcode 9 is officially released.**

Note: I think Swift 4 support will be a non-issue once this larger issue is fixed as well.