### PR TITLE
[CocoaPods] Support `swift_versions` which is available since CocoaPods 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - &cocoapods
       name: CocoaPods Lint
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       install: bundle install
       script: ./test podspec
     - &xcode

--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -51,5 +51,9 @@ Pod::Spec.new do |s|
   }
 
   s.cocoapods_version = '>= 1.4.0'
-  s.swift_version = '4.2'
+  if s.respond_to?(:swift_versions) then
+    s.swift_versions = ['4.2', '5.0']
+  else
+    s.swift_version = '4.2'
+  end
 end


### PR DESCRIPTION
Resolves #662.

Ref: #668.