### PR TITLE
Fix `beEmpty` and `contain` matcher ambiguity for some types which conform to both Sequence and SetAlgebra

### DIFF
--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -4,11 +4,10 @@ import Foundation
 /// means the are no items in that collection. For strings, it is an empty string.
 public func beEmpty<S: Sequence>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
-        let actualSeq = try actualExpression.evaluate()
-        if actualSeq == nil {
+        guard let actual = try actualExpression.evaluate() else {
             return .fail
         }
-        var generator = actualSeq!.makeIterator()
+        var generator = actual.makeIterator()
         return PredicateStatus(bool: generator.next() == nil)
     }
 }
@@ -16,6 +15,17 @@ public func beEmpty<S: Sequence>() -> Predicate<S> {
 /// A Nimble matcher that succeeds when a value is "empty". For collections, this
 /// means the are no items in that collection. For strings, it is an empty string.
 public func beEmpty<S: SetAlgebra>() -> Predicate<S> {
+    return Predicate.simple("be empty") { actualExpression in
+        guard let actual = try actualExpression.evaluate() else {
+            return .fail
+        }
+        return PredicateStatus(bool: actual.isEmpty)
+    }
+}
+
+/// A Nimble matcher that succeeds when a value is "empty". For collections, this
+/// means the are no items in that collection. For strings, it is an empty string.
+public func beEmpty<S: Sequence & SetAlgebra>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else {
             return .fail

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -40,6 +40,26 @@ public func contain<S: SetAlgebra, T: Equatable>(_ items: [T]) -> Predicate<S>
         }
 }
 
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: Sequence & SetAlgebra, T: Equatable>(_ items: T...) -> Predicate<S>
+    where S.Element == T {
+        return contain(items)
+}
+
+/// A Nimble matcher that succeeds when the actual set contains the expected values.
+public func contain<S: Sequence & SetAlgebra, T: Equatable>(_ items: [T]) -> Predicate<S>
+    where S.Element == T {
+        return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
+            if let actual = try actualExpression.evaluate() {
+                let matches = items.allSatisfy {
+                    return actual.contains($0)
+                }
+                return PredicateStatus(bool: matches)
+            }
+            return .fail
+        }
+}
+
 /// A Nimble matcher that succeeds when the actual string contains the expected substring.
 public func contain(_ substrings: String...) -> Predicate<String> {
     return contain(substrings)

--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -10,6 +10,9 @@ final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         expect([] as [CInt]).to(beEmpty())
         expect([1] as [CInt]).toNot(beEmpty())
 
+        expect([] as Set<Int>).to(beEmpty())
+        expect([1] as Set<Int>).toNot(beEmpty())
+
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         expect(NSDictionary() as? [Int: Int]).to(beEmpty())
         expect(NSDictionary(object: 1, forKey: 1 as NSNumber) as? [Int: Int]).toNot(beEmpty())
@@ -45,6 +48,13 @@ final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         }
         failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())
+        }
+
+        failsWithErrorMessage("expected to not be empty, got <Set([])>") {
+            expect([] as Set<Int>).toNot(beEmpty())
+        }
+        failsWithErrorMessage("expected to be empty, got <Set([1])>") {
+            expect([1] as Set<Int>).to(beEmpty())
         }
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -91,6 +101,13 @@ final class BeEmptyTest: XCTestCase, XCTestCaseProvider {
         }
         failsWithErrorMessageForNil("expected to not be empty, got <nil>") {
             expect(nil as [CInt]?).toNot(beEmpty())
+        }
+
+        failsWithErrorMessageForNil("expected to be empty, got <nil>") {
+            expect(nil as Set<Int>?).to(beEmpty())
+        }
+        failsWithErrorMessageForNil("expected to not be empty, got <nil>") {
+            expect(nil as Set<Int>?).toNot(beEmpty())
         }
 
         failsWithErrorMessageForNil("expected to be empty, got <nil>") {

--- a/Tests/NimbleTests/Matchers/ContainTest.swift
+++ b/Tests/NimbleTests/Matchers/ContainTest.swift
@@ -50,6 +50,27 @@ final class ContainTest: XCTestCase, XCTestCaseProvider {
         }
     }
 
+    func testContainSequenceAndSetAlgebra() {
+        let set = [1, 2, 3] as Set<Int>
+
+        expect(set).to(contain(1))
+        expect(set).toNot(contain(4))
+
+        failsWithErrorMessage("expected to contain <4>, got <\(set.debugDescription)>") {
+            expect(set).to(contain(4))
+        }
+        failsWithErrorMessage("expected to not contain <2>, got <\(set.debugDescription)>") {
+            expect(set).toNot(contain(2))
+        }
+
+        failsWithErrorMessageForNil("expected to contain <1>, got <nil>") {
+            expect(nil as Set<Int>?).to(contain(1))
+        }
+        failsWithErrorMessageForNil("expected to not contain <1>, got <nil>") {
+            expect(nil as Set<Int>?).toNot(contain(1))
+        }
+    }
+
     func testContainSubstring() {
         expect("foo").to(contain("o"))
         expect("foo").to(contain("oo"))

--- a/Tests/NimbleTests/XCTestManifests.swift
+++ b/Tests/NimbleTests/XCTestManifests.swift
@@ -202,6 +202,7 @@ extension ContainTest {
         ("testCollectionArguments", testCollectionArguments),
         ("testContainObjCSubstring", testContainObjCSubstring),
         ("testContainSequence", testContainSequence),
+        ("testContainSequenceAndSetAlgebra", testContainSequenceAndSetAlgebra),
         ("testContainSetAlgebra", testContainSetAlgebra),
         ("testContainSubstring", testContainSubstring),
         ("testVariadicArguments", testVariadicArguments),


### PR DESCRIPTION
Fixes #638.

The issue is due to #594 and #609.