### PR TITLE
Yet another introduction of Protocol extension-based matchers

### DIFF
--- a/Sources/Nimble/ExtensibleExpecation.swift
+++ b/Sources/Nimble/ExtensibleExpecation.swift
@@ -17,30 +17,30 @@ import Foundation
 ///
 /// With this approach we can have more readable matcher syntax like `expect(1).to.equal(1)` instead of `expect(1).to(equal(1))`
 public struct ExtensibleExpecation<Type> {
-    public typealias T = Type
-    private let base: Expectation<T>
+    private let base: Expectation<Type>
     private let style: ExpectationStyle
-    
+
     private let isAsync: Bool
     private let timeout: TimeInterval
     private let pollInterval: TimeInterval
-    init(base: Expectation<T>, style: ExpectationStyle,
+    init(base: Expectation<Type>, style: ExpectationStyle,
          isAsync: Bool = false,
          timeout: TimeInterval = AsyncDefaults.Timeout, pollInterval: TimeInterval = AsyncDefaults.PollInterval
         ) {
         self.base = base
         self.style = style
-        
+
         self.isAsync = isAsync
         self.timeout = timeout
         self.pollInterval = pollInterval
     }
-    
-    public func match(description: String? = nil, _ predicateFactory: @escaping () -> Predicate<T>) {
+
+    public func match(description: String? = nil, _ predicateFactory: @escaping () -> Predicate<Type>) {
         if isAsync {
-            nimblePrecondition(base.expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+            nimblePrecondition(base.expression.isClosure, "NimbleInternalError",
+                               toEventuallyRequiresClosureError.stringValue)
         }
-        
+
         let to = style == .toMatch ? "to" : "to not"
         let predicate = isAsync ?
             predicateFactory() :
@@ -49,7 +49,7 @@ public struct ExtensibleExpecation<Type> {
                   timeout: timeout,
                   poll: pollInterval,
                   fnName: style == .toMatch ? "toEventually" : "toEventuallyNot")
-        
+
         let (pass, msg) = execute(base.expression,
                                   style,
                                   predicate,
@@ -59,18 +59,18 @@ public struct ExtensibleExpecation<Type> {
     }
 }
 
-//MARK: Expectation extensions
+// MARK: Expectation extensions
 extension Expectation {
     /// Expectation extension to test the actual value using a matcher to match.
     public var to: ExtensibleExpecation<T> {
         return ExtensibleExpecation(base: self, style: .toMatch)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match
     public var notTo: ExtensibleExpecation<T> {
         return ExtensibleExpecation(base: self, style: .toNotMatch)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match
     ///
     /// Alias to `notTo`.
@@ -79,7 +79,7 @@ extension Expectation {
     }
 }
 
-//MARK: Async Expectation Extensions
+// MARK: Async Expectation Extensions
 extension Expectation {
     /// Expectation extension to test the actual value using a matcher to match by checking continously at default poll interval until the default timeout is reached.
     public var toEventually: ExtensibleExpecation<T> {
@@ -87,31 +87,37 @@ extension Expectation {
                                     style: .toMatch,
                                     isAsync: true)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match by checking continously at default poll interval until the default timeout is reached.
     public var toEventuallyNot: ExtensibleExpecation<T> {
         return ExtensibleExpecation(base: self,
                                     style: .toNotMatch,
                                     isAsync: true)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match by checking continously at default poll interval until the default timeout is reached.
     ///
     /// Alias to `toEventuallyNot`
     public var toNotEventually: ExtensibleExpecation<T> {
         return toEventuallyNot
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to match by checking continously at pollInterval until the timeout is reached.
     public func toEventually(timeout: TimeInterval, pollInterval: TimeInterval) -> ExtensibleExpecation<T> {
-        return ExtensibleExpecation(base: self, style: .toMatch, isAsync: true, timeout: timeout, pollInterval: pollInterval)
+        return ExtensibleExpecation(base: self,
+                                    style: .toMatch,
+                                    isAsync: true,
+                                    timeout: timeout, pollInterval: pollInterval)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match by checking continously at pollInterval until the timeout is reached.
     public func toEventuallyNot(timeout: TimeInterval, pollInterval: TimeInterval) -> ExtensibleExpecation<T> {
-        return ExtensibleExpecation(base: self, style: .toNotMatch, isAsync: true, timeout: timeout, pollInterval: pollInterval)
+        return ExtensibleExpecation(base: self,
+                                    style: .toNotMatch,
+                                    isAsync: true,
+                                    timeout: timeout, pollInterval: pollInterval)
     }
-    
+
     /// Expectation extension to test the actual value using a matcher to not match by checking continously at pollInterval until the timeout is reached.
     ///
     /// Alias to `toEventuallyNot()`

--- a/Sources/Nimble/ExtinsibleExpecation.swift
+++ b/Sources/Nimble/ExtinsibleExpecation.swift
@@ -19,15 +19,18 @@ import Foundation
 public struct ExtensibleExpecation<Type> {
     public typealias T = Type
     private let base: Expectation<T>
-    init(_ base: Expectation<T>) {
+    private let style: ExpectationStyle
+    init(base: Expectation<T>, style: ExpectationStyle) {
         self.base = base
+        self.style = style
     }
 
     public func match(description: String? = nil, _ predicateFactory: @escaping () -> Predicate<T>) {
+        let to = style == .toMatch ? "to" : "to not"
         let (pass, msg) = execute(base.expression,
-                                  .toMatch,
+                                  style,
                                   predicateFactory(),
-                                  to: "to",
+                                  to: to,
                                   description: description)
         base.verify(pass, msg)
     }
@@ -37,6 +40,16 @@ public struct ExtensibleExpecation<Type> {
 extension Expectation {
     /// Expectation extension to test the actual value using a matcher to match.
     public var to: ExtensibleExpecation<T> {
-        return ExtensibleExpecation(self)
+        return ExtensibleExpecation(base: self, style: .toMatch)
+    }
+    /// Expectation extension to test the actual value using a matcher to not match
+    public var notTo: ExtensibleExpecation<T> {
+        return ExtensibleExpecation(base: self, style: .toNotMatch)
+    }
+    /// Expectation extension to test the actual value using a matcher to not match
+    ///
+    /// Alias to `notTo`.
+    public var toNot: ExtensibleExpecation<T> {
+        return notTo
     }
 }

--- a/Sources/Nimble/ExtinsibleExpecation.swift
+++ b/Sources/Nimble/ExtinsibleExpecation.swift
@@ -20,16 +20,34 @@ public struct ExtensibleExpecation<Type> {
     public typealias T = Type
     private let base: Expectation<T>
     private let style: ExpectationStyle
-    init(base: Expectation<T>, style: ExpectationStyle) {
+    
+    private let isAsync: Bool
+    init(base: Expectation<T>, style: ExpectationStyle,
+         isAsync: Bool = false
+        ) {
         self.base = base
         self.style = style
+        
+        self.isAsync = isAsync
     }
-
+    
     public func match(description: String? = nil, _ predicateFactory: @escaping () -> Predicate<T>) {
+        if isAsync {
+            nimblePrecondition(base.expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+        }
+        
         let to = style == .toMatch ? "to" : "to not"
+        let predicate = isAsync ?
+            predicateFactory() :
+            async(style: style,
+                  predicate: predicateFactory(),
+                  timeout: AsyncDefaults.Timeout,
+                  poll: AsyncDefaults.PollInterval,
+                  fnName: style == .toMatch ? "toEventually" : "toEventuallyNot")
+        
         let (pass, msg) = execute(base.expression,
                                   style,
-                                  predicateFactory(),
+                                  predicate,
                                   to: to,
                                   description: description)
         base.verify(pass, msg)
@@ -42,14 +60,41 @@ extension Expectation {
     public var to: ExtensibleExpecation<T> {
         return ExtensibleExpecation(base: self, style: .toMatch)
     }
+    
     /// Expectation extension to test the actual value using a matcher to not match
     public var notTo: ExtensibleExpecation<T> {
         return ExtensibleExpecation(base: self, style: .toNotMatch)
     }
+    
     /// Expectation extension to test the actual value using a matcher to not match
     ///
     /// Alias to `notTo`.
     public var toNot: ExtensibleExpecation<T> {
         return notTo
+    }
+}
+
+//MARK: Async Expectation Extensions
+extension Expectation {
+    
+    /// Expectation extension to test the actual value using a matcher to match by checking continously at default poll interval until the default timeout is reached.
+    public var toEventually: ExtensibleExpecation<T> {
+        return ExtensibleExpecation(base: self,
+                                    style: .toMatch,
+                                    isAsync: true)
+    }
+    
+    /// Expectation extension to test the actual value using a matcher to not match by checking continously at default poll interval until the default timeout is reached.
+    public var toEventuallyNot: ExtensibleExpecation<T> {
+        return ExtensibleExpecation(base: self,
+                                    style: .toNotMatch,
+                                    isAsync: true)
+    }
+    
+    /// Expectation extension to test the actual value using a matcher to not match by checking continously at default poll interval until the default timeout is reached.
+    ///
+    /// Alias to `toEventuallyNot`
+    public var toNotEventually: ExtensibleExpecation<T> {
+        return toEventuallyNot
     }
 }

--- a/Sources/Nimble/ExtinsibleExpecation.swift
+++ b/Sources/Nimble/ExtinsibleExpecation.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A proxt type to allow protocol extension-based matchers
+///
+/// Use `ExtensibleExpectation` proxy as follows:
+///
+/// // 1. Extend ExtensibleExpectation with constrain on Type
+/// // Read as: ExtensibleExpectation Extension where Type is a SomeType
+/// extension ExtensibleExpectation where Type: SomeType {
+/// // 2. Define any type specific matchers
+///     func equal(_ expectedValue: Type) {
+///         match {actualExpression -> Predicate<Type> in
+///             // Build a predicate
+///         }
+///     }
+/// }
+///
+/// With this approach we can have more readable matcher syntax like `expect(1).to.equal(1)` instead of `expect(1).to(equal(1))`
+public struct ExtensibleExpecation<Type> {
+    public typealias T = Type
+    private let base: Expectation<T>
+    init(_ base: Expectation<T>) {
+        self.base = base
+    }
+
+    public func match(description: String? = nil, _ predicateFactory: @escaping () -> Predicate<T>) {
+        let (pass, msg) = execute(base.expression,
+                                  .toMatch,
+                                  predicateFactory(),
+                                  to: "to",
+                                  description: description)
+        base.verify(pass, msg)
+    }
+}
+
+//MARK: Expectation extensions
+extension Expectation {
+    /// Expectation extension to test the actual value using a matcher to match.
+    public var to: ExtensibleExpecation<T> {
+        return ExtensibleExpecation(self)
+    }
+}

--- a/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
+++ b/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
@@ -7,7 +7,7 @@ public struct AsyncDefaults {
     public static var PollInterval: TimeInterval = 0.01
 }
 
-private func async<T>(style: ExpectationStyle, predicate: Predicate<T>, timeout: TimeInterval, poll: TimeInterval, fnName: String) -> Predicate<T> {
+internal func async<T>(style: ExpectationStyle, predicate: Predicate<T>, timeout: TimeInterval, poll: TimeInterval, fnName: String) -> Predicate<T> {
     return Predicate { actualExpression in
         let uncachedExpression = actualExpression.withoutCaching()
         let fnName = "expect(...).\(fnName)(...)"
@@ -106,7 +106,7 @@ internal struct AsyncMatcherWrapper<T, U>: Matcher
     }
 }
 
-private let toEventuallyRequiresClosureError = FailureMessage(
+internal let toEventuallyRequiresClosureError = FailureMessage(
     // swiftlint:disable:next line_length
     stringValue: "expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )\nSwift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function"
 )


### PR DESCRIPTION
This PR is another attempt for #217, which is much less ambitious compared to #218 

This PR introduces protocol extension-based matchers for `Expectation`. It only provides an infrastructure for the technique and would allow users to write their own custom matchers using it. Nimble matchers can be gradually migrated on later pull requests.

It allows the following code;
```
class NimblePlaygroundTests: XCTestCase {
    
    func testExample() {
        expect(1).to.equal(1)
        expect(1).notTo.equal(2)
        expect(1).toNot.equal(2)
        expect(1).toEventually.equal(1)
        expect(1).toNotEventually.equal(2)
        expect(1).toNotEventually.equal(2)
    }
}

extension ExtensibleExpecation where Type: Equatable {
    func equal(_ expectedValue: Type) {
        match {
            Predicate {actualExpression in
                let actualValue = try actualExpression.evaluate()
                return PredicateResult(
                    bool: actualValue == expectedValue,
                    message: .expectedCustomValueTo(
                        "equal \(stringify(expectedValue))",
                        stringify(actualValue)))
            }
        }
    }
}
```

### Future Work:
- Add test cases
- Update readme
- Migrate Nimble matchers to protocol extensions
- Migrate Predicate helpers to `ExtensibleExpectation`
- Better name for `ExtensibleExpectation`  ¯\_(ツ)_/¯