### PR TITLE
[7.x][Predicate] Override `NSObject.hash` over `Hashable.hashValue`

### DIFF
--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -311,7 +311,7 @@ final public class NMBPredicateStatus: NSObject {
     public static let doesNotMatch: NMBPredicateStatus = NMBPredicateStatus(status: 1)
     public static let fail: NMBPredicateStatus = NMBPredicateStatus(status: 2)
 
-    public override var hashValue: Int { return self.status.hashValue }
+    public override var hash: Int { return self.status.hashValue }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let otherPredicate = object as? NMBPredicateStatus else {


### PR DESCRIPTION
Closes #625.

This had been addressed on master by https://github.com/Quick/Nimble/pull/604.