### PR TITLE
[7.x ][containElementSatisfyingMatcher] Using `postfixMessage` would be preferable instead of overwriting `to`

### DIFF
--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -50,8 +50,7 @@ public func containElementSatisfying<S: Sequence, T>(_ predicate: @escaping ((T)
                 }
 
                 failureMessage.actualValue = nil
-                failureMessage.postfixMessage = ""
-                failureMessage.to = "to find object in collection that satisfies predicate"
+                failureMessage.postfixMessage = "find object in collection that satisfies predicate"
                 return false
             }
         }


### PR DESCRIPTION
The previous implementation is problematic when used with `FailureMessage.toExpectationMessage()`.

The error message in that case is not `expected to find object in collection that satisfies predicate` but `expected to`.

- https://github.com/Quick/Nimble/blob/b14479988a12eb784c1575243af58f30980265bb/Sources/Nimble/Matchers/ContainElementSatisfying.swift#L52-L54
- https://github.com/Quick/Nimble/blob/b14479988a12eb784c1575243af58f30980265bb/Sources/Nimble/ExpectationMessage.swift#L194-L200

```
.expectedTo("") // This is not what we want!
```