### PR TITLE
[7.x] Refactor `contain` matcher using `Predicate.simple`

### DIFF
--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -8,15 +8,15 @@ public func contain<S: Sequence, T: Equatable>(_ items: T...) -> Predicate<S>
 
 public func contain<S: Sequence, T: Equatable>(_ items: [T]) -> Predicate<S>
     where S.Iterator.Element == T {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
+    return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            return items.all {
+            let matches = items.all {
                 return actual.contains($0)
             }
+            return PredicateStatus(bool: matches)
         }
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual string contains the expected substring.
@@ -25,16 +25,16 @@ public func contain(_ substrings: String...) -> Predicate<String> {
 }
 
 public func contain(_ substrings: [String]) -> Predicate<String> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
+    return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            return substrings.all {
+            let matches = substrings.all {
                 let range = actual.range(of: $0)
                 return range != nil && !range!.isEmpty
             }
+            return PredicateStatus(bool: matches)
         }
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual string contains the expected substring.
@@ -43,13 +43,13 @@ public func contain(_ substrings: NSString...) -> Predicate<NSString> {
 }
 
 public func contain(_ substrings: [NSString]) -> Predicate<NSString> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "contain <\(arrayAsString(substrings))>"
+    return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         if let actual = try actualExpression.evaluate() {
-            return substrings.all { actual.range(of: $0.description).length != 0 }
+            let matches = substrings.all { actual.range(of: $0.description).length != 0 }
+            return PredicateStatus(bool: matches)
         }
-        return false
-    }.requireNonNil
+        return .fail
+    }
 }
 
 /// A Nimble matcher that succeeds when the actual collection contains the expected object.
@@ -58,13 +58,13 @@ public func contain(_ items: Any?...) -> Predicate<NMBContainer> {
 }
 
 public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "contain <\(arrayAsString(items))>"
-        guard let actual = try actualExpression.evaluate() else { return false }
-        return items.all { item in
+    return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
+        guard let actual = try actualExpression.evaluate() else { return .fail }
+        let matches = items.all { item in
             return item != nil && actual.contains(item!)
         }
-    }.requireNonNil
+        return PredicateStatus(bool: matches)
+    }
 }
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -61,7 +61,7 @@ public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         let matches = items.all { item in
-            return item != nil && actual.contains(item!)
+            return item.map { actual.contains($0) } ?? false
         }
         return PredicateStatus(bool: matches)
     }


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.