### PR TITLE
[7.x] The `closure` parameters of `failsWithErrorMessage` and `gatherExpectations` are `noescape` now

### DIFF
--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -65,7 +65,7 @@ public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler, closu
 ///                 assertion handler when this is true. Defaults to false.
 ///
 /// @see gatherFailingExpectations
-public func gatherExpectations(silently: Bool = false, closure: @escaping () -> Void) -> [AssertionRecord] {
+public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let previousRecorder = NimbleEnvironment.activeInstance.assertionHandler
     let recorder = AssertionRecorder()
     let handlers: [AssertionHandler]
@@ -92,7 +92,7 @@ public func gatherExpectations(silently: Bool = false, closure: @escaping () -> 
 ///
 /// @see gatherExpectations
 /// @see raiseException source for an example use case.
-public func gatherFailingExpectations(silently: Bool = false, closure: @escaping () -> Void) -> [AssertionRecord] {
+public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let assertions = gatherExpectations(silently: silently, closure: closure)
     return assertions.filter { assertion in
         !assertion.success

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import Nimble
 import XCTest
 
-func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () throws -> Void) {
+func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
 
@@ -45,7 +45,7 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
     }
 }
 
-func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () -> Void) {
+func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     return failsWithErrorMessage(
         [message],
         file: file,
@@ -55,7 +55,7 @@ func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UI
     )
 }
 
-func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: @escaping () -> Void) {
+func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
@@ -68,15 +68,15 @@ func deferToMainQueue(action: @escaping () -> Void) {
 
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
 public class NimbleHelper: NSObject {
-    @objc public class func expectFailureMessage(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
+    @objc public class func expectFailureMessage(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(String(describing: message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    @objc public class func expectFailureMessages(_ messages: [NSString], block: @escaping () -> Void, file: FileString, line: UInt) {
+    @objc public class func expectFailureMessages(_ messages: [NSString], block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(messages.map({String(describing: $0)}), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 
-    @objc public class func expectFailureMessageForNil(_ message: NSString, block: @escaping () -> Void, file: FileString, line: UInt) {
+    @objc public class func expectFailureMessageForNil(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessageForNil(String(describing: message), file: file, line: line, preferOriginalSourceLocation: true, closure: block)
     }
 }


### PR DESCRIPTION
Just a minor refactoring.