### PR TITLE
[gardening] Remove redundant OS checks

### DIFF
--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 
 fileprivate func from(objcPredicate: NMBPredicate) -> Predicate<NSObject> {
     return Predicate { actualExpression in

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // This matcher requires the Objective-C, and being built by Xcode rather than the Swift Package Manager 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 
 /// A Nimble matcher that succeeds when the actual expression raises an
 /// exception with the specified name, reason, and/or userInfo.

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public func throwAssertion() -> Predicate<Void> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-    #if arch(x86_64) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+    #if arch(x86_64) && !SWIFT_PACKAGE
         failureMessage.postfixMessage = "throw an assertion"
         failureMessage.actualValue = nil
 

--- a/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Nimble
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 
 final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (RaisesExceptionTest) -> () throws -> Void)] {

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import XCTest
 import Nimble
 
-#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
 
 final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ThrowAssertionTest) -> () throws -> Void)] {


### PR DESCRIPTION
`#if !SWIFT_PACKAGE` should be sufficient for those cases.

Same as https://github.com/Quick/Quick/pull/728. Just a minor refactoring.