### PR TITLE
Support cocoapods 1.5 change to imports

### DIFF
--- a/Sources/NimbleObjectiveC/CurrentTestCaseTracker.h
+++ b/Sources/NimbleObjectiveC/CurrentTestCaseTracker.h
@@ -1,5 +1,9 @@
 #import <XCTest/XCTest.h>
+#if __has_include("Nimble-Swift.h")
+#import "Nimble-Swift.h"
+#else
 #import <Nimble/Nimble-Swift.h>
+#endif
 
 SWIFT_CLASS("_TtC6Nimble22CurrentTestCaseTracker")
 @interface CurrentTestCaseTracker : NSObject <XCTestObservation>

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -1,5 +1,9 @@
 #import <Nimble/DSL.h>
+#if __has_include("Nimble-Swift.h")
+#import "Nimble-Swift.h"
+#else
 #import <Nimble/Nimble-Swift.h>
+#endif
 
 SWIFT_CLASS("_TtC6Nimble7NMBWait")
 @interface NMBWait : NSObject

--- a/Sources/NimbleObjectiveC/NMBStringify.m
+++ b/Sources/NimbleObjectiveC/NMBStringify.m
@@ -1,5 +1,9 @@
 #import "NMBStringify.h"
+#if __has_include("Nimble-Swift.h")
+#import "Nimble-Swift.h"
+#else
 #import <Nimble/Nimble-Swift.h>
+#endif
 
 NSString *_Nonnull NMBStringify(id _Nullable anyObject) {
     return [NMBStringer stringify:anyObject];


### PR DESCRIPTION
This PR fixes an issue in relation to Cocoapods 1.5. In this new version of Cocoapods, some things have changed in how header files are found. The recommendation from the Cocoapods team seems to be to change the imports to this:

```
#if __has_include("Nimble-Swift.h")
#import "Nimble-Swift.h"
#else
#import <Nimble/Nimble-Swift.h>
#endif
```

I tested this against my app and it seems to work fine with no side-effects. 