### PR TITLE
[7.x] Fix `ExpectationMessage.update(failureMessage:)` not to update a `FailureMessage` instance with empty string

### DIFF
--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -152,8 +152,10 @@ public indirect enum ExpectationMessage {
     // Backwards compatibility: converts ExpectationMessage tree to FailureMessage
     internal func update(failureMessage: FailureMessage) {
         switch self {
-        case let .fail(msg):
+        case let .fail(msg) where !msg.isEmpty:
             failureMessage.stringValue = msg
+        case .fail:
+            break
         case let .expectedTo(msg):
             failureMessage.actualValue = nil
             failureMessage.postfixMessage = msg

--- a/Tests/NimbleTests/SynchronousTests.swift
+++ b/Tests/NimbleTests/SynchronousTests.swift
@@ -16,6 +16,7 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
             ("testToNotProvidesActualValueExpression", testToNotProvidesActualValueExpression),
             ("testToNotProvidesAMemoizedActualValueExpression", testToNotProvidesAMemoizedActualValueExpression),
             ("testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl", testToNotProvidesAMemoizedActualValueExpressionIsEvaluatedAtMatcherControl),
+            ("testToNegativeMatches", testToNegativeMatches),
             ("testToNotNegativeMatches", testToNotNegativeMatches),
             ("testNotToMatchesLikeToNot", testNotToMatchesLikeToNot),
         ]
@@ -114,6 +115,15 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
             return false
         })
         expect(callCount).to(equal(1))
+    }
+
+    func testToNegativeMatches() {
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(MatcherFunc { _, _ in false })
+        }
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(MatcherFunc { _, _ in false }.predicate)
+        }
     }
 
     func testToNotNegativeMatches() {

--- a/Tests/NimbleTests/SynchronousTests.swift
+++ b/Tests/NimbleTests/SynchronousTests.swift
@@ -130,6 +130,9 @@ final class SynchronousTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to not match, got <1>") {
             expect(1).toNot(MatcherFunc { _, _ in true })
         }
+        failsWithErrorMessage("expected to not match, got <1>") {
+            expect(1).toNot(MatcherFunc { _, _ in true }.predicate)
+        }
     }
 
     func testNotToMatchesLikeToNot() {


### PR DESCRIPTION
The followings is the previous (problematic) behavior:

- `FailureMessage().toExpectationMessage()` will be `ExpectationMessage.fail("")`
- `ExpectationMessage.fail("").update(failureMessage: aMessage)` will set `aMessage.stringValue = ""`
- Thus the error message of `expect(1).to(MatcherFunc { _, _ in false }.predicate)` will be empty
