### PR TITLE
Update NimbleXCTestHandler.swift

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -61,7 +61,7 @@ func isXCTestAvailable() -> Bool {
 #endif
 }
 
-private func recordFailure(_ message: String, location: SourceLocation) {
+public func recordFailure(_ message: String, location: SourceLocation) {
 #if SWIFT_PACKAGE
     XCTFail("\(message)", file: location.file, line: location.line)
 #else


### PR DESCRIPTION
change access level for `recordFailure`, which can be used in custom AssertionHandler class.

So I want to have a custom `AssertionHandler` to do some stuff before fail the test. ( like sending some information to server ) 
I created a `AssertionHandler` and set my `NimbleAssertionHandler` as that custom one. I expected to do some stuff in the `AssertionHandler ` function and then see the failure. but apperantly it doesn't fail the test and I have to do it in my custom `AssertionHandler` class.  So I needed to have access to some functions to use `XCTFail` or `recordFailure` for the test case file location. 

So I think we should keep the `recordFailure ` function as public then everyone wants to implement the `AssertionHandler` can call the test failing stuff as well.
