### PR TITLE
[7.x] Replace `expressionMatches` with `execute` in `to` and `toEventually`

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -1,24 +1,6 @@
 import Foundation
 
 // Deprecated
-internal func expressionMatches<T, U>(_ expression: Expression<T>, matcher: U, to: String, description: String?) -> (Bool, FailureMessage)
-    where U: Matcher, U.ValueType == T {
-    let msg = FailureMessage()
-    msg.userDescription = description
-    msg.to = to
-    do {
-        let pass = try matcher.matches(expression, failureMessage: msg)
-        if msg.actualValue == "" {
-            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
-        }
-        return (pass, msg)
-    } catch let error {
-        msg.stringValue = "unexpected error thrown: <\(error)>"
-        return (false, msg)
-    }
-}
-
-// Deprecated
 internal func expressionDoesNotMatch<T, U>(_ expression: Expression<T>, matcher: U, toNot: String, description: String?) -> (Bool, FailureMessage)
     where U: Matcher, U.ValueType == T {
     let msg = FailureMessage()
@@ -89,8 +71,15 @@ public struct Expectation<T> {
     /// DEPRECATED: Tests the actual value using a matcher to match.
     public func to<U>(_ matcher: U, description: String? = nil)
         where U: Matcher, U.ValueType == T {
-        let (pass, msg) = expressionMatches(expression, matcher: matcher, to: "to", description: description)
-        verify(pass, msg)
+            let (pass, msg) = execute(
+                expression,
+                .toMatch,
+                matcher.predicate,
+                to: "to",
+                description: description,
+                captureExceptions: false
+            )
+            verify(pass, msg)
     }
 
     /// DEPRECATED: Tests the actual value using a matcher to not match.

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -113,9 +113,10 @@ extension Expectation {
     public func toEventually<U>(_ matcher: U, timeout: TimeInterval = AsyncDefaults.Timeout, pollInterval: TimeInterval = AsyncDefaults.PollInterval, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         if expression.isClosure {
-            let (pass, msg) = expressionMatches(
+            let (pass, msg) = execute(
                 expression,
-                matcher: async(
+                .toMatch,
+                async(
                     style: .toMatch,
                     predicate: matcher.predicate,
                     timeout: timeout,
@@ -123,7 +124,8 @@ extension Expectation {
                     fnName: "toEventually"
                 ),
                 to: "to eventually",
-                description: description
+                description: description,
+                captureExceptions: false
             )
             verify(pass, msg)
         } else {


### PR DESCRIPTION
This is based on the works in #587 and #588.