### PR TITLE
🐛Workaround to noescape bug in Xcode 10 beta 1

### DIFF
--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -42,19 +42,20 @@ public class AssertionRecorder: AssertionHandler {
 ///
 /// Once the closure finishes, then the original Nimble assertion handler is restored.
 ///
-/// TEMP: @escaping annotation to closure param is workaround to Radar 40857699
-/// https://openradar.appspot.com/radar?id=5595735974215680
-///
 /// @see AssertionHandler
-public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closure: @escaping () throws -> Void) {
+public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closure: () throws -> Void) {
     let environment = NimbleEnvironment.activeInstance
     let oldRecorder = environment.assertionHandler
     let capturer = NMBExceptionCapture(handler: nil, finally: ({
         environment.assertionHandler = oldRecorder
     }))
     environment.assertionHandler = tempAssertionHandler
-    capturer.tryBlock {
-        try! closure()
+    // TEMP: withoutActuallyEscaping is workaround to Radar 40857699
+    // https://openradar.appspot.com/radar?id=5595735974215680
+    withoutActuallyEscaping(closure) { escapable in
+        capturer.tryBlock {
+            try! escapable()
+        }
     }
 }
 

--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -42,8 +42,11 @@ public class AssertionRecorder: AssertionHandler {
 ///
 /// Once the closure finishes, then the original Nimble assertion handler is restored.
 ///
+/// TEMP: @escaping annotation to closure param is workaround to Radar 40857699
+/// https://openradar.appspot.com/radar?id=5595735974215680
+///
 /// @see AssertionHandler
-public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closure: () throws -> Void) {
+public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closure: @escaping () throws -> Void) {
     let environment = NimbleEnvironment.activeInstance
     let oldRecorder = environment.assertionHandler
     let capturer = NMBExceptionCapture(handler: nil, finally: ({

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.h
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.h
@@ -4,7 +4,14 @@
 @interface NMBExceptionCapture : NSObject
 
 - (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)(void))finally;
-- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
+
+/**
+ TEMP: unsafeBlock should be annotated with __attribute__((noescape)). This was removed
+ as a workaround to Radar 40857699 https://openradar.appspot.com/radar?id=5595735974215680
+
+ @param unsafeBlock Closure to run inside an @try block.
+ */
+- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
 
 @end
 

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.m
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.m
@@ -16,7 +16,7 @@
     return self;
 }
 
-- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock {
+- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock {
     @try {
         unsafeBlock();
     }


### PR DESCRIPTION
When using Xcode 10 beta 1, the test suite crashes with the following exception:

> Thread 1: closure argument passed as @noescape to Objective-C has escaped: file  /Users/phatblat/dev/ios/pods/Nimble/Sources/Nimble/DSL+Wait.swift, line 57, column 38

![crash at capture.tryBlock](https://user-images.githubusercontent.com/909674/41007167-68dd1b2c-68d9-11e8-8313-abbe980eecb6.png)

This is a bug in the Swift runtime checker mistakenly identifying the given `@noescape` closure as escaping. The issue was introduced in #530 and has been logged in 
[rdar://40857699](https://openradar.appspot.com/radar?id=5595735974215680)

This PR applies the workaround suggested by the Apple engineers in the Swift lab at WWDC, which involves removing the `noescape` attribute from the Objective-C side and annotating the closure as `@escaping`. This change is temporary as Apple acknowledged this as a bug, but will allow for Xcode 10 to be used for running tests using Nimble without crashing.