### PR TITLE
Refactor `equal` matchers using `switch` and `guard`

### DIFF
--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -7,17 +7,15 @@ import Foundation
 public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
-        let matches = actualValue == expectedValue && expectedValue != nil
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
             return PredicateResult(status: .fail, message: msg)
+        case (let expected?, let actual?):
+            let matches = expected == actual
+            return PredicateResult(bool: matches, message: msg)
         }
-        return PredicateResult(status: PredicateStatus(bool: matches), message: msg)
     }
 }
 
@@ -28,19 +26,15 @@ public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
 public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
             return PredicateResult(status: .fail, message: msg)
+        case (let expected?, let actual?):
+            let matches = expected == actual
+            return PredicateResult(bool: matches, message: msg)
         }
-        return PredicateResult(
-            status: PredicateStatus(bool: expectedValue! == actualValue!),
-            message: msg
-        )
     }
 }
 
@@ -49,61 +43,54 @@ public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]
 public func equal<T: Equatable>(_ expectedValue: [T]?) -> Predicate<[T]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         let actualValue = try actualExpression.evaluate()
-        if expectedValue == nil || actualValue == nil {
-            if expectedValue == nil && actualValue != nil {
-                return PredicateResult(
-                    status: .fail,
-                    message: msg.appendedBeNilHint()
-                )
-            }
-            return PredicateResult(
-                status: .fail,
-                message: msg
-            )
+        switch (expectedValue, actualValue) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
+        case (nil, nil), (_, nil):
+            return PredicateResult(status: .fail, message: msg)
+        case (let expected?, let actual?):
+            let matches = expected == actual
+            return PredicateResult(bool: matches, message: msg)
         }
-        return PredicateResult(
-            bool: expectedValue! == actualValue!,
-            message: msg
-        )
     }
 }
 
 /// A Nimble matcher allowing comparison of collection with optional type
 public func equal<T: Equatable>(_ expectedValue: [T?]) -> Predicate<[T?]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        if let actualValue = try actualExpression.evaluate() {
-            let doesNotMatch = PredicateResult(
-                status: .doesNotMatch,
-                message: msg
-            )
-
-            if expectedValue.count != actualValue.count {
-                return doesNotMatch
-            }
-
-            for (index, item) in actualValue.enumerated() {
-                let otherItem = expectedValue[index]
-                if item == nil && otherItem == nil {
-                    continue
-                } else if item == nil && otherItem != nil {
-                    return doesNotMatch
-                } else if item != nil && otherItem == nil {
-                    return doesNotMatch
-                } else if item! != otherItem! {
-                    return doesNotMatch
-                }
-            }
-
-            return PredicateResult(
-                status: .matches,
-                message: msg
-            )
-        } else {
+        guard let actualValue = try actualExpression.evaluate() else {
             return PredicateResult(
                 status: .fail,
                 message: msg.appendedBeNilHint()
             )
         }
+
+        let doesNotMatch = PredicateResult(
+            status: .doesNotMatch,
+            message: msg
+        )
+
+        if expectedValue.count != actualValue.count {
+            return doesNotMatch
+        }
+
+        for (index, item) in actualValue.enumerated() {
+            let otherItem = expectedValue[index]
+            if item == nil && otherItem == nil {
+                continue
+            } else if item == nil && otherItem != nil {
+                return doesNotMatch
+            } else if item != nil && otherItem == nil {
+                return doesNotMatch
+            } else if item! != otherItem! {
+                return doesNotMatch
+            }
+        }
+
+        return PredicateResult(
+            status: .matches,
+            message: msg
+        )
     }
 }
 
@@ -128,44 +115,45 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
         var errorMessage: ExpectationMessage =
             .expectedActualValueTo("equal <\(stringify(expectedValue))>")
 
-        if let expectedValue = expectedValue {
-            if let actualValue = try actualExpression.evaluate() {
-                errorMessage = .expectedCustomValueTo(
-                    "equal <\(stringify(expectedValue))>",
-                    "<\(stringify(actualValue))>"
-                )
-
-                if expectedValue == actualValue {
-                    return PredicateResult(
-                        status: .matches,
-                        message: errorMessage
-                    )
-                }
-
-                let missing = expectedValue.subtracting(actualValue)
-                if missing.count > 0 {
-                    errorMessage = errorMessage.appended(message: ", missing <\(stringify(missing))>")
-                }
-
-                let extra = actualValue.subtracting(expectedValue)
-                if extra.count > 0 {
-                    errorMessage = errorMessage.appended(message: ", extra <\(stringify(extra))>")
-                }
-                return  PredicateResult(
-                    status: .doesNotMatch,
-                    message: errorMessage
-                )
-            }
-            return PredicateResult(
-                status: .fail,
-                message: errorMessage.appendedBeNilHint()
-            )
-        } else {
+        guard let expectedValue = expectedValue else {
             return PredicateResult(
                 status: .fail,
                 message: errorMessage.appendedBeNilHint()
             )
         }
+
+        guard let actualValue = try actualExpression.evaluate() else {
+            return PredicateResult(
+                status: .fail,
+                message: errorMessage.appendedBeNilHint()
+            )
+        }
+
+        errorMessage = .expectedCustomValueTo(
+            "equal <\(stringify(expectedValue))>",
+            "<\(stringify(actualValue))>"
+        )
+
+        if expectedValue == actualValue {
+            return PredicateResult(
+                status: .matches,
+                message: errorMessage
+            )
+        }
+
+        let missing = expectedValue.subtracting(actualValue)
+        if missing.count > 0 {
+            errorMessage = errorMessage.appended(message: ", missing <\(stringify(missing))>")
+        }
+
+        let extra = actualValue.subtracting(expectedValue)
+        if extra.count > 0 {
+            errorMessage = errorMessage.appended(message: ", extra <\(stringify(extra))>")
+        }
+        return  PredicateResult(
+            status: .doesNotMatch,
+            message: errorMessage
+        )
     }
 }
 


### PR DESCRIPTION
This is just a refactoring and non-functional change.

https://github.com/Quick/Nimble/pull/519/files?w=1