### PR TITLE
Update Nimble.podspec

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -51,5 +51,5 @@ Pod::Spec.new do |s|
   }
 
   s.cocoapods_version = '>= 1.4.0'
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
 end


### PR DESCRIPTION
Updated podspec to specify swift_version = 5.0. So that Xcode doesn't prompt you to migrate. 
(No real code changes)
