### PR TITLE
[gardening] Move operators into types where possible

### DIFF
--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -98,20 +98,24 @@ public func beCloseTo(_ expectedValues: [Double], within delta: Double = Default
 
 infix operator ≈ : ComparisonPrecedence
 
-public func ≈(lhs: Expectation<[Double]>, rhs: [Double]) {
-    lhs.to(beCloseTo(rhs))
+extension Expectation where T == [Double] {
+    public static func ≈ (lhs: Expectation, rhs: [Double]) {
+        lhs.to(beCloseTo(rhs))
+    }
 }
 
-public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: NMBDoubleConvertible) {
-    lhs.to(beCloseTo(rhs))
-}
+extension Expectation where T == NMBDoubleConvertible {
+    public static func ≈ (lhs: Expectation, rhs: NMBDoubleConvertible) {
+        lhs.to(beCloseTo(rhs))
+    }
 
-public func ≈(lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
-    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
-}
+    public static func ≈ (lhs: Expectation, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
+        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+    }
 
-public func == (lhs: Expectation<NMBDoubleConvertible>, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
-    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+    public static func == (lhs: Expectation, rhs: (expected: NMBDoubleConvertible, delta: Double)) {
+        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+    }
 }
 
 // make this higher precedence than exponents so the Doubles either end aren't pulled in

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -19,11 +19,14 @@ public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
     }.requireNonNil
 }
 
-public func === (lhs: Expectation<Any>, rhs: Any?) {
-    lhs.to(beIdenticalTo(rhs))
-}
-public func !== (lhs: Expectation<Any>, rhs: Any?) {
-    lhs.toNot(beIdenticalTo(rhs))
+extension Expectation where T == Any {
+    public static func === (lhs: Expectation, rhs: Any?) {
+        lhs.to(beIdenticalTo(rhs))
+    }
+
+    public static func !== (lhs: Expectation, rhs: Any?) {
+        lhs.toNot(beIdenticalTo(rhs))
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual value is the same instance

--- a/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Sources/Nimble/Matchers/BeVoid.swift
@@ -9,10 +9,12 @@ public func beVoid() -> Predicate<()> {
     }
 }
 
-public func == (lhs: Expectation<()>, rhs: ()) {
-    lhs.to(beVoid())
-}
+extension Expectation where T == () {
+    public static func == (lhs: Expectation, rhs: ()) {
+        lhs.to(beVoid())
+    }
 
-public func != (lhs: Expectation<()>, rhs: ()) {
-    lhs.toNot(beVoid())
+    public static func != (lhs: Expectation, rhs: ()) {
+        lhs.toNot(beVoid())
+    }
 }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -169,12 +169,14 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
     }
 }
 
-public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
-    lhs.to(equal(rhs))
-}
+extension Expectation where T: Equatable {
+    public static func == (lhs: Expectation, rhs: T?) {
+        lhs.to(equal(rhs))
+    }
 
-public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
-    lhs.toNot(equal(rhs))
+    public static func != (lhs: Expectation, rhs: T?) {
+        lhs.toNot(equal(rhs))
+    }
 }
 
 public func ==<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {


### PR DESCRIPTION
This requires Xcode 8.3 (Swift 3.1) at least to build Nimble (Concrete same-type requirements in the generics). So this would be a breaking change to Swift 3.0 users and may not be worth to do (but I'm not sure if the current `master` success to compile with Swift 3.0).

Any thoughts?