### PR TITLE
[7.x] Refactor `beGreaterThanOrEqualTo` matcher using `Predicate.simple`

### DIFF
--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -3,25 +3,25 @@ import Foundation
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be greater than or equal to <\(stringify(expectedValue))>"
+    let message = "be greater than or equal to <\(stringify(expectedValue))>"
+    return Predicate.simple(message) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         if let actual = actualValue, let expected = expectedValue {
-            return actual >= expected
+            return PredicateStatus(bool: actual >= expected)
         }
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be greater than or equal to <\(stringify(expectedValue))>"
+    let message = "be greater than or equal to <\(stringify(expectedValue))>"
+    return Predicate.simple(message) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) != ComparisonResult.orderedAscending
-        return matches
-    }.requireNonNil
+        return PredicateStatus(bool: matches)
+    }
 }
 
 public func >=<T: Comparable>(lhs: Expectation<T>, rhs: T) {


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.