### PR TITLE
Remove `equal` matcher overloads for `[T: C]?` and `[T]?` thanks to Conditional Conformance

### DIFF
--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -19,42 +19,6 @@ public func equal<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-/// A Nimble matcher that succeeds when the actual value is equal to the expected value.
-/// Values can support equal by supporting the Equatable protocol.
-///
-/// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
-public func equal<T, C: Equatable>(_ expectedValue: [T: C]?) -> Predicate<[T: C]> {
-    return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        let actualValue = try actualExpression.evaluate()
-        switch (expectedValue, actualValue) {
-        case (nil, _?):
-            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
-        case (nil, nil), (_, nil):
-            return PredicateResult(status: .fail, message: msg)
-        case (let expected?, let actual?):
-            let matches = expected == actual
-            return PredicateResult(bool: matches, message: msg)
-        }
-    }
-}
-
-/// A Nimble matcher that succeeds when the actual collection is equal to the expected collection.
-/// Items must implement the Equatable protocol.
-public func equal<T: Equatable>(_ expectedValue: [T]?) -> Predicate<[T]> {
-    return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
-        let actualValue = try actualExpression.evaluate()
-        switch (expectedValue, actualValue) {
-        case (nil, _?):
-            return PredicateResult(status: .fail, message: msg.appendedBeNilHint())
-        case (nil, nil), (_, nil):
-            return PredicateResult(status: .fail, message: msg)
-        case (let expected?, let actual?):
-            let matches = expected == actual
-            return PredicateResult(bool: matches, message: msg)
-        }
-    }
-}
-
 /// A Nimble matcher allowing comparison of collection with optional type
 public func equal<T: Equatable>(_ expectedValue: [T?]) -> Predicate<[T?]> {
     return Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in


### PR DESCRIPTION
[SE-0143](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md)

Should be non-functional change.