### PR TITLE
Fix memory leak when using async expectations. Closes #405

### DIFF
--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -105,6 +105,10 @@ internal class AwaitPromise<T> {
         signal = DispatchSemaphore(value: 1)
     }
 
+    deinit {
+        signal.signal()
+    }
+
     /// Resolves the promise with the given result if it has not been resolved. Repeated calls to
     /// this method will resolve in a no-op.
     ///
@@ -252,7 +256,7 @@ internal class AwaitPromiseBuilder<T> {
                 // Stopping the run loop does not work unless we run only 1 mode
                 _ = RunLoop.current.run(mode: .defaultRunLoopMode, before: .distantFuture)
             }
-            self.trigger.timeoutSource.suspend()
+
             self.trigger.timeoutSource.cancel()
             if let asyncSource = self.trigger.actionSource {
                 asyncSource.cancel()

--- a/Tests/NimbleTests/AsynchronousTest.swift
+++ b/Tests/NimbleTests/AsynchronousTest.swift
@@ -18,6 +18,7 @@ final class AsyncTest: XCTestCase, XCTestCaseProvider {
             ("testWaitUntilErrorsIfDoneIsCalledMultipleTimes", testWaitUntilErrorsIfDoneIsCalledMultipleTimes),
             ("testWaitUntilMustBeInMainThread", testWaitUntilMustBeInMainThread),
             ("testToEventuallyMustBeInMainThread", testToEventuallyMustBeInMainThread),
+            ("testSubjectUnderTestIsReleasedFromMemory", testSubjectUnderTestIsReleasedFromMemory),
         ]
     }
 
@@ -217,4 +218,28 @@ final class AsyncTest: XCTestCase, XCTestCaseProvider {
         expect(executedAsyncBlock).toEventually(beTruthy())
 #endif
     }
+
+    func testSubjectUnderTestIsReleasedFromMemory() {
+        final class ClassUnderTest {
+            var deinitCalled: (() -> Void)?
+            var count = 0
+            deinit { deinitCalled?() }
+        }
+
+        var subject: ClassUnderTest? = ClassUnderTest()
+
+        if let sub = subject {
+            expect(sub.count).toEventually(equal(0), timeout: 0.1)
+            expect(sub.count).toEventuallyNot(equal(1), timeout: 0.1)
+        }
+
+        waitUntil(timeout: 0.5) { done in
+            subject?.deinitCalled = {
+                done()
+            }
+
+            deferToMainQueue { subject = nil }
+        }
+    }
+
 }


### PR DESCRIPTION
 - What behavior was changed?
 - What code was refactored / updated to support this change?
 - What issues are related to this PR? Or why was this change introduced?
    - This fixes issue #405 , a memory leak when using async expectations

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

