### PR TITLE
Revert "🐛Workaround to noescape bug in Xcode 10 beta 1"

### DIFF
--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -50,12 +50,8 @@ public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closu
         environment.assertionHandler = oldRecorder
     }))
     environment.assertionHandler = tempAssertionHandler
-    // TEMP: withoutActuallyEscaping is workaround to Radar 40857699
-    // https://openradar.appspot.com/radar?id=5595735974215680
-    withoutActuallyEscaping(closure) { escapable in
-        capturer.tryBlock {
-            try! escapable()
-        }
+    capturer.tryBlock {
+        try! closure()
     }
 }
 

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.h
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.h
@@ -4,14 +4,7 @@
 @interface NMBExceptionCapture : NSObject
 
 - (nonnull instancetype)initWithHandler:(void(^ _Nullable)(NSException * _Nonnull))handler finally:(void(^ _Nullable)(void))finally;
-
-/**
- TEMP: unsafeBlock should be annotated with __attribute__((noescape)). This was removed
- as a workaround to Radar 40857699 https://openradar.appspot.com/radar?id=5595735974215680
-
- @param unsafeBlock Closure to run inside an @try block.
- */
-- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
+- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock NS_SWIFT_NAME(tryBlock(_:));
 
 @end
 

--- a/Sources/NimbleObjectiveC/NMBExceptionCapture.m
+++ b/Sources/NimbleObjectiveC/NMBExceptionCapture.m
@@ -16,7 +16,7 @@
     return self;
 }
 
-- (void)tryBlock:(void(^ _Nonnull)(void))unsafeBlock {
+- (void)tryBlock:(__attribute__((noescape)) void(^ _Nonnull)(void))unsafeBlock {
     @try {
         unsafeBlock();
     }


### PR DESCRIPTION
Reverts Quick/Nimble#537

The underlying issue seems to be fixed in Xcode 10 beta 3. See https://github.com/Quick/Nimble/pull/537#issuecomment-402522713 for the details.