### PR TITLE
[7.x] Update CwlPreconditionTesting and utilize _swift_reportFatalErrorsToDebugger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,18 @@ matrix:
       env: TYPE=macos
       osx_image: xcode9
     - os: osx
+      env: TYPE=macos
+      osx_image: xcode9.1
+    - os: osx
+      env: TYPE=macos
+      osx_image: xcode9.2
+    - os: osx
+      env: TYPE=macos
+      osx_image: xcode9.3
+    - os: osx
+      env: TYPE=macos
+      osx_image: xcode9.4
+    - os: osx
       env: TYPE=swiftpm
     - os: osx
       env: TYPE=swiftpm

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "mattgallagher/CwlPreconditionTesting" "cb7ab89273cfd0725a7a2f865cc6fc560a9b9083"
+github "mattgallagher/CwlPreconditionTesting" "1e62a726d54c743f4585233f08fcaac7307319b5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "mattgallagher/CwlCatchException" "b14c111e9b33cd142bd4bc75c482cfd5c3490923"
-github "mattgallagher/CwlPreconditionTesting" "cb7ab89273cfd0725a7a2f865cc6fc560a9b9083"
+github "mattgallagher/CwlPreconditionTesting" "1e62a726d54c743f4585233f08fcaac7307319b5"

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h
@@ -20,6 +20,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern bool _swift_reportFatalErrorsToDebugger;
+
 //! Project version number for CwlUtils.
 FOUNDATION_EXPORT double CwlPreconditionTestingVersionNumber;
 

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Posix/CwlPreconditionTesting_POSIX.h
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Posix/CwlPreconditionTesting_POSIX.h
@@ -20,6 +20,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern bool _swift_reportFatalErrorsToDebugger;
+
 //! Project version number for CwlUtils.
 FOUNDATION_EXPORT double CwlPreconditionTesting_POSIXVersionNumber;
 

--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -43,11 +43,19 @@ class NimbleXCTestUnavailableHandler: AssertionHandler {
     private(set) var currentTestCase: XCTestCase?
 
     @objc func testCaseWillStart(_ testCase: XCTestCase) {
+        #if swift(>=3.2)
+        _swift_reportFatalErrorsToDebugger = false
+        #endif
+
         currentTestCase = testCase
     }
 
     @objc func testCaseDidFinish(_ testCase: XCTestCase) {
         currentTestCase = nil
+
+        #if swift(>=3.2)
+        _swift_reportFatalErrorsToDebugger = true
+        #endif
     }
 }
 #endif

--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -42,8 +42,11 @@ class NimbleXCTestUnavailableHandler: AssertionHandler {
 
     private(set) var currentTestCase: XCTestCase?
 
+    private var stashed_swift_reportFatalErrorsToDebugger: Bool = false
+
     @objc func testCaseWillStart(_ testCase: XCTestCase) {
         #if swift(>=3.2)
+        stashed_swift_reportFatalErrorsToDebugger = _swift_reportFatalErrorsToDebugger
         _swift_reportFatalErrorsToDebugger = false
         #endif
 
@@ -54,7 +57,7 @@ class NimbleXCTestUnavailableHandler: AssertionHandler {
         currentTestCase = nil
 
         #if swift(>=3.2)
-        _swift_reportFatalErrorsToDebugger = true
+        _swift_reportFatalErrorsToDebugger = stashed_swift_reportFatalErrorsToDebugger
         #endif
     }
 }


### PR DESCRIPTION
Fixes #478. See https://github.com/Quick/Nimble/issues/478#issuecomment-395253950 for the details.