### PR TITLE
Support `throwAssertion` matcher on SwiftPM on Darwin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
+          "version": "1.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,19 @@ let package = Package(
     products: [
         .library(name: "Nimble", targets: ["Nimble"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", .exact("1.2.0")),
+    ],
     targets: [
         .target(
             name: "Nimble", 
-            dependencies: []
+            dependencies: {
+                #if os(macOS)
+                return ["CwlPreconditionTesting"]
+                #else
+                return []
+                #endif
+            }()
         ),
         .testTarget(
             name: "NimbleTests", 

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -6,10 +6,19 @@ let package = Package(
     products: [
         .library(name: "Nimble", targets: ["Nimble"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", .exact("1.2.0")),
+    ],
     targets: [
         .target(
             name: "Nimble", 
-            dependencies: []
+            dependencies: {
+                #if os(macOS)
+                return ["CwlPreconditionTesting"]
+                #else
+                return []
+                #endif
+            }()
         ),
         .testTarget(
             name: "NimbleTests", 

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -1,8 +1,12 @@
 import Foundation
 
+#if canImport(CwlPreconditionTesting)
+import CwlPreconditionTesting
+#endif
+
 public func throwAssertion() -> Predicate<Void> {
     return Predicate { actualExpression in
-    #if arch(x86_64) && canImport(Darwin) && !SWIFT_PACKAGE
+    #if arch(x86_64) && canImport(Darwin)
         let message = ExpectationMessage.expectedTo("throw an assertion")
 
         var actualError: Error?
@@ -38,10 +42,6 @@ public func throwAssertion() -> Predicate<Void> {
         } else {
             return PredicateResult(bool: caughtException != nil, message: message)
         }
-    #elseif SWIFT_PACKAGE
-        fatalError("The throwAssertion Nimble matcher does not currently support Swift CLI." +
-            " You can silence this error by placing the test case inside an #if !SWIFT_PACKAGE" +
-            " conditional statement")
     #else
         fatalError("The throwAssertion Nimble matcher can only run on x86_64 platforms with " +
             "Objective-C (e.g. macOS, iPhone 5s or later simulators). You can silence this error " +

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import XCTest
 import Nimble
 
-#if canImport(Darwin) && !SWIFT_PACKAGE
+#if canImport(Darwin)
 
 private let error: Error = NSError(domain: "test", code: 0, userInfo: nil)
 


### PR DESCRIPTION
This would (partially) resolves #674. 