### PR TITLE
[podspec] Remove duplicate swift_version setting

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/Quick/Nimble"
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }
   s.author       = "Quick Contributors"
-  s.swift_version = '4.0'
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"


### PR DESCRIPTION
Refs:
- https://github.com/Quick/Nimble/pull/515
- https://github.com/Quick/Nimble/pull/628

The setting is overwritten with `'4.2'`: https://github.com/Quick/Nimble/blob/fa4811ef4d305d6d878ed77421e8bb80d82e911a/Nimble.podspec#L54-L55