### PR TITLE
[7.x] Refactor `beLessThanOrEqualTo` matcher using `Predicate.simple`

### DIFF
--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -3,23 +3,22 @@ import Foundation
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 public func beLessThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be less than or equal to <\(stringify(expectedValue))>"
+    return Predicate.simple("be less than or equal to <\(stringify(expectedValue))>") { actualExpression in
         if let actual = try actualExpression.evaluate(), let expected = expectedValue {
-            return actual <= expected
+            return PredicateStatus(bool: actual <= expected)
         }
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "be less than or equal to <\(stringify(expectedValue))>"
+    return Predicate.simple("be less than or equal to <\(stringify(expectedValue))>") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        return actualValue != nil && actualValue!.NMB_compare(expectedValue) != ComparisonResult.orderedDescending
-    }.requireNonNil
+        let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) != .orderedDescending
+        return PredicateStatus(bool: matches)
+    }
 }
 
 public func <=<T: Comparable>(lhs: Expectation<T>, rhs: T) {

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -16,7 +16,7 @@ public func beLessThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predicate
 public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
     return Predicate.simple("be less than or equal to <\(stringify(expectedValue))>") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) != .orderedDescending
+        let matches = actualValue.map { $0.NMB_compare(expectedValue) != .orderedDescending } ?? false
         return PredicateStatus(bool: matches)
     }
 }


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.