### PR TITLE
Add noescape attribute to unsafeBlock

### DIFF
--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.m
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.m
@@ -16,7 +16,7 @@
     return self;
 }
 
-- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock {
+- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock {
     @try {
         unsafeBlock();
     }


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
No behavior changed.

 - What code was refactored / updated to support this change?
Only one parameter attribute was added so this project can be compiled with Xcode 10.

 - What issues are related to this PR? Or why was this change introduced?
Can now be compiled with Xcode 10.

Checklist - While not every PR needs it, new features should consider this list:

It's not a new features, the following items are not needed.

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?

