### PR TITLE
[7.x] Refactor `satisfyAnyOf` matcher using `Matcher.predicate`

### DIFF
--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -4,33 +4,11 @@ import Foundation
 /// provided in the variable list of matchers. 
 public func satisfyAnyOf<T, U>(_ matchers: U...) -> Predicate<T>
     where U: Matcher, U.ValueType == T {
-    return satisfyAnyOf(matchers)
-}
-
-/// Deprecated. Please use `satisfyAnyOf<T>(_) -> Predicate<T>` instead.
-internal func satisfyAnyOf<T, U>(_ matchers: [U]) -> Predicate<T>
-    where U: Matcher, U.ValueType == T {
-        return NonNilMatcherFunc<T> { actualExpression, failureMessage in
-            let postfixMessages = NSMutableArray()
-            var matches = false
-            for matcher in matchers {
-                if try matcher.matches(actualExpression, failureMessage: failureMessage) {
-                    matches = true
-                }
-                postfixMessages.add(NSString(string: "{\(failureMessage.postfixMessage)}"))
-            }
-
-            failureMessage.postfixMessage = "match one of: " + postfixMessages.componentsJoined(by: ", or ")
-            if let actualValue = try actualExpression.evaluate() {
-                failureMessage.actualValue = "\(actualValue)"
-            }
-
-            return matches
-        }.predicate
+        return satisfyAnyOf(matchers.map { $0.predicate })
 }
 
 internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
-        return Predicate { actualExpression in
+        return Predicate.define { actualExpression in
             var postfixMessages = [String]()
             var matches = false
             for predicate in predicates {
@@ -53,11 +31,8 @@ internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
                 )
             }
 
-            return PredicateResult(
-                status: PredicateStatus(bool: matches),
-                message: msg
-            )
-        }.requireNonNil
+            return PredicateResult(bool: matches, message: msg)
+        }
 }
 
 public func || <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {


### PR DESCRIPTION
By the change we can remove `internal func satisfyAnyOf<T, U>(_ matchers: [U]) -> Predicate<T> where U: Matcher, U.ValueType == T`.