### PR TITLE
Add swift version check for default runloop case name

### DIFF
--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -256,7 +256,11 @@ internal class AwaitPromiseBuilder<T> {
             self.trigger.timeoutSource.resume()
             while self.promise.asyncResult.isIncomplete() {
                 // Stopping the run loop does not work unless we run only 1 mode
+                #if swift(>=4.2)
+                _ = RunLoop.current.run(mode: .default, before: .distantFuture)
+                #else
                 _ = RunLoop.current.run(mode: .defaultRunLoopMode, before: .distantFuture)
+                #endif
             }
 
             self.trigger.timeoutSource.cancel()


### PR DESCRIPTION
Hey there! 

I was playing with `Nimble` on Swift 4.2 and there was only one change needed for my scheme to compile: name change for `default` runloop. 

Note: I was trying to find in the codebase how (or if) do you guys handle backwards compatibility, but couldn't find anything after dropping the support of Swift 3. I've made a single `#if` directive, but I'm happy to update the PR with any given guidelines for these kinds of PRs.
