### PR TITLE
Can Chain assertions

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -108,22 +108,27 @@ public struct Expectation<T> {
     ////////////////// NEW API /////////////////////
 
     /// Tests the actual value using a matcher to match.
-    public func to(_ predicate: Predicate<T>, description: String? = nil) {
+    @discardableResult
+    public func to(_ predicate: Predicate<T>, description: String? = nil) -> Expectation {
         let (pass, msg) = execute(expression, .toMatch, predicate, to: "to", description: description)
         verify(pass, msg)
+        return self
     }
 
     /// Tests the actual value using a matcher to not match.
-    public func toNot(_ predicate: Predicate<T>, description: String? = nil) {
+    @discardableResult
+    public func toNot(_ predicate: Predicate<T>, description: String? = nil) -> Expectation {
         let (pass, msg) = execute(expression, .toNotMatch, predicate, to: "to not", description: description)
         verify(pass, msg)
+        return self
     }
 
     /// Tests the actual value using a matcher to not match.
     ///
     /// Alias to toNot().
-    public func notTo(_ predicate: Predicate<T>, description: String? = nil) {
-        toNot(predicate, description: description)
+    @discardableResult
+    public func notTo(_ predicate: Predicate<T>, description: String? = nil) -> Expectation {
+        return toNot(predicate, description: description)
     }
 
     // see:

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public func throwAssertion() -> Predicate<Void> {
+public func throwAssertion<T>() -> Predicate<T> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
     #if arch(x86_64) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
         failureMessage.postfixMessage = "throw an assertion"

--- a/Sources/Nimble/Matchers/ThrowError.swift
+++ b/Sources/Nimble/Matchers/ThrowError.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func throwError() -> Predicate<Any> {
+public func throwError<T>() -> Predicate<T> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?
@@ -42,7 +42,7 @@ public func throwError() -> Predicate<Any> {
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func throwError<T: Error>(_ error: T, closure: ((Error) -> Void)? = nil) -> Predicate<Any> {
+public func throwError<T: Error, U>(_ error: T, closure: ((Error) -> Void)? = nil) -> Predicate<U> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?
@@ -87,7 +87,7 @@ public func throwError<T: Error>(_ error: T, closure: ((Error) -> Void)? = nil) 
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func throwError<T: Error & Equatable>(_ error: T, closure: ((T) -> Void)? = nil) -> Predicate<Any> {
+public func throwError<T: Error & Equatable, U>(_ error: T, closure: ((T) -> Void)? = nil) -> Predicate<U> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?
@@ -133,9 +133,9 @@ public func throwError<T: Error & Equatable>(_ error: T, closure: ((T) -> Void)?
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func throwError<T: Error>(
+public func throwError<T: Error, U>(
     errorType: T.Type,
-    closure: ((T) -> Void)? = nil) -> Predicate<Any> {
+    closure: ((T) -> Void)? = nil) -> Predicate<U> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?
@@ -194,7 +194,7 @@ public func throwError<T: Error>(
 /// values of the existential type `Error` in the closure.
 ///
 /// The closure only gets called when an error was thrown.
-public func throwError(closure: @escaping ((Error) -> Void)) -> Predicate<Any> {
+public func throwError<T>(closure: @escaping ((Error) -> Void)) -> Predicate<T> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?
@@ -229,7 +229,7 @@ public func throwError(closure: @escaping ((Error) -> Void)) -> Predicate<Any> {
 /// values of the existential type `Error` in the closure.
 ///
 /// The closure only gets called when an error was thrown.
-public func throwError<T: Error>(closure: @escaping ((T) -> Void)) -> Predicate<Any> {
+public func throwError<T: Error, U>(closure: @escaping ((T) -> Void)) -> Predicate<U> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
 
         var actualError: Error?

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -13,6 +13,7 @@ final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
             ("testNegativeMatch", testNegativeMatch),
             ("testPositiveMessage", testPositiveMessage),
             ("testNegativeMessage", testNegativeMessage),
+            ("testChainOnThrowAssertion", testChainOnThrowAssertion),
         ]
     }
 
@@ -56,6 +57,10 @@ final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to not throw an assertion") {
             expect { () -> Void in fatalError() }.toNot(throwAssertion())
         }
+    }
+    
+    func testChainOnThrowAssertion() {
+        expect { () -> Int in return 5 }.toNot(throwAssertion()).to(equal(5))
     }
 }
 

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -58,7 +58,7 @@ final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
             expect { () -> Void in fatalError() }.toNot(throwAssertion())
         }
     }
-    
+
     func testChainOnThrowAssertion() {
         expect { () -> Int in return 5 }.toNot(throwAssertion()).to(equal(5))
     }

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -153,7 +153,7 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
             expect { throw NimbleError.laugh }.to(throwError(NimbleError.laugh, closure: closure))
         }
     }
-    
+
     func testChainOnThrowError() {
         let closure = { () throws -> Int in
             return 5

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -136,7 +136,7 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
     func testNegativeMatchesWithClosure() {
         let moduleName = "NimbleTests"
         let innerFailureMessage = "expected to equal <foo>, got <\(moduleName).NimbleError>"
-        let closure = { (error: Error) in
+        let closure = { (error: Error) -> Void in
             expect(error._domain).to(equal("foo"))
         }
 

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -41,6 +41,7 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
             ("testNegativeNegatedMatches", testNegativeNegatedMatches),
             ("testNegativeMatchesDoNotCallClosureWithoutError", testNegativeMatchesDoNotCallClosureWithoutError),
             ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+            ("testChainOnThrowError", testChainOnThrowError),
         ]
     }
 
@@ -151,5 +152,13 @@ final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage([innerFailureMessage, "expected to throw error <laugh> that satisfies block, got <laugh>"]) {
             expect { throw NimbleError.laugh }.to(throwError(NimbleError.laugh, closure: closure))
         }
+    }
+    
+    func testChainOnThrowError() {
+        let closure = { () throws -> Int in
+            return 5
+        }
+
+        expect(try closure()).toNot(throwError()).to(equal(5))
     }
 }

--- a/Tests/NimbleTests/SynchronousTests.swift
+++ b/Tests/NimbleTests/SynchronousTests.swift
@@ -19,7 +19,7 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
             ("testToNotNegativeMatches", testToNotNegativeMatches),
             ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
             ("testChainExpectation", testChainExpectation),
-            ("testChainFailOnFirstError", testChainFailOnFirstError)
+            ("testChainFailOnFirstError", testChainFailOnFirstError),
         ]
     }
 
@@ -127,7 +127,7 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
     func testNotToMatchesLikeToNot() {
         expect(1).notTo(MatcherFunc { _, _ in false })
     }
-    
+
     func testChainExpectation() {
         expect(2).toNot(equal(1)).to(equal(2)).notTo(equal(3))
     }

--- a/Tests/NimbleTests/SynchronousTests.swift
+++ b/Tests/NimbleTests/SynchronousTests.swift
@@ -18,6 +18,8 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
             ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
             ("testToNotNegativeMatches", testToNotNegativeMatches),
             ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
+            ("testChainExpectation", testChainExpectation),
+            ("testChainFailOnFirstError", testChainFailOnFirstError)
         ]
     }
 
@@ -125,4 +127,15 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
     func testNotToMatchesLikeToNot() {
         expect(1).notTo(MatcherFunc { _, _ in false })
     }
+    
+    func testChainExpectation() {
+        expect(2).toNot(equal(1)).to(equal(2)).notTo(equal(3))
+    }
+
+    func testChainFailOnFirstError() {
+        failsWithErrorMessage("expected to not equal <2>, got <2>") {
+            expect(2).toNot(equal(1)).toNot(equal(2)).to(equal(3))
+        }
+    }
+
 }


### PR DESCRIPTION
related to #369 
The goal is to be able to chain assertions, for example:

```swift
expect(2).toNot(equal(1)).to(equal(2)).notTo(equal(3))
expect(["a", "b"]).to(haveCount(2)).to(contain("a"))
expect { () -> Int in return 5 }.toNot(throwError()).to(equal(5))
```