### PR TITLE
Replace deprecated `Predicate.matches(_:failureMessage:)` and `Predicate.doesNotMatch(_:failureMessage:)`

### DIFF
--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -51,10 +51,12 @@ public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
             return actualExpression() as? NMBDoubleConvertible
         })
         let expr = Expression(expression: actualBlock, location: location)
-        let matcher = beCloseTo(self._expected, within: self._delta)
+        let predicate = beCloseTo(self._expected, within: self._delta)
 
         do {
-            return try matcher.matches(expr, failureMessage: failureMessage)
+            let result = try predicate.satisfies(expr)
+            result.message.update(failureMessage: failureMessage)
+            return result.toBoolean(expectation: .toMatch)
         } catch let error {
             failureMessage.stringValue = "unexpected error thrown: <\(error)>"
             return false
@@ -66,10 +68,12 @@ public class NMBObjCBeCloseToMatcher: NSObject, NMBMatcher {
             return actualExpression() as? NMBDoubleConvertible
         })
         let expr = Expression(expression: actualBlock, location: location)
-        let matcher = beCloseTo(self._expected, within: self._delta)
+        let predicate = beCloseTo(self._expected, within: self._delta)
 
         do {
-            return try matcher.doesNotMatch(expr, failureMessage: failureMessage)
+            let result = try predicate.satisfies(expr)
+            result.message.update(failureMessage: failureMessage)
+            return result.toBoolean(expectation: .toNotMatch)
         } catch let error {
             failureMessage.stringValue = "unexpected error thrown: <\(error)>"
             return false

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -51,14 +51,18 @@ public func postNotifications(
             _ = try actualExpression.evaluate()
         }
 
-        let failureMessage = FailureMessage()
-        let match = try predicate.matches(collectorNotificationsExpression, failureMessage: failureMessage)
+        let actualValue: String
         if collector.observedNotifications.isEmpty {
-            failureMessage.actualValue = "no notifications"
+            actualValue = "no notifications"
         } else {
-            failureMessage.actualValue = "<\(stringify(collector.observedNotifications))>"
+            actualValue = "<\(stringify(collector.observedNotifications))>"
         }
-        return PredicateResult(bool: match, message: failureMessage.toExpectationMessage())
+
+        var result = try predicate.satisfies(collectorNotificationsExpression)
+        result.message = result.message.replacedExpectation { message in
+            return .expectedCustomValueTo(message.expectedMessage, actualValue)
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
Refs: #661, #663 