### PR TITLE
Update Package.swift to support Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,11 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "Nimble",
+    platforms: [
+      .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
+    ],
     products: [
         .library(name: "Nimble", targets: ["Nimble"]),
     ],
@@ -17,5 +20,5 @@ let package = Package(
             exclude: ["objc"]
         ),
     ],
-    swiftLanguageVersions: [.v4_2]
+    swiftLanguageVersions: [.v5]
 )

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Nimble",
+    products: [
+        .library(name: "Nimble", targets: ["Nimble"]),
+    ],
+    targets: [
+        .target(
+            name: "Nimble", 
+            dependencies: []
+        ),
+        .testTarget(
+            name: "NimbleTests", 
+            dependencies: ["Nimble"], 
+            exclude: ["objc"]
+        ),
+    ],
+    swiftLanguageVersions: [.v4_2]
+)


### PR DESCRIPTION
As upgrading to Swift 5, without having `platforms` the default deployment target is set to the latest version of each OS. It causes a compile error.

* Add `platforms`
* Add `.v5` to `swiftLanguageVersions`

(The description is same with https://github.com/Quick/Quick/pull/843)