### PR TITLE
Fix forcefullyAbortTimeout for toEventually usage

### DIFF
--- a/Sources/Nimble/Utils/Await.swift
+++ b/Sources/Nimble/Utils/Await.swift
@@ -369,7 +369,7 @@ internal func pollBlock(
                 return true
             }
             return nil
-        }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval / 2.0).wait(fnName, file: file, line: line)
+        }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval * 2.0).wait(fnName, file: file, line: line)
 
         return result
 }


### PR DESCRIPTION
Change forcefullyAbortTimeout in pollBlock

because when I fully testing need to time more than 10 seconds with timeout like 12 or 14
sometimes blocked all testing infinitely ( maybe 6 or 7 I guess seconds after forcefullyaborted)

```swift
// as is
internal func pollBlock(
    pollInterval: TimeInterval,
    timeoutInterval: TimeInterval,
    file: FileString,
    line: UInt,
    fnName: String = #function,
    expression: @escaping () throws -> Bool) -> AwaitResult<Bool> {
        print("@@ poll block", timeoutInterval)
        let awaiter = NimbleEnvironment.activeInstance.awaiter
        let result = awaiter.poll(pollInterval) { () throws -> Bool? in
            if try expression() {
                return true
            }
            return nil
        }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval / 2).wait(fnName, file: file, line: line)

        return result
}

// to be
internal func pollBlock(
    pollInterval: TimeInterval,
    timeoutInterval: TimeInterval,
    file: FileString,
    line: UInt,
    fnName: String = #function,
    expression: @escaping () throws -> Bool) -> AwaitResult<Bool> {
        print("@@ poll block", timeoutInterval)
        let awaiter = NimbleEnvironment.activeInstance.awaiter
        let result = awaiter.poll(pollInterval) { () throws -> Bool? in
            if try expression() {
                return true
            }
            return nil
        }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval * 2.0).wait(fnName, file: file, line: line)

        return result
}

```

Checklist - While not every PR needs it, new features should consider this list:

