### PR TITLE
Make PredicateResult members public for use in custom matchers

### DIFF
--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -82,7 +82,7 @@ extension Predicate {
     }
 }
 
-// Question: Should this be exposed? It's safer to not for now and decide later.
+// The Expectation style intended for comparison to a PredicateStatus.
 public enum ExpectationStyle {
     case toMatch, toNotMatch
 }

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -83,7 +83,7 @@ extension Predicate {
 }
 
 // Question: Should this be exposed? It's safer to not for now and decide later.
-internal enum ExpectationStyle {
+public enum ExpectationStyle {
     case toMatch, toNotMatch
 }
 
@@ -108,7 +108,7 @@ public struct PredicateResult {
     }
 
     /// Converts the result to a boolean based on what the expectation intended
-    internal func toBoolean(expectation style: ExpectationStyle) -> Bool {
+    public func toBoolean(expectation style: ExpectationStyle) -> Bool {
         return status.toBoolean(expectation: style)
     }
 }

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -91,9 +91,9 @@ internal enum ExpectationStyle {
 /// predicate.
 public struct PredicateResult {
     /// Status indicates if the predicate matches, does not match, or fails.
-    var status: PredicateStatus
+    public var status: PredicateStatus
     /// The error message that can be displayed if it does not match
-    var message: ExpectationMessage
+    public var message: ExpectationMessage
 
     /// Constructs a new PredicateResult with a given status and error message
     public init(status: PredicateStatus, message: ExpectationMessage) {


### PR DESCRIPTION
Making details of `PredicateResult` accessible when implementing custom matchers that themselves host another matcher(s) can be very useful in fact essential for escalating failures when these hosted `Predicate`(s) themselves fail (and do not match). 

Example: I was implementing `Predicate` style matchers to [Guanaco](https://github.com/modocache/Guanaco). When matching detailed `Result` type and error inside these matchers, `PredicateResult`'s members can be used for better info about a predicate result, decision making and providing more informed expectation failure message. Please check [this](https://github.com/ishaanSejwal/Guanaco/blob/bf4c37f54489d83d8f154e6ebe215a173be0b38c/Sources/HaveSucceeded.swift#L109) and [this](https://github.com/ishaanSejwal/Guanaco/blob/bf4c37f54489d83d8f154e6ebe215a173be0b38c/Sources/BeAnError.swift#L37) lines in my fork of Guanaco for more information about my implementation that uses `PredicateResult`'s members.

I have also added some documentation to `ExpectationStyle` which I thought was appropriate for someone who would want to use it with `PredicateResult`'s `func toBoolean(expectation style: ExpectationStyle) -> Bool`  (Since this is the only way `ExpectationStyle` can be used externally). More info can be added that explicitly mentions that `ExpectationStyle` is used when making custom matchers to make things clear.
 - What behavior was changed?
`status`, `message` variables and `func toBoolean(expectation style: ExpectationStyle) -> Bool` of `PredicateResult` were made public. `ExpectationStyle` was changed from `internal` to `public`.

 - What code was refactored / updated to support this change?
Access levels of above mentioned entities

 - What issues are related to this PR? Or why was this change introduced?
None as I see. Just that `ExpectationStyle` will be exposed to users who are only interested in using nimble and not making custom matchers.

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?
