### PR TITLE
Make Expectation constructor public

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -75,6 +75,10 @@ public struct Expectation<T> {
 
     public let expression: Expression<T>
 
+    public init(expression: Expression<T>) {
+        self.expression = expression
+    }
+
     public func verify(_ pass: Bool, _ message: FailureMessage) {
         let handler = NimbleEnvironment.activeInstance.assertionHandler
         handler.assert(pass, message: message, location: expression.location)


### PR DESCRIPTION
Some libraries (like `RxNimble`) create their own expectations. The [following excerpt from RxNimble](https://github.com/RxSwiftCommunity/RxNimble/blob/602c14aae95db274004cc77ff1779a5feaf6f6fc/Source/Expectation%2BExt.swift#L4-L6) looks like a workaround to the lack of a public constructor:

```
extension Expectation {
    init(_ expression: Expression<T>) {
        self.expression = expression
    }

    // ...
}
```

But in current Swift versions this does not work anymore:

> Initializer for struct 'Expectation<T>' must use "self.init(...)" or "self = ..." because it is not in module 'Nimble'

That of course is not possible as the constructor is not public.

---

Not sure if this should be a patch or minor version bump.