### PR TITLE
Make PredicateStatus status and message properties public

### DIFF
--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -91,9 +91,9 @@ internal enum ExpectationStyle {
 /// predicate.
 public struct PredicateResult {
     /// Status indicates if the predicate matches, does not match, or fails.
-    var status: PredicateStatus
+    public var status: PredicateStatus
     /// The error message that can be displayed if it does not match
-    var message: ExpectationMessage
+    public var message: ExpectationMessage
 
     /// Constructs a new PredicateResult with a given status and error message
     public init(status: PredicateStatus, message: ExpectationMessage) {


### PR DESCRIPTION
This PR makes `PredicateResult.status` and `PredicateResult.message` properties `public`.

Access to these properties outside Nimble module is especially useful when creating and composing predicates. For example the following is not possible with those properties being `internal`:

```swift
func useOtherPredicate<T>(_ other: Predicate<T>) -> Predicate<T> {
    return .define { expression in
        let result = other.satisfies(expression)
        return .init(status: result.status, message: result.message.prepended(message: "foo "))
    }
}
```

Of course the above trivial example does not make sense, but you can imagine a real-life use cases where one predicate would be composed out of different predicates and custom matching code to create one coherent `PredicateResult`.

Making these properties accessible from the outside world does not expose Nimble to any risks (including shared state modifications, as `PredicateResult` is a value type).

This change is additive and it does not break public API.

_P.S. 500! :tada:_