### PR TITLE
Fix elementsEqual matcher constraint to match with the Swift standard library equivalent

### DIFF
--- a/Sources/Nimble/Matchers/ElementsEqual.swift
+++ b/Sources/Nimble/Matchers/ElementsEqual.swift
@@ -1,5 +1,7 @@
 /// A Nimble matcher that succeeds when the actual sequence contain the same elements in the same order to the exepected sequence.
-public func elementsEqual<S: Sequence>(_ expectedValue: S?) -> Predicate<S> where S.Element: Equatable {
+public func elementsEqual<Seq1: Sequence, Seq2: Sequence>(_ expectedValue: Seq2?)
+    -> Predicate<Seq1> where Seq1.Element: Equatable, Seq1.Element == Seq2.Element
+{ //swiftlint:disable:this opening_brace
     // A matcher abstraction for https://developer.apple.com/documentation/swift/sequence/2949668-elementsequal
     return Predicate.define("elementsEqual <\(stringify(expectedValue))>") { (actualExpression, msg) in
         let actualValue = try actualExpression.evaluate()

--- a/Tests/NimbleTests/Matchers/ElementsEqualTest.swift
+++ b/Tests/NimbleTests/Matchers/ElementsEqualTest.swift
@@ -22,6 +22,11 @@ final class ElementsEqualTest: XCTestCase {
         expect(sequence1).toNot(elementsEqual(sequence2))
         expect(sequence1).toNot(elementsEqual([3, 2, 1]))
         expect(sequence1).to(elementsEqual([1, 2, 3]))
+    }
 
+    func testElementsEqualDifferentSequenceTypes() {
+        expect(1...3).to(elementsEqual([1, 2, 3]))
+        expect(1...3).toNot(elementsEqual([1, 2, 3, 4, 5]))
+        expect(1...3).toNot(elementsEqual([3, 2, 1]))
     }
 }

--- a/Tests/NimbleTests/XCTestManifests.swift
+++ b/Tests/NimbleTests/XCTestManifests.swift
@@ -281,6 +281,7 @@ extension ElementsEqualTest {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ElementsEqualTest = [
+        ("testElementsEqualDifferentSequenceTypes", testElementsEqualDifferentSequenceTypes),
         ("testSequenceElementsEquality", testSequenceElementsEquality),
     ]
 }


### PR DESCRIPTION
Fixes #690.