### PR TITLE
[7.x] Refactor `throwAssertion` matcher using `Predicate.init`

### DIFF
--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -5,7 +5,7 @@ public func throwAssertion() -> Predicate<Void> {
     #if arch(x86_64) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
         let message = ExpectationMessage.expectedTo("throw an assertion")
 
-        var actualError: Error? = nil
+        var actualError: Error?
         let caughtException: BadInstructionException? = catchBadInstruction {
             #if os(tvOS)
                 if !NimbleEnvironment.activeInstance.suppressTVOSAssertionWarning {

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -35,9 +35,9 @@ public func throwAssertion() -> Predicate<Void> {
                 bool: false,
                 message: message.appended(message: "; threw error instead <\(actualError)>")
             )
+        } else {
+            return PredicateResult(bool: caughtException != nil, message: message)
         }
-
-        return PredicateResult(bool: caughtException != nil, message: message)
     #elseif SWIFT_PACKAGE
         fatalError("The throwAssertion Nimble matcher does not currently support Swift CLI." +
             " You can silence this error by placing the test case inside an #if !SWIFT_PACKAGE" +

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -1,13 +1,11 @@
 import Foundation
 
 public func throwAssertion() -> Predicate<Void> {
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+    return Predicate { actualExpression in
     #if arch(x86_64) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
-        failureMessage.postfixMessage = "throw an assertion"
-        failureMessage.actualValue = nil
+        let message = ExpectationMessage.expectedTo("throw an assertion")
 
-        var succeeded = true
-
+        var actualError: Error? = nil
         let caughtException: BadInstructionException? = catchBadInstruction {
             #if os(tvOS)
                 if !NimbleEnvironment.activeInstance.suppressTVOSAssertionWarning {
@@ -27,21 +25,19 @@ public func throwAssertion() -> Predicate<Void> {
             #endif
             do {
                 try actualExpression.evaluate()
-            } catch let error {
-                succeeded = false
-                failureMessage.postfixMessage += "; threw error instead <\(error)>"
+            } catch {
+                actualError = error
             }
         }
 
-        if !succeeded {
-            return false
+        if let actualError = actualError {
+            return PredicateResult(
+                bool: false,
+                message: message.appended(message: "; threw error instead <\(actualError)>")
+            )
         }
 
-        if caughtException == nil {
-            return false
-        }
-
-        return true
+        return PredicateResult(bool: caughtException != nil, message: message)
     #elseif SWIFT_PACKAGE
         fatalError("The throwAssertion Nimble matcher does not currently support Swift CLI." +
             " You can silence this error by placing the test case inside an #if !SWIFT_PACKAGE" +

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -4,6 +4,8 @@ import Nimble
 
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 
+private let error: Error = NSError(domain: "test", code: 0, userInfo: nil)
+
 final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
     static var allTests: [(String, (ThrowAssertionTest) -> () throws -> Void)] {
         return [
@@ -21,7 +23,7 @@ final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
     }
 
     func testErrorThrown() {
-        expect { throw NSError(domain: "test", code: 0, userInfo: nil) }.toNot(throwAssertion())
+        expect { throw error }.toNot(throwAssertion())
     }
 
     func testPostAssertionCodeNotRun() {
@@ -49,6 +51,10 @@ final class ThrowAssertionTest: XCTestCase, XCTestCaseProvider {
     func testPositiveMessage() {
         failsWithErrorMessage("expected to throw an assertion") {
             expect { () -> Void? in return }.to(throwAssertion())
+        }
+
+        failsWithErrorMessage("expected to throw an assertion; threw error instead <\(error)>") {
+            expect { throw error }.to(throwAssertion())
         }
     }
 


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.