### PR TITLE
[7.x] Refactor `postNotifications` matcher using `Predicate.init`

### DIFF
--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -74,7 +74,8 @@ public func postNotifications<T>(
     let collector = NotificationCollector(notificationCenter: center)
     collector.startObserving()
     var once: Bool = false
-    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
+
+    return Predicate { actualExpression in
         let collectorNotificationsExpression = Expression(memoizedExpression: { _ in
             return collector.observedNotifications
             }, location: actualExpression.location, withoutCaching: true)
@@ -85,12 +86,13 @@ public func postNotifications<T>(
             _ = try actualExpression.evaluate()
         }
 
+        let failureMessage = FailureMessage()
         let match = try notificationsMatcher.matches(collectorNotificationsExpression, failureMessage: failureMessage)
         if collector.observedNotifications.isEmpty {
             failureMessage.actualValue = "no notifications"
         } else {
             failureMessage.actualValue = "<\(stringify(collector.observedNotifications))>"
         }
-        return match
+        return PredicateResult(bool: match, message: failureMessage.toExpectationMessage())
     }
 }


### PR DESCRIPTION
Replacing `Predicate.fromDeprecatedClosure`.