### PR TITLE
Fix async Swift docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,11 +398,10 @@ waitUntil(^(void (^done)(void)){
 // Swift
 
 waitUntil(timeout: 10) { done in
-    doSomethingAsync { success in
+    ocean.goFish { success in
         expect(success).to(beTrue())
         done()
     }
-    done()
 }
 ```
 


### PR DESCRIPTION
Just use the same example from above. The timeout example (a) used a method that wasn't used anywhere else and (b) called `done()` at the wrong time. This clears it up and harmonizes the async examples!