### PR TITLE
[7.x] Refactor `match` matcher using `Predicate.define`

### DIFF
--- a/Sources/Nimble/Matchers/Match.swift
+++ b/Sources/Nimble/Matchers/Match.swift
@@ -3,17 +3,16 @@ import Foundation
 /// A Nimble matcher that succeeds when the actual string satisfies the regular expression
 /// described by the expected string.
 public func match(_ expectedValue: String?) -> Predicate<String> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "match <\(stringify(expectedValue))>"
-
+    return Predicate.simple("match <\(stringify(expectedValue))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
             if let regexp = expectedValue {
-                return actual.range(of: regexp, options: .regularExpression) != nil
+                let bool = actual.range(of: regexp, options: .regularExpression) != nil
+                return PredicateStatus(bool: bool)
             }
         }
 
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.