### PR TITLE
[7.x] Update NimbleXCTestHandler.swift

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -72,7 +72,7 @@ func isXCTestAvailable() -> Bool {
 #endif
 }
 
-private func recordFailure(_ message: String, location: SourceLocation) {
+public func recordFailure(_ message: String, location: SourceLocation) {
 #if SWIFT_PACKAGE
     XCTFail("\(message)", file: location.file, line: location.line)
 #else


### PR DESCRIPTION
Cherry-picks #543 into `7.x-branch`.

https://github.com/Quick/Nimble/issues/598#issuecomment-417991134

---

Make `recordFailure` public, which is useful for defining a custom `AssertionHandler`.