### PR TITLE
Swift 4.1: Adopt LinuxMain generation feature by `swift test --generate-linuxmain`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,8 @@ included:
 
 excluded:
   - Carthage/Checkouts
+  - Tests/NimbleTests/XCTestManifests.swift
+  - Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
 
 trailing_comma:
   mandatory_comma: true

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 		AE7ADE491C80C00D00B94CD3 /* MatchErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7ADE481C80C00D00B94CD3 /* MatchErrorTest.swift */; };
 		AE7ADE4A1C80C00D00B94CD3 /* MatchErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7ADE481C80C00D00B94CD3 /* MatchErrorTest.swift */; };
 		AE7ADE4B1C80C00D00B94CD3 /* MatchErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7ADE481C80C00D00B94CD3 /* MatchErrorTest.swift */; };
+		CD037213207DCC580047AF28 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD037212207DCC580047AF28 /* XCTestManifests.swift */; };
 		CD79C99E1D2CC832004B6F9A /* ObjCAsyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56651A3B305F009E1637 /* ObjCAsyncTest.m */; };
 		CD79C99F1D2CC835004B6F9A /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		CD79C9A01D2CC839004B6F9A /* ObjCBeAnInstanceOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56691A3B3108009E1637 /* ObjCBeAnInstanceOfTest.m */; };
@@ -612,6 +613,7 @@
 		AE4BA9AC1C88DDB500B73906 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		AE7ADE441C80BF8000B94CD3 /* MatchError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatchError.swift; sourceTree = "<group>"; };
 		AE7ADE481C80C00D00B94CD3 /* MatchErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatchErrorTest.swift; sourceTree = "<group>"; };
+		CD037212207DCC580047AF28 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		CDFB6A1E1F7E07C600AD8CC7 /* CwlCatchException.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlCatchException.swift; sourceTree = "<group>"; };
 		CDFB6A201F7E07C600AD8CC7 /* CwlCatchException.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CwlCatchException.m; sourceTree = "<group>"; };
 		CDFB6A221F7E07C600AD8CC7 /* CwlCatchException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CwlCatchException.h; sourceTree = "<group>"; };
@@ -773,6 +775,7 @@
 				1F0648D31963AAB2001F9C46 /* SynchronousTests.swift */,
 				965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */,
 				6CAEDD091CAEA86F003F1584 /* LinuxSupport.swift */,
+				CD037212207DCC580047AF28 /* XCTestManifests.swift */,
 				1FFD729A1963FC8200CD29A2 /* objc */,
 				1F14FB61194180A7009F2A08 /* Helpers */,
 				1F925EE3195C11B000ED456B /* Matchers */,
@@ -1678,6 +1681,7 @@
 				DDB4D5F119FE442800E9D9FE /* MatchTest.swift in Sources */,
 				1F4A56741A3B3210009E1637 /* ObjCBeginWithTest.m in Sources */,
 				1F4A56831A3B336F009E1637 /* ObjCBeLessThanOrEqualToTest.m in Sources */,
+				CD037213207DCC580047AF28 /* XCTestManifests.swift in Sources */,
 				7B13BA0D1DD361DE00C9098C /* ContainElementSatisfyingTest.swift in Sources */,
 				1F925F03195C189500ED456B /* ContainTest.swift in Sources */,
 				A8A3B6FD2073644700E25A08 /* ObjcStringersTest.m in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,37 +1,8 @@
 import XCTest
-@testable import NimbleTests
 
-// This is the entry point for NimbleTests on Linux
+import NimbleTests
 
-XCTMain([
-    testCase(AsyncTest.allTests),
-    testCase(SynchronousTest.allTests),
-    testCase(UserDescriptionTest.allTests),
+var tests = [XCTestCaseEntry]()
+tests += NimbleTests.__allTests()
 
-    // Matchers
-    testCase(AllPassTest.allTests),
-    testCase(BeAKindOfSwiftTest.allTests),
-    testCase(BeAnInstanceOfTest.allTests),
-    testCase(BeCloseToTest.allTests),
-    testCase(BeginWithTest.allTests),
-    testCase(BeGreaterThanOrEqualToTest.allTests),
-    testCase(BeGreaterThanTest.allTests),
-    testCase(BeIdenticalToObjectTest.allTests),
-    testCase(BeIdenticalToTest.allTests),
-    testCase(BeLessThanOrEqualToTest.allTests),
-    testCase(BeLessThanTest.allTests),
-    testCase(BeTruthyTest.allTests),
-    testCase(BeTrueTest.allTests),
-    testCase(BeFalsyTest.allTests),
-    testCase(BeFalseTest.allTests),
-    testCase(BeNilTest.allTests),
-    testCase(ContainTest.allTests),
-    testCase(EndWithTest.allTests),
-    testCase(EqualTest.allTests),
-    testCase(HaveCountTest.allTests),
-    testCase(MatchTest.allTests),
-    // testCase(RaisesExceptionTest.allTests),
-    testCase(ThrowErrorTest.allTests),
-    testCase(SatisfyAnyOfTest.allTests),
-    testCase(PostNotificationTest.allTests),
-])
+XCTMain(tests)

--- a/Tests/NimbleTests/AsynchronousTest.swift
+++ b/Tests/NimbleTests/AsynchronousTest.swift
@@ -4,25 +4,6 @@ import XCTest
 import Nimble
 
 final class AsyncTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (AsyncTest) -> () throws -> Void)] {
-        return [
-            ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
-            ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
-            ("testWaitUntilWithCustomDefaultsTimeout", testWaitUntilWithCustomDefaultsTimeout),
-            ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
-            ("testToEventuallyWithCustomDefaultTimeout", testToEventuallyWithCustomDefaultTimeout),
-            ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
-            ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
-            ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
-            ("testWaitUntilDetectsStalledMainThreadActivity", testWaitUntilDetectsStalledMainThreadActivity),
-            ("testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed", testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed),
-            ("testWaitUntilErrorsIfDoneIsCalledMultipleTimes", testWaitUntilErrorsIfDoneIsCalledMultipleTimes),
-            ("testWaitUntilMustBeInMainThread", testWaitUntilMustBeInMainThread),
-            ("testToEventuallyMustBeInMainThread", testToEventuallyMustBeInMainThread),
-            ("testSubjectUnderTestIsReleasedFromMemory", testSubjectUnderTestIsReleasedFromMemory),
-        ]
-    }
-
     class Error: Swift.Error {}
     let errorToThrow = Error()
 

--- a/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
+++ b/Tests/NimbleTests/Helpers/XCTestCaseProvider.swift
@@ -4,7 +4,7 @@ import XCTest
 // XCTestCaseProvider should be adopted by all XCTestCase subclasses. It provides a
 // mechanism for us to fail tests in Xcode which haven't been included in the `allTests`
 // list for swift-corelibs-xctest which is unable to dynamically discover tests. Note
-// that only `static var allTests` needs to be explicitly implemented, as `allTestNames`
+// that only `static var __allTests` needs to be explicitly implemented, as `allTestNames`
 // has a default implementation provided by a protocol extension.
 
 // Implementation note: This is broken down into two separate protocols because we need a
@@ -12,7 +12,7 @@ import XCTest
 
 public protocol XCTestCaseProviderStatic {
     // This should be explicitly implemented by XCTestCase subclasses
-    static var allTests: [(String, (Self) -> () throws -> Void)] { get }
+    static var __allTests: [(String, (Self) -> () -> ())] { get }
 }
 
 public protocol XCTestCaseNameProvider {
@@ -20,17 +20,21 @@ public protocol XCTestCaseNameProvider {
     var allTestNames: [String] { get }
 }
 
+#if os(macOS)
 public protocol XCTestCaseProvider: XCTestCaseProviderStatic, XCTestCaseNameProvider {}
 
 extension XCTestCaseProvider {
     var allTestNames: [String] {
-        return type(of: self).allTests.map({ name, _ in
+        return type(of: self).__allTests.map({ name, _ in
             return name
         })
     }
 }
+#else
+public protocol XCTestCaseProvider {}
+#endif
 
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS)
 
 extension XCTestCase {
     override open func tearDown() {
@@ -45,7 +49,13 @@ extension XCTestCase {
 extension XCTestCaseNameProvider {
     fileprivate func assertContainsTest(_ name: String) {
         let contains = self.allTestNames.contains(name)
-        XCTAssert(contains, "Test '\(name)' is missing from the allTests array")
+        XCTAssert(
+            contains,
+            """
+            Test '\(name)' is missing from the __allTests array.
+            Please run `$ swift test --generate-linuxmain` to update the manifests.
+            """
+        )
     }
 }
 

--- a/Tests/NimbleTests/Matchers/AllPassTest.swift
+++ b/Tests/NimbleTests/Matchers/AllPassTest.swift
@@ -43,17 +43,6 @@ extension Optional where Wrapped: Comparable {
 }
 
 final class AllPassTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (AllPassTest) -> () throws -> Void)] {
-        return [
-            ("testAllPassArray", testAllPassArray),
-            ("testAllPassMatcher", testAllPassMatcher),
-            ("testAllPassCollectionsWithOptionalsDontWork", testAllPassCollectionsWithOptionalsDontWork),
-            ("testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer", testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer),
-            ("testAllPassSet", testAllPassSet),
-            ("testAllPassWithNilAsExpectedValue", testAllPassWithNilAsExpectedValue),
-        ]
-    }
-
     func testAllPassArray() {
         expect([1, 2, 3, 4]).to(allPass({$0 < 5}))
         expect([1, 2, 3, 4]).toNot(allPass({$0 > 5}))

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -8,13 +8,6 @@ private class TestClassConformingToProtocol: TestProtocol {}
 private struct TestStructConformingToProtocol: TestProtocol {}
 
 final class BeAKindOfSwiftTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeAKindOfSwiftTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatch", testPositiveMatch),
-            ("testFailureMessages", testFailureMessages),
-        ]
-    }
-
     enum TestEnum {
         case one, two
     }
@@ -54,23 +47,17 @@ final class BeAKindOfSwiftTest: XCTestCase, XCTestCaseProvider {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-
 final class BeAKindOfObjCTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeAKindOfObjCTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatch", testPositiveMatch),
-            ("testFailureMessages", testFailureMessages),
-        ]
-    }
-
     func testPositiveMatch() {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         expect(TestNull()).to(beAKindOf(NSNull.self))
         expect(NSObject()).to(beAKindOf(NSObject.self))
         expect(NSNumber(value: 1)).toNot(beAKindOf(NSDate.self))
+#endif
     }
 
     func testFailureMessages() {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         failsWithErrorMessageForNil("expected to not be a kind of NSNull, got <nil>") {
             expect(nil as NSNull?).toNot(beAKindOf(NSNull.self))
         }
@@ -83,7 +70,6 @@ final class BeAKindOfObjCTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to not be a kind of NSNumber, got <__NSCFNumber instance>") {
             expect(NSNumber(value: 1)).toNot(beAKindOf(NSNumber.self))
         }
+#endif
     }
 }
-
-#endif

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -7,15 +7,6 @@ private class TestClassConformingToProtocol: TestProtocol {}
 private struct TestStructConformingToProtocol: TestProtocol {}
 
 final class BeAnInstanceOfTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeAnInstanceOfTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatch", testPositiveMatch),
-            ("testPositiveMatchSwiftTypes", testPositiveMatchSwiftTypes),
-            ("testFailureMessages", testFailureMessages),
-            ("testFailureMessagesSwiftTypes", testFailureMessagesSwiftTypes),
-        ]
-    }
-
     func testPositiveMatch() {
         expect(NSNull()).to(beAnInstanceOf(NSNull.self))
         expect(NSNumber(value: 1)).toNot(beAnInstanceOf(NSDate.self))

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -3,24 +3,6 @@ import XCTest
 import Nimble
 
 final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeCloseToTest) -> () throws -> Void)] {
-        return [
-            ("testBeCloseTo", testBeCloseTo),
-            ("testBeCloseToWithin", testBeCloseToWithin),
-            ("testBeCloseToWithNSNumber", testBeCloseToWithNSNumber),
-            ("testBeCloseToWithDate", testBeCloseToWithDate),
-            ("testBeCloseToWithNSDate", testBeCloseToWithNSDate),
-            ("testBeCloseToOperator", testBeCloseToOperator),
-            ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
-            ("testPlusMinusOperator", testPlusMinusOperator),
-            ("testBeCloseToOperatorWithDate", testBeCloseToOperatorWithDate),
-            ("testBeCloseToWithinOperatorWithDate", testBeCloseToWithinOperatorWithDate),
-            ("testPlusMinusOperatorWithDate", testPlusMinusOperatorWithDate),
-            ("testBeCloseToArray", testBeCloseToArray),
-            ("testBeCloseToWithCGFloat", testBeCloseToWithCGFloat),
-        ]
-    }
-
     func testBeCloseTo() {
         expect(1.2).to(beCloseTo(1.2001))
         expect(1.2 as CDouble).to(beCloseTo(1.2001))

--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -51,12 +51,14 @@ final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
             expect([1]).to(beEmpty())
         }
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         failsWithErrorMessage("expected to not be empty, got <{()}>") {
             expect(NSSet()).toNot(beEmpty())
         }
         failsWithErrorMessage("expected to be empty, got <{(1)}>") {
             expect(NSSet(object: NSNumber(value: 1))).to(beEmpty())
         }
+#endif
 
         failsWithErrorMessage("expected to not be empty, got <()>") {
             expect(NSIndexSet()).toNot(beEmpty())

--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeEmptyTest) -> () throws -> Void)] {
-        return [
-            ("testBeEmptyPositive", testBeEmptyPositive),
-            ("testBeEmptyNegative", testBeEmptyNegative),
-        ]
-    }
-
     func testBeEmptyPositive() {
         expect([] as [Int]).to(beEmpty())
         expect([1]).toNot(beEmpty())

--- a/Tests/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeGreaterThanOrEqualToTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeGreaterThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeGreaterThanOrEqualToTest) -> () throws -> Void)] {
-        return [
-            ("testGreaterThanOrEqualTo", testGreaterThanOrEqualTo),
-            ("testGreaterThanOrEqualToOperator", testGreaterThanOrEqualToOperator),
-        ]
-    }
-
     func testGreaterThanOrEqualTo() {
         expect(10).to(beGreaterThanOrEqualTo(10))
         expect(10).to(beGreaterThanOrEqualTo(2))

--- a/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
+++ b/Tests/NimbleTests/Matchers/BeGreaterThanTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeGreaterThanTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeGreaterThanTest) -> () throws -> Void)] {
-        return [
-            ("testGreaterThan", testGreaterThan),
-            ("testGreaterThanOperator", testGreaterThanOperator),
-        ]
-    }
-
     func testGreaterThan() {
         expect(10).to(beGreaterThan(2))
         expect(1).toNot(beGreaterThan(2))

--- a/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -3,17 +3,6 @@ import XCTest
 import Nimble
 
 final class BeIdenticalToObjectTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeIdenticalToObjectTest) -> () throws -> Void)] {
-        return [
-            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
-            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
-            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
-            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
-            ("testFailsOnNils", testFailsOnNils),
-            ("testOperators", testOperators),
-        ]
-    }
-
     private class BeIdenticalToObjectTester {}
     private let testObjectA = BeIdenticalToObjectTester()
     private let testObjectB = BeIdenticalToObjectTester()

--- a/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -3,17 +3,6 @@ import XCTest
 @testable import Nimble
 
 final class BeIdenticalToTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeIdenticalToTest) -> () throws -> Void)] {
-        return [
-            ("testBeIdenticalToPositive", testBeIdenticalToPositive),
-            ("testBeIdenticalToNegative", testBeIdenticalToNegative),
-            ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
-            ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
-            ("testOperators", testOperators),
-            ("testBeAlias", testBeAlias),
-        ]
-    }
-
     func testBeIdenticalToPositive() {
         let value = NSDate()
         expect(value).to(beIdenticalTo(value))

--- a/Tests/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeLessThanOrEqualToTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeLessThanOrEqualToTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeLessThanOrEqualToTest) -> () throws -> Void)] {
-        return [
-            ("testLessThanOrEqualTo", testLessThanOrEqualTo),
-            ("testLessThanOrEqualToOperator", testLessThanOrEqualToOperator),
-        ]
-    }
-
     func testLessThanOrEqualTo() {
         expect(10).to(beLessThanOrEqualTo(10))
         expect(2).to(beLessThanOrEqualTo(10))

--- a/Tests/NimbleTests/Matchers/BeLessThanTest.swift
+++ b/Tests/NimbleTests/Matchers/BeLessThanTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeLessThanTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeLessThanTest) -> () throws -> Void)] {
-        return [
-            ("testLessThan", testLessThan),
-            ("testLessThanOperator", testLessThanOperator),
-        ]
-    }
-
     func testLessThan() {
         expect(2).to(beLessThan(10))
         expect(2).toNot(beLessThan(1))

--- a/Tests/NimbleTests/Matchers/BeLogicalTest.swift
+++ b/Tests/NimbleTests/Matchers/BeLogicalTest.swift
@@ -30,18 +30,6 @@ enum ConvertsToBool: ExpressibleByBooleanLiteral, CustomStringConvertible {
 }
 
 final class BeTruthyTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeTruthyTest) -> () throws -> Void)] {
-        return [
-            ("testShouldMatchNonNilTypes", testShouldMatchNonNilTypes),
-            ("testShouldMatchTrue", testShouldMatchTrue),
-            ("testShouldNotMatchNilTypes", testShouldNotMatchNilTypes),
-            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
-            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
-            ("testShouldMatchBoolConvertibleTypesThatConvertToTrue", testShouldMatchBoolConvertibleTypesThatConvertToTrue),
-            ("testShouldNotMatchBoolConvertibleTypesThatConvertToFalse", testShouldNotMatchBoolConvertibleTypesThatConvertToFalse),
-        ]
-    }
-
     func testShouldMatchNonNilTypes() {
         expect(true as Bool?).to(beTruthy())
 
@@ -123,14 +111,6 @@ final class BeTruthyTest: XCTestCase, XCTestCaseProvider {
 }
 
 final class BeTrueTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeTrueTest) -> () throws -> Void)] {
-        return [
-            ("testShouldMatchTrue", testShouldMatchTrue),
-            ("testShouldNotMatchFalse", testShouldNotMatchFalse),
-            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
-        ]
-    }
-
     func testShouldMatchTrue() {
         expect(true).to(beTrue())
 
@@ -159,16 +139,6 @@ final class BeTrueTest: XCTestCase, XCTestCaseProvider {
 }
 
 final class BeFalsyTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeFalsyTest) -> () throws -> Void)] {
-        return [
-            ("testShouldMatchNilTypes", testShouldMatchNilTypes),
-            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
-            ("testShouldNotMatchNonNilTypes", testShouldNotMatchNonNilTypes),
-            ("testShouldMatchFalse", testShouldMatchFalse),
-            ("testShouldMatchNilBools", testShouldMatchNilBools),
-        ]
-    }
-
     func testShouldMatchNilTypes() {
         expect(false as Bool?).to(beFalsy())
 
@@ -234,14 +204,6 @@ final class BeFalsyTest: XCTestCase, XCTestCaseProvider {
 }
 
 final class BeFalseTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeFalseTest) -> () throws -> Void)] {
-        return [
-            ("testShouldNotMatchTrue", testShouldNotMatchTrue),
-            ("testShouldMatchFalse", testShouldMatchFalse),
-            ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
-        ]
-    }
-
     func testShouldNotMatchTrue() {
         expect(true).toNot(beFalse())
 

--- a/Tests/NimbleTests/Matchers/BeNilTest.swift
+++ b/Tests/NimbleTests/Matchers/BeNilTest.swift
@@ -2,12 +2,6 @@ import XCTest
 import Nimble
 
 final class BeNilTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeNilTest) -> () throws -> Void)] {
-        return [
-            ("testBeNil", testBeNil),
-        ]
-    }
-
     func producesNil() -> [Int]? {
         return nil
     }

--- a/Tests/NimbleTests/Matchers/BeVoidTest.swift
+++ b/Tests/NimbleTests/Matchers/BeVoidTest.swift
@@ -2,12 +2,6 @@ import XCTest
 import Nimble
 
 final class BeVoidTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeVoidTest) -> () throws -> Void)] {
-        return [
-            ("testBeVoid", testBeVoid),
-        ]
-    }
-
     func testBeVoid() {
         expect(()).to(beVoid())
         expect(() as ()?).to(beVoid())

--- a/Tests/NimbleTests/Matchers/BeginWithTest.swift
+++ b/Tests/NimbleTests/Matchers/BeginWithTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class BeginWithTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (BeginWithTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatches", testPositiveMatches),
-            ("testNegativeMatches", testNegativeMatches),
-        ]
-    }
-
     func testPositiveMatches() {
         expect([1, 2, 3]).to(beginWith(1))
         expect([1, 2, 3]).toNot(beginWith(2))

--- a/Tests/NimbleTests/Matchers/ContainElementSatisfyingTest.swift
+++ b/Tests/NimbleTests/Matchers/ContainElementSatisfyingTest.swift
@@ -3,20 +3,6 @@ import XCTest
 import Nimble
 
 final class ContainElementSatisfyingTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (ContainElementSatisfyingTest) -> () throws -> Void)] {
-        return [
-            ("testContainElementSatisfying", testContainElementSatisfying),
-            ("testContainElementSatisfyingDefaultErrorMessage", testContainElementSatisfyingDefaultErrorMessage),
-            ("testContainElementSatisfyingSpecificErrorMessage", testContainElementSatisfyingSpecificErrorMessage),
-            ("testContainElementSatisfyingNegativeCase",
-             testContainElementSatisfyingNegativeCase),
-            ("testContainElementSatisfyingNegativeCaseDefaultErrorMessage",
-             testContainElementSatisfyingNegativeCaseDefaultErrorMessage),
-            ("testContainElementSatisfyingNegativeCaseSpecificErrorMessage",
-             testContainElementSatisfyingNegativeCaseSpecificErrorMessage),
-        ]
-    }
-
     func testContainElementSatisfying() {
         var orderIndifferentArray = [1, 2, 3]
         expect(orderIndifferentArray).to(containElementSatisfying({ number in

--- a/Tests/NimbleTests/Matchers/ContainTest.swift
+++ b/Tests/NimbleTests/Matchers/ContainTest.swift
@@ -3,16 +3,6 @@ import XCTest
 import Nimble
 
 final class ContainTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (ContainTest) -> () throws -> Void)] {
-        return [
-            ("testContain", testContain),
-            ("testContainSubstring", testContainSubstring),
-            ("testContainObjCSubstring", testContainObjCSubstring),
-            ("testVariadicArguments", testVariadicArguments),
-            ("testCollectionArguments", testCollectionArguments),
-        ]
-    }
-
     func testContain() {
         expect([1, 2, 3]).to(contain(1))
         expect([1, 2, 3] as [CInt]).to(contain(1 as CInt))

--- a/Tests/NimbleTests/Matchers/EndWithTest.swift
+++ b/Tests/NimbleTests/Matchers/EndWithTest.swift
@@ -3,13 +3,6 @@ import XCTest
 import Nimble
 
 final class EndWithTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (EndWithTest) -> () throws -> Void)] {
-        return [
-            ("testEndWithPositives", testEndWithPositives),
-            ("testEndWithNegatives", testEndWithNegatives),
-        ]
-    }
-
     func testEndWithPositives() {
         expect([1, 2, 3]).to(endWith(3))
         expect([1, 2, 3]).toNot(endWith(2))

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -3,24 +3,6 @@ import XCTest
 import Nimble
 
 final class EqualTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (EqualTest) -> () throws -> Void)] {
-        return [
-            ("testEquality", testEquality),
-            ("testArrayEquality", testArrayEquality),
-            ("testSetEquality", testSetEquality),
-            ("testDoesNotMatchNils", testDoesNotMatchNils),
-            ("testDictionaryEquality", testDictionaryEquality),
-            ("testDataEquality", testDataEquality),
-            ("testNSObjectEquality", testNSObjectEquality),
-            ("testOperatorEquality", testOperatorEquality),
-            ("testOperatorEqualityWithArrays", testOperatorEqualityWithArrays),
-            ("testOperatorEqualityWithDictionaries", testOperatorEqualityWithDictionaries),
-            ("testOptionalEquality", testOptionalEquality),
-            ("testArrayOfOptionalsEquality", testArrayOfOptionalsEquality),
-            ("testDictionariesWithDifferentSequences", testDictionariesWithDifferentSequences),
-        ]
-    }
-
     func testEquality() {
         expect(1 as CInt).to(equal(1 as CInt))
         expect(1 as CInt).to(equal(1))

--- a/Tests/NimbleTests/Matchers/HaveCountTest.swift
+++ b/Tests/NimbleTests/Matchers/HaveCountTest.swift
@@ -2,14 +2,6 @@ import XCTest
 import Nimble
 
 final class HaveCountTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (HaveCountTest) -> () throws -> Void)] {
-        return [
-            ("testHaveCountForArray", testHaveCountForArray),
-            ("testHaveCountForDictionary", testHaveCountForDictionary),
-            ("testHaveCountForSet", testHaveCountForSet),
-        ]
-    }
-
     func testHaveCountForArray() {
         expect([1, 2, 3]).to(haveCount(3))
         expect([1, 2, 3]).notTo(haveCount(1))

--- a/Tests/NimbleTests/Matchers/MatchErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchErrorTest.swift
@@ -3,18 +3,6 @@ import XCTest
 import Nimble
 
 final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (MatchErrorTest) -> () throws -> Void)] {
-        return [
-            ("testMatchErrorPositive", testMatchErrorPositive),
-            ("testMatchErrorNegative", testMatchErrorNegative),
-            ("testMatchNSErrorPositive", testMatchNSErrorPositive),
-            ("testMatchNSErrorNegative", testMatchNSErrorNegative),
-            ("testMatchPositiveMessage", testMatchPositiveMessage),
-            ("testMatchNegativeMessage", testMatchNegativeMessage),
-            ("testDoesNotMatchNils", testDoesNotMatchNils),
-        ]
-    }
-
     func testMatchErrorPositive() {
         expect(NimbleError.laugh).to(matchError(NimbleError.laugh))
         expect(NimbleError.laugh).to(matchError(NimbleError.self))

--- a/Tests/NimbleTests/Matchers/MatchErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchErrorTest.swift
@@ -19,10 +19,12 @@ final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testMatchNSErrorPositive() {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         let error1 = NSError(domain: "err", code: 0, userInfo: nil)
         let error2 = NSError(domain: "err", code: 0, userInfo: nil)
 
         expect(error1).to(matchError(error2))
+#endif
     }
 
     func testMatchNSErrorNegative() {
@@ -43,11 +45,13 @@ final class MatchErrorTest: XCTestCase, XCTestCaseProvider {
             expect(CustomDebugStringConvertibleError.a).to(matchError(CustomDebugStringConvertibleError.b))
         }
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         failsWithErrorMessage("expected to match error <Error Domain=err Code=1 \"(null)\">, got <Error Domain=err Code=0 \"(null)\">") {
             let error1 = NSError(domain: "err", code: 0, userInfo: nil)
             let error2 = NSError(domain: "err", code: 1, userInfo: nil)
             expect(error1).to(matchError(error2))
         }
+#endif
     }
 
     func testMatchNegativeMessage() {

--- a/Tests/NimbleTests/Matchers/MatchTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchTest.swift
@@ -2,16 +2,6 @@ import XCTest
 import Nimble
 
 final class MatchTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (MatchTest) -> () throws -> Void)] {
-        return [
-            ("testMatchPositive", testMatchPositive),
-            ("testMatchNegative", testMatchNegative),
-            ("testMatchPositiveMessage", testMatchPositiveMessage),
-            ("testMatchNegativeMessage", testMatchNegativeMessage),
-            ("testMatchNils", testMatchNils),
-        ]
-    }
-
     func testMatchPositive() {
         expect("11:14").to(match("\\d{2}:\\d{2}"))
     }

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -3,18 +3,6 @@ import Nimble
 import Foundation
 
 final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (PostNotificationTest) -> () throws -> Void)] {
-        return [
-            ("testPassesWhenNoNotificationsArePosted", testPassesWhenNoNotificationsArePosted),
-            ("testPassesWhenExpectedNotificationIsPosted", testPassesWhenExpectedNotificationIsPosted),
-            ("testPassesWhenAllExpectedNotificationsArePosted", testPassesWhenAllExpectedNotificationsArePosted),
-            ("testFailsWhenNoNotificationsArePosted", testFailsWhenNoNotificationsArePosted),
-            ("testFailsWhenNotificationWithWrongNameIsPosted", testFailsWhenNotificationWithWrongNameIsPosted),
-            ("testFailsWhenNotificationWithWrongObjectIsPosted", testFailsWhenNotificationWithWrongObjectIsPosted),
-            ("testPassesWhenExpectedNotificationEventuallyIsPosted", testPassesWhenExpectedNotificationEventuallyIsPosted),
-        ]
-    }
-
     let notificationCenter = NotificationCenter()
 
     func testPassesWhenNoNotificationsArePosted() {

--- a/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -3,17 +3,7 @@ import Nimble
 
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
-final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (RaisesExceptionTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatches", testPositiveMatches),
-            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
-            ("testNegativeMatches", testNegativeMatches),
-            ("testNegativeMatchesDoNotCallClosureWithoutException", testNegativeMatchesDoNotCallClosureWithoutException),
-            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
-        ]
-    }
-
+final class RaisesExceptionTest: XCTestCase {
     var anException = NSException(name: NSExceptionName("laugh"), reason: "Lulz", userInfo: ["key": "value"])
 
     func testPositiveMatches() {

--- a/Tests/NimbleTests/Matchers/SatisfyAllOfTest.swift
+++ b/Tests/NimbleTests/Matchers/SatisfyAllOfTest.swift
@@ -3,13 +3,6 @@ import Nimble
 import Foundation
 
 final class SatisfyAllOfTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (SatisfyAllOfTest) -> () throws -> Void)] {
-        return [
-            ("testSatisfyAllOf", testSatisfyAllOf),
-            ("testOperatorAnd", testOperatorAnd),
-        ]
-    }
-
     func testSatisfyAllOf() {
         expect(2).to(satisfyAllOf(equal(2), beLessThan(3)))
 #if SUPPORT_IMPLICIT_BRIDGING_CONVERSION

--- a/Tests/NimbleTests/Matchers/SatisfyAnyOfTest.swift
+++ b/Tests/NimbleTests/Matchers/SatisfyAnyOfTest.swift
@@ -3,13 +3,6 @@ import Nimble
 import Foundation
 
 final class SatisfyAnyOfTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (SatisfyAnyOfTest) -> () throws -> Void)] {
-        return [
-            ("testSatisfyAnyOf", testSatisfyAnyOf),
-            ("testOperatorOr", testOperatorOr),
-        ]
-    }
-
     func testSatisfyAnyOf() {
         expect(2).to(satisfyAnyOf(equal(2), equal(3)))
 #if SUPPORT_IMPLICIT_BRIDGING_CONVERSION

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -4,18 +4,7 @@ import Nimble
 
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
-final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (ThrowAssertionTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatch", testPositiveMatch),
-            ("testErrorThrown", testErrorThrown),
-            ("testPostAssertionCodeNotRun", testPostAssertionCodeNotRun),
-            ("testNegativeMatch", testNegativeMatch),
-            ("testPositiveMessage", testPositiveMessage),
-            ("testNegativeMessage", testNegativeMessage),
-        ]
-    }
-
+final class ThrowAssertionTest: XCTestCase {
     func testPositiveMatch() {
         expect { () -> Void in fatalError() }.to(throwAssertion())
     }

--- a/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowErrorTest.swift
@@ -32,18 +32,6 @@ extension CustomDebugStringConvertibleError: CustomDebugStringConvertible {
 }
 
 final class ThrowErrorTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (ThrowErrorTest) -> () throws -> Void)] {
-        return [
-            ("testPositiveMatches", testPositiveMatches),
-            ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
-            ("testNegativeMatches", testNegativeMatches),
-            ("testPositiveNegatedMatches", testPositiveNegatedMatches),
-            ("testNegativeNegatedMatches", testNegativeNegatedMatches),
-            ("testNegativeMatchesDoNotCallClosureWithoutError", testNegativeMatchesDoNotCallClosureWithoutError),
-            ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
-        ]
-    }
-
     func testPositiveMatches() {
         expect { throw NimbleError.laugh }.to(throwError())
         expect { throw NimbleError.laugh }.to(throwError(NimbleError.laugh))

--- a/Tests/NimbleTests/Matchers/ToSucceedTest.swift
+++ b/Tests/NimbleTests/Matchers/ToSucceedTest.swift
@@ -2,12 +2,6 @@ import XCTest
 import Nimble
 
 final class ToSucceedTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (ToSucceedTest) -> () throws -> Void)] {
-        return [
-            ("testToSucceed", testToSucceed),
-        ]
-    }
-
     func testToSucceed() {
         expect({
             return .succeeded

--- a/Tests/NimbleTests/SynchronousTests.swift
+++ b/Tests/NimbleTests/SynchronousTests.swift
@@ -3,24 +3,6 @@ import XCTest
 import Nimble
 
 final class SynchronousTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (SynchronousTest) -> () throws -> Void)] {
-        return [
-            ("testFailAlwaysFails", testFailAlwaysFails),
-            ("testUnexpectedErrorsThrownFails", testUnexpectedErrorsThrownFails),
-            ("testToMatchesIfMatcherReturnsTrue", testToMatchesIfMatcherReturnsTrue),
-            ("testToProvidesActualValueExpression", testToProvidesActualValueExpression),
-            ("testToProvidesAMemoizedActualValueExpression", testToProvidesActualValueExpression),
-            ("testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
-            ("testToMatchAgainstLazyProperties", testToMatchAgainstLazyProperties),
-            ("testToNotMatchesIfMatcherReturnsTrue", testToNotMatchesIfMatcherReturnsTrue),
-            ("testToNotProvidesActualValueExpression", testToNotProvidesActualValueExpression),
-            ("testToNotProvidesAMemoizedActualValueExpression", testToNotProvidesAMemoizedActualValueExpression),
-            ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
-            ("testToNotNegativeMatches", testToNotNegativeMatches),
-            ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
-        ]
-    }
-
     class Error: Swift.Error {}
     let errorToThrow = Error()
 

--- a/Tests/NimbleTests/UserDescriptionTest.swift
+++ b/Tests/NimbleTests/UserDescriptionTest.swift
@@ -2,17 +2,6 @@ import XCTest
 import Nimble
 
 final class UserDescriptionTest: XCTestCase, XCTestCaseProvider {
-    static var allTests: [(String, (UserDescriptionTest) -> () throws -> Void)] {
-        return [
-            ("testToMatcher_CustomFailureMessage", testToMatcher_CustomFailureMessage),
-            ("testNotToMatcher_CustomFailureMessage", testNotToMatcher_CustomFailureMessage),
-            ("testToNotMatcher_CustomFailureMessage", testToNotMatcher_CustomFailureMessage),
-            ("testToEventuallyMatch_CustomFailureMessage", testToEventuallyMatch_CustomFailureMessage),
-            ("testToEventuallyNotMatch_CustomFailureMessage", testToEventuallyNotMatch_CustomFailureMessage),
-            ("testToNotEventuallyMatch_CustomFailureMessage", testToNotEventuallyMatch_CustomFailureMessage),
-        ]
-    }
-
     func testToMatcher_CustomFailureMessage() {
         failsWithErrorMessage(
             "These aren't equal!\n" +

--- a/Tests/NimbleTests/XCTestManifests.swift
+++ b/Tests/NimbleTests/XCTestManifests.swift
@@ -1,0 +1,376 @@
+import XCTest
+
+extension AllPassTest {
+    static let __allTests = [
+        ("testAllPassArray", testAllPassArray),
+        ("testAllPassCollectionsWithOptionalsDontWork", testAllPassCollectionsWithOptionalsDontWork),
+        ("testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer", testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer),
+        ("testAllPassMatcher", testAllPassMatcher),
+        ("testAllPassSet", testAllPassSet),
+        ("testAllPassWithNilAsExpectedValue", testAllPassWithNilAsExpectedValue),
+    ]
+}
+
+extension AsyncTest {
+    static let __allTests = [
+        ("testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed", testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed),
+        ("testSubjectUnderTestIsReleasedFromMemory", testSubjectUnderTestIsReleasedFromMemory),
+        ("testToEventuallyMustBeInMainThread", testToEventuallyMustBeInMainThread),
+        ("testToEventuallyNegativeMatches", testToEventuallyNegativeMatches),
+        ("testToEventuallyPositiveMatches", testToEventuallyPositiveMatches),
+        ("testToEventuallyWithCustomDefaultTimeout", testToEventuallyWithCustomDefaultTimeout),
+        ("testWaitUntilDetectsStalledMainThreadActivity", testWaitUntilDetectsStalledMainThreadActivity),
+        ("testWaitUntilErrorsIfDoneIsCalledMultipleTimes", testWaitUntilErrorsIfDoneIsCalledMultipleTimes),
+        ("testWaitUntilMustBeInMainThread", testWaitUntilMustBeInMainThread),
+        ("testWaitUntilNegativeMatches", testWaitUntilNegativeMatches),
+        ("testWaitUntilPositiveMatches", testWaitUntilPositiveMatches),
+        ("testWaitUntilTimesOutIfNotCalled", testWaitUntilTimesOutIfNotCalled),
+        ("testWaitUntilTimesOutWhenExceedingItsTime", testWaitUntilTimesOutWhenExceedingItsTime),
+        ("testWaitUntilWithCustomDefaultsTimeout", testWaitUntilWithCustomDefaultsTimeout),
+    ]
+}
+
+extension BeAKindOfObjCTest {
+    static let __allTests = [
+        ("testFailureMessages", testFailureMessages),
+        ("testPositiveMatch", testPositiveMatch),
+    ]
+}
+
+extension BeAKindOfSwiftTest {
+    static let __allTests = [
+        ("testFailureMessages", testFailureMessages),
+        ("testPositiveMatch", testPositiveMatch),
+    ]
+}
+
+extension BeAnInstanceOfTest {
+    static let __allTests = [
+        ("testFailureMessages", testFailureMessages),
+        ("testFailureMessagesSwiftTypes", testFailureMessagesSwiftTypes),
+        ("testPositiveMatch", testPositiveMatch),
+        ("testPositiveMatchSwiftTypes", testPositiveMatchSwiftTypes),
+    ]
+}
+
+extension BeCloseToTest {
+    static let __allTests = [
+        ("testBeCloseTo", testBeCloseTo),
+        ("testBeCloseToArray", testBeCloseToArray),
+        ("testBeCloseToOperator", testBeCloseToOperator),
+        ("testBeCloseToOperatorWithDate", testBeCloseToOperatorWithDate),
+        ("testBeCloseToWithCGFloat", testBeCloseToWithCGFloat),
+        ("testBeCloseToWithDate", testBeCloseToWithDate),
+        ("testBeCloseToWithin", testBeCloseToWithin),
+        ("testBeCloseToWithinOperator", testBeCloseToWithinOperator),
+        ("testBeCloseToWithinOperatorWithDate", testBeCloseToWithinOperatorWithDate),
+        ("testBeCloseToWithNSDate", testBeCloseToWithNSDate),
+        ("testBeCloseToWithNSNumber", testBeCloseToWithNSNumber),
+        ("testPlusMinusOperator", testPlusMinusOperator),
+        ("testPlusMinusOperatorWithDate", testPlusMinusOperatorWithDate),
+    ]
+}
+
+extension BeEmptyTest {
+    static let __allTests = [
+        ("testBeEmptyNegative", testBeEmptyNegative),
+        ("testBeEmptyPositive", testBeEmptyPositive),
+    ]
+}
+
+extension BeFalseTest {
+    static let __allTests = [
+        ("testShouldMatchFalse", testShouldMatchFalse),
+        ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+    ]
+}
+
+extension BeFalsyTest {
+    static let __allTests = [
+        ("testShouldMatchFalse", testShouldMatchFalse),
+        ("testShouldMatchNilBools", testShouldMatchNilBools),
+        ("testShouldMatchNilTypes", testShouldMatchNilTypes),
+        ("testShouldNotMatchNonNilTypes", testShouldNotMatchNonNilTypes),
+        ("testShouldNotMatchTrue", testShouldNotMatchTrue),
+    ]
+}
+
+extension BeGreaterThanOrEqualToTest {
+    static let __allTests = [
+        ("testGreaterThanOrEqualTo", testGreaterThanOrEqualTo),
+        ("testGreaterThanOrEqualToOperator", testGreaterThanOrEqualToOperator),
+    ]
+}
+
+extension BeGreaterThanTest {
+    static let __allTests = [
+        ("testGreaterThan", testGreaterThan),
+        ("testGreaterThanOperator", testGreaterThanOperator),
+    ]
+}
+
+extension BeIdenticalToObjectTest {
+    static let __allTests = [
+        ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+        ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+        ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+        ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+        ("testFailsOnNils", testFailsOnNils),
+        ("testOperators", testOperators),
+    ]
+}
+
+extension BeIdenticalToTest {
+    static let __allTests = [
+        ("testBeAlias", testBeAlias),
+        ("testBeIdenticalToNegative", testBeIdenticalToNegative),
+        ("testBeIdenticalToNegativeMessage", testBeIdenticalToNegativeMessage),
+        ("testBeIdenticalToPositive", testBeIdenticalToPositive),
+        ("testBeIdenticalToPositiveMessage", testBeIdenticalToPositiveMessage),
+        ("testOperators", testOperators),
+    ]
+}
+
+extension BeLessThanOrEqualToTest {
+    static let __allTests = [
+        ("testLessThanOrEqualTo", testLessThanOrEqualTo),
+        ("testLessThanOrEqualToOperator", testLessThanOrEqualToOperator),
+    ]
+}
+
+extension BeLessThanTest {
+    static let __allTests = [
+        ("testLessThan", testLessThan),
+        ("testLessThanOperator", testLessThanOperator),
+    ]
+}
+
+extension BeNilTest {
+    static let __allTests = [
+        ("testBeNil", testBeNil),
+    ]
+}
+
+extension BeTrueTest {
+    static let __allTests = [
+        ("testShouldMatchTrue", testShouldMatchTrue),
+        ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+        ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+    ]
+}
+
+extension BeTruthyTest {
+    static let __allTests = [
+        ("testShouldMatchBoolConvertibleTypesThatConvertToTrue", testShouldMatchBoolConvertibleTypesThatConvertToTrue),
+        ("testShouldMatchNonNilTypes", testShouldMatchNonNilTypes),
+        ("testShouldMatchTrue", testShouldMatchTrue),
+        ("testShouldNotMatchBoolConvertibleTypesThatConvertToFalse", testShouldNotMatchBoolConvertibleTypesThatConvertToFalse),
+        ("testShouldNotMatchFalse", testShouldNotMatchFalse),
+        ("testShouldNotMatchNilBools", testShouldNotMatchNilBools),
+        ("testShouldNotMatchNilTypes", testShouldNotMatchNilTypes),
+    ]
+}
+
+extension BeVoidTest {
+    static let __allTests = [
+        ("testBeVoid", testBeVoid),
+    ]
+}
+
+extension BeginWithTest {
+    static let __allTests = [
+        ("testNegativeMatches", testNegativeMatches),
+        ("testPositiveMatches", testPositiveMatches),
+    ]
+}
+
+extension ContainElementSatisfyingTest {
+    static let __allTests = [
+        ("testContainElementSatisfying", testContainElementSatisfying),
+        ("testContainElementSatisfyingDefaultErrorMessage", testContainElementSatisfyingDefaultErrorMessage),
+        ("testContainElementSatisfyingNegativeCase", testContainElementSatisfyingNegativeCase),
+        ("testContainElementSatisfyingNegativeCaseDefaultErrorMessage", testContainElementSatisfyingNegativeCaseDefaultErrorMessage),
+        ("testContainElementSatisfyingNegativeCaseSpecificErrorMessage", testContainElementSatisfyingNegativeCaseSpecificErrorMessage),
+        ("testContainElementSatisfyingSpecificErrorMessage", testContainElementSatisfyingSpecificErrorMessage),
+    ]
+}
+
+extension ContainTest {
+    static let __allTests = [
+        ("testCollectionArguments", testCollectionArguments),
+        ("testContain", testContain),
+        ("testContainObjCSubstring", testContainObjCSubstring),
+        ("testContainSubstring", testContainSubstring),
+        ("testVariadicArguments", testVariadicArguments),
+    ]
+}
+
+extension EndWithTest {
+    static let __allTests = [
+        ("testEndWithNegatives", testEndWithNegatives),
+        ("testEndWithPositives", testEndWithPositives),
+    ]
+}
+
+extension EqualTest {
+    static let __allTests = [
+        ("testArrayEquality", testArrayEquality),
+        ("testArrayOfOptionalsEquality", testArrayOfOptionalsEquality),
+        ("testDataEquality", testDataEquality),
+        ("testDictionariesWithDifferentSequences", testDictionariesWithDifferentSequences),
+        ("testDictionaryEquality", testDictionaryEquality),
+        ("testDoesNotMatchNils", testDoesNotMatchNils),
+        ("testEquality", testEquality),
+        ("testNSObjectEquality", testNSObjectEquality),
+        ("testOperatorEquality", testOperatorEquality),
+        ("testOperatorEqualityWithArrays", testOperatorEqualityWithArrays),
+        ("testOperatorEqualityWithDictionaries", testOperatorEqualityWithDictionaries),
+        ("testOptionalEquality", testOptionalEquality),
+        ("testSetEquality", testSetEquality),
+    ]
+}
+
+extension HaveCountTest {
+    static let __allTests = [
+        ("testHaveCountForArray", testHaveCountForArray),
+        ("testHaveCountForDictionary", testHaveCountForDictionary),
+        ("testHaveCountForSet", testHaveCountForSet),
+    ]
+}
+
+extension MatchErrorTest {
+    static let __allTests = [
+        ("testDoesNotMatchNils", testDoesNotMatchNils),
+        ("testMatchErrorNegative", testMatchErrorNegative),
+        ("testMatchErrorPositive", testMatchErrorPositive),
+        ("testMatchNegativeMessage", testMatchNegativeMessage),
+        ("testMatchNSErrorNegative", testMatchNSErrorNegative),
+        ("testMatchNSErrorPositive", testMatchNSErrorPositive),
+        ("testMatchPositiveMessage", testMatchPositiveMessage),
+    ]
+}
+
+extension MatchTest {
+    static let __allTests = [
+        ("testMatchNegative", testMatchNegative),
+        ("testMatchNegativeMessage", testMatchNegativeMessage),
+        ("testMatchNils", testMatchNils),
+        ("testMatchPositive", testMatchPositive),
+        ("testMatchPositiveMessage", testMatchPositiveMessage),
+    ]
+}
+
+extension PostNotificationTest {
+    static let __allTests = [
+        ("testFailsWhenNoNotificationsArePosted", testFailsWhenNoNotificationsArePosted),
+        ("testFailsWhenNotificationWithWrongNameIsPosted", testFailsWhenNotificationWithWrongNameIsPosted),
+        ("testFailsWhenNotificationWithWrongObjectIsPosted", testFailsWhenNotificationWithWrongObjectIsPosted),
+        ("testPassesWhenAllExpectedNotificationsArePosted", testPassesWhenAllExpectedNotificationsArePosted),
+        ("testPassesWhenExpectedNotificationEventuallyIsPosted", testPassesWhenExpectedNotificationEventuallyIsPosted),
+        ("testPassesWhenExpectedNotificationIsPosted", testPassesWhenExpectedNotificationIsPosted),
+        ("testPassesWhenNoNotificationsArePosted", testPassesWhenNoNotificationsArePosted),
+    ]
+}
+
+extension SatisfyAllOfTest {
+    static let __allTests = [
+        ("testOperatorAnd", testOperatorAnd),
+        ("testSatisfyAllOf", testSatisfyAllOf),
+    ]
+}
+
+extension SatisfyAnyOfTest {
+    static let __allTests = [
+        ("testOperatorOr", testOperatorOr),
+        ("testSatisfyAnyOf", testSatisfyAnyOf),
+    ]
+}
+
+extension SynchronousTest {
+    static let __allTests = [
+        ("testFailAlwaysFails", testFailAlwaysFails),
+        ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
+        ("testToMatchAgainstLazyProperties", testToMatchAgainstLazyProperties),
+        ("testToMatchesIfMatcherReturnsTrue", testToMatchesIfMatcherReturnsTrue),
+        ("testToNotMatchesIfMatcherReturnsTrue", testToNotMatchesIfMatcherReturnsTrue),
+        ("testToNotNegativeMatches", testToNotNegativeMatches),
+        ("testToNotProvidesActualValueExpression", testToNotProvidesActualValueExpression),
+        ("testToNotProvidesAMemoizedActualValueExpression", testToNotProvidesAMemoizedActualValueExpression),
+        ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+        ("testToProvidesActualValueExpression", testToProvidesActualValueExpression),
+        ("testToProvidesAMemoizedActualValueExpression", testToProvidesAMemoizedActualValueExpression),
+        ("testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+        ("testUnexpectedErrorsThrownFails", testUnexpectedErrorsThrownFails),
+    ]
+}
+
+extension ThrowErrorTest {
+    static let __allTests = [
+        ("testNegativeMatches", testNegativeMatches),
+        ("testNegativeMatchesDoNotCallClosureWithoutError", testNegativeMatchesDoNotCallClosureWithoutError),
+        ("testNegativeMatchesWithClosure", testNegativeMatchesWithClosure),
+        ("testNegativeNegatedMatches", testNegativeNegatedMatches),
+        ("testPositiveMatches", testPositiveMatches),
+        ("testPositiveMatchesWithClosures", testPositiveMatchesWithClosures),
+        ("testPositiveNegatedMatches", testPositiveNegatedMatches),
+    ]
+}
+
+extension ToSucceedTest {
+    static let __allTests = [
+        ("testToSucceed", testToSucceed),
+    ]
+}
+
+extension UserDescriptionTest {
+    static let __allTests = [
+        ("testNotToMatcher_CustomFailureMessage", testNotToMatcher_CustomFailureMessage),
+        ("testToEventuallyMatch_CustomFailureMessage", testToEventuallyMatch_CustomFailureMessage),
+        ("testToEventuallyNotMatch_CustomFailureMessage", testToEventuallyNotMatch_CustomFailureMessage),
+        ("testToMatcher_CustomFailureMessage", testToMatcher_CustomFailureMessage),
+        ("testToNotEventuallyMatch_CustomFailureMessage", testToNotEventuallyMatch_CustomFailureMessage),
+        ("testToNotMatcher_CustomFailureMessage", testToNotMatcher_CustomFailureMessage),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(AllPassTest.__allTests),
+        testCase(AsyncTest.__allTests),
+        testCase(BeAKindOfObjCTest.__allTests),
+        testCase(BeAKindOfSwiftTest.__allTests),
+        testCase(BeAnInstanceOfTest.__allTests),
+        testCase(BeCloseToTest.__allTests),
+        testCase(BeEmptyTest.__allTests),
+        testCase(BeFalseTest.__allTests),
+        testCase(BeFalsyTest.__allTests),
+        testCase(BeGreaterThanOrEqualToTest.__allTests),
+        testCase(BeGreaterThanTest.__allTests),
+        testCase(BeIdenticalToObjectTest.__allTests),
+        testCase(BeIdenticalToTest.__allTests),
+        testCase(BeLessThanOrEqualToTest.__allTests),
+        testCase(BeLessThanTest.__allTests),
+        testCase(BeNilTest.__allTests),
+        testCase(BeTrueTest.__allTests),
+        testCase(BeTruthyTest.__allTests),
+        testCase(BeVoidTest.__allTests),
+        testCase(BeginWithTest.__allTests),
+        testCase(ContainElementSatisfyingTest.__allTests),
+        testCase(ContainTest.__allTests),
+        testCase(EndWithTest.__allTests),
+        testCase(EqualTest.__allTests),
+        testCase(HaveCountTest.__allTests),
+        testCase(MatchErrorTest.__allTests),
+        testCase(MatchTest.__allTests),
+        testCase(PostNotificationTest.__allTests),
+        testCase(SatisfyAllOfTest.__allTests),
+        testCase(SatisfyAnyOfTest.__allTests),
+        testCase(SynchronousTest.__allTests),
+        testCase(ThrowErrorTest.__allTests),
+        testCase(ToSucceedTest.__allTests),
+        testCase(UserDescriptionTest.__allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
```
$ swift test --generate-linuxmain
```

Each time we run the command on macOS, new test cases will be added to XCTestManifests.swift.