### PR TITLE
[7.x] Refactor `beGreaterThan` matcher using `Predicate.simple`

### DIFF
--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -13,13 +13,13 @@ public func beGreaterThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
 
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 public func beGreaterThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be greater than <\(stringify(expectedValue))>"
+    let errorMessage = "be greater than <\(stringify(expectedValue))>"
+    return Predicate.simple(errorMessage) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil
             && actualValue!.NMB_compare(expectedValue) == ComparisonResult.orderedDescending
-        return matches
-    }.requireNonNil
+        return PredicateStatus(bool: matches)
+    }
 }
 
 public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) {


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.