### PR TITLE
[7.x] Refactor `beVoid` matcher using `Predicate.simpleNilable`

### DIFF
--- a/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Sources/Nimble/Matchers/BeVoid.swift
@@ -2,10 +2,9 @@ import Foundation
 
 /// A Nimble matcher that succeeds when the actual value is Void.
 public func beVoid() -> Predicate<()> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be void"
+    return Predicate.simpleNilable("be void") { actualExpression in
         let actualValue: ()? = try actualExpression.evaluate()
-        return actualValue != nil
+        return PredicateStatus(bool: actualValue != nil)
     }
 }
 


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.