### PR TITLE
Swift 4.2 Support - Remove usage of obsolete RunLoop.Mode

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1946,6 +1946,7 @@
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1980,6 +1981,7 @@
 				PRODUCT_NAME = Nimble;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2173,6 +2175,7 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
@@ -2211,6 +2214,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				VALID_ARCHS = x86_64;
 			};
 			name = Release;

--- a/Sources/Nimble/Utils/Async.swift
+++ b/Sources/Nimble/Utils/Async.swift
@@ -261,7 +261,7 @@ internal class AwaitPromiseBuilder<T> {
             self.trigger.timeoutSource.resume()
             while self.promise.asyncResult.isIncomplete() {
                 // Stopping the run loop does not work unless we run only 1 mode
-                _ = RunLoop.current.run(mode: .defaultRunLoopMode, before: .distantFuture)
+                _ = RunLoop.current.run(mode: .default, before: .distantFuture)
             }
 
             self.trigger.timeoutSource.cancel()


### PR DESCRIPTION
### Issue Overview
A build error is thrown when trying to use Nimble in a project using Swift 4.2 + Xcode 10 B2 due to renamed `RunLoop.Mode` constants.

### Changes
- Replaced usage of `RunLoop.Mode.defaultRunLoopMode` with `.default` in `AwaitPromiseBuilder`.

