### PR TITLE
[7.x] fix escaping closure crash within Xcode 10

### DIFF
--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -89,11 +89,17 @@ internal class NMBWait: NSObject {
 
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && !SWIFT_PACKAGE
     @objc(untilFile:line:action:)
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
+    internal class func until(
+        _ file: FileString = #file,
+        line: UInt = #line,
+        action: @escaping (@escaping () -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
 #else
-    internal class func until(_ file: FileString = #file, line: UInt = #line, action: @escaping (() -> Void) -> Void) {
+    internal class func until(
+        _ file: FileString = #file,
+        line: UInt = #line,
+        action: @escaping (@escaping () -> Void) -> Void) {
         until(timeout: 1, file: file, line: line, action: action)
     }
 #endif

--- a/Tests/NimbleTests/objc/ObjCAsyncTest.m
+++ b/Tests/NimbleTests/objc/ObjCAsyncTest.m
@@ -29,6 +29,11 @@
     waitUntil(^(void (^done)(void)){
         done();
     });
+    waitUntil(^(void (^done)(void)){
+        dispatch_async(dispatch_get_main_queue(), ^{
+            done();
+        });
+    });
 
     expectFailureMessage(@"Waited more than 1.0 second", ^{
         waitUntil(^(void (^done)(void)){ /* ... */ });


### PR DESCRIPTION
Cherry-picks #612 into `7.x-branch`.