### PR TITLE
Provide fallback messages to prevent crashes when main run loop is busy

### DIFF
--- a/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
+++ b/Sources/Nimble/Matchers/AsyncMatcherWrapper.swift
@@ -23,14 +23,18 @@ private func async<T>(style: ExpectationStyle, predicate: Predicate<T>, timeout:
         }
         switch result {
         case .completed: return lastPredicateResult!
-        case .timedOut: return PredicateResult(status: .fail, message: lastPredicateResult!.message)
+        case .timedOut:
+            let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
+            return PredicateResult(status: .fail, message: message)
         case let .errorThrown(error):
             return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
         case let .raisedException(exception):
             return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
         case .blockedRunLoop:
             // swiftlint:disable:next line_length
-            return PredicateResult(status: .fail, message: lastPredicateResult!.message.appended(message: " (timed out, but main thread was unresponsive)."))
+            let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
+                .fail("main run loop was unresponsive")
+            return PredicateResult(status: .fail, message: message)
         case .incomplete:
             internalError("Reached .incomplete state for toEventually(...).")
         }


### PR DESCRIPTION
When running our somewhat large (4500 specs) test suite, it is not uncommon to encounter both of the `.timedOut` and `.blockedRunLoop` cases in the `async` function used by `toEventually[Not]`. This is previously reported in #475.

If one of those cases is encountered before the block passed to `pollBlock` gets a chance to execute, `lastPredicateResult` will not be set, and will trap when it's unwrapped.

This PR uses optional chaining and defaults to provide a sane message and not crash when these scenarios pop up.

I'm interested to hear of others' opinions on how this could be tested; I tried briefly to add some tests but couldn't find an easy way to block the run loop and trigger these.

 - [ ] Does this have tests?

