### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 // Deprecated
+@available(*, deprecated)
 internal func expressionDoesNotMatch<T, U>(_ expression: Expression<T>, matcher: U, toNot: String, description: String?) -> (Bool, FailureMessage)
     where U: Matcher, U.ValueType == T {
     let msg = FailureMessage()
@@ -69,6 +70,7 @@ public struct Expectation<T> {
     ////////////////// OLD API /////////////////////
 
     /// DEPRECATED: Tests the actual value using a matcher to match.
+    @available(*, deprecated)
     public func to<U>(_ matcher: U, description: String? = nil)
         where U: Matcher, U.ValueType == T {
             let (pass, msg) = execute(
@@ -83,6 +85,7 @@ public struct Expectation<T> {
     }
 
     /// DEPRECATED: Tests the actual value using a matcher to not match.
+    @available(*, deprecated)
     public func toNot<U>(_ matcher: U, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         // swiftlint:disable:next line_length
@@ -93,6 +96,7 @@ public struct Expectation<T> {
     /// DEPRECATED: Tests the actual value using a matcher to not match.
     ///
     /// Alias to toNot().
+    @available(*, deprecated)
     public func notTo<U>(_ matcher: U, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         toNot(matcher, description: description)

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -18,6 +18,7 @@ public func allPass<T, U>
         return createPredicate(matcher)
 }
 
+@available(*, deprecated)
 public func allPass<S, M>(_ elementMatcher: M) -> Predicate<S>
     where S: Sequence, M: Matcher, S.Iterator.Element == M.ValueType {
         return createPredicate(elementMatcher.predicate)

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -116,6 +116,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    @available(*, deprecated)
     public func toEventually<U>(_ matcher: U, timeout: TimeInterval = AsyncDefaults.Timeout, pollInterval: TimeInterval = AsyncDefaults.PollInterval, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         if expression.isClosure {
@@ -145,6 +146,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    @available(*, deprecated)
     public func toEventuallyNot<U>(_ matcher: U, timeout: TimeInterval = AsyncDefaults.Timeout, pollInterval: TimeInterval = AsyncDefaults.PollInterval, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         if expression.isClosure {
@@ -174,6 +176,7 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    @available(*, deprecated)
     public func toNotEventually<U>(_ matcher: U, timeout: TimeInterval = AsyncDefaults.Timeout, pollInterval: TimeInterval = AsyncDefaults.PollInterval, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         return toEventuallyNot(matcher, timeout: timeout, pollInterval: pollInterval, description: description)

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -46,6 +46,7 @@ public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
         _delta = within
     }
 
+    @available(*, deprecated)
     @objc public func matches(_ actualExpression: @escaping () -> NSObject?, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let actualBlock: () -> NMBDoubleConvertible? = ({
             return actualExpression() as? NMBDoubleConvertible
@@ -61,6 +62,7 @@ public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
         }
     }
 
+    @available(*, deprecated)
     @objc public func doesNotMatch(_ actualExpression: @escaping () -> NSObject?, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let actualBlock: () -> NMBDoubleConvertible? = ({
             return actualExpression() as? NMBDoubleConvertible

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -12,6 +12,7 @@ public protocol Matcher {
     func doesNotMatch(_ actualExpression: Expression<ValueType>, failureMessage: FailureMessage) throws -> Bool
 }
 
+@available(*, deprecated, message: "Use Predicate instead")
 extension Matcher {
     var predicate: Predicate<ValueType> {
         return Predicate.fromDeprecatedMatcher(self)

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -27,6 +27,7 @@ internal class NotificationCollector {
 
 private let mainThread = pthread_self()
 
+@available(*, deprecated)
 public func postNotifications<T>(
     _ notificationsMatcher: T,
     fromNotificationCenter center: NotificationCenter = .default)

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -167,6 +167,7 @@ public enum PredicateStatus {
 }
 
 // Backwards compatibility until Old Matcher API removal
+@available(*, deprecated)
 extension Predicate: Matcher {
     /// Compatibility layer for old Matcher API, deprecated
     public static func fromDeprecatedFullClosure(_ matcher: @escaping (Expression<T>, FailureMessage, Bool) throws -> Bool) -> Predicate {
@@ -196,6 +197,7 @@ extension Predicate: Matcher {
 
     /// Compatibility layer for old Matcher API, deprecated.
     /// Same as calling .predicate on a MatcherFunc or NonNilMatcherFunc type.
+    @available(*, deprecated)
     public static func fromDeprecatedMatcher<M>(_ matcher: M) -> Predicate where M: Matcher, M.ValueType == T {
         return self.fromDeprecatedFullClosure(matcher.toClosure)
     }

--- a/Sources/Nimble/Matchers/SatisfyAllOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAllOf.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// A Nimble matcher that succeeds when the actual value matches with all of the matchers
 /// provided in the variable list of matchers.
+@available(*, deprecated)
 public func satisfyAllOf<T, U>(_ matchers: U...) -> Predicate<T>
     where U: Matcher, U.ValueType == T {
         return satisfyAllOf(matchers.map { $0.predicate })
@@ -35,6 +36,7 @@ internal func satisfyAllOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
     }
 }
 
+@available(*, deprecated)
 public func && <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
     return satisfyAllOf(left, right)
 }

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// A Nimble matcher that succeeds when the actual value matches with any of the matchers
-/// provided in the variable list of matchers. 
+/// provided in the variable list of matchers.
+@available(*, deprecated)
 public func satisfyAnyOf<T, U>(_ matchers: U...) -> Predicate<T>
     where U: Matcher, U.ValueType == T {
         return satisfyAnyOf(matchers.map { $0.predicate })
@@ -35,14 +36,17 @@ internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
         }
 }
 
+@available(*, deprecated)
 public func || <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
-        return satisfyAnyOf(left, right)
+    return satisfyAnyOf(left, right)
 }
 
+@available(*, deprecated)
 public func || <T>(left: NonNilMatcherFunc<T>, right: NonNilMatcherFunc<T>) -> Predicate<T> {
     return satisfyAnyOf(left, right)
 }
 
+@available(*, deprecated)
 public func || <T>(left: MatcherFunc<T>, right: MatcherFunc<T>) -> Predicate<T> {
     return satisfyAnyOf(left, right)
 }


### PR DESCRIPTION
Hey there! :) 
The project has `Matcher` deprecations for a while, but many methods and classes using `Matcher` aren't market as deprecated. This causes manny inner warnings _inside_ Nimble itself. 

For consumers using SPM there's no real way to turn this off. 

![image](https://user-images.githubusercontent.com/605076/58747939-8d1ee700-847a-11e9-8a19-cc987f851181.png)

I've marked all consumers of `Matcher` as deprecated themselves to resolve this.