### PR TITLE
Fix code example typo on Writing Your Own Matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,7 +1277,7 @@ public func equal<T: Equatable>(expectedValue: T?) -> Predicate<T> {
     //   Predicate { actual in  ... }
     //
     // But shown with types here for clarity.
-    return Predicate { (actual: Expression<T>) throws -> PredicateResult in
+    return Predicate { (actualExpression: Expression<T>) throws -> PredicateResult in
         let msg = ExpectationMessage.expectedActualValueTo("equal <\(expectedValue)>")
         if let actualValue = try actualExpression.evaluate() {
             return PredicateResult(


### PR DESCRIPTION
The closure parameter is `action`, but the example is using `actualExpression` instead

