### PR TITLE
[CI] Fix github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,21 @@ on:
 jobs:
   cocoapods:
     name: CocoaPods Lint
-    runs-on: macOS-10.14
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.x'
-    - run: sudo xcode-select -s '/Applications/Xcode_10.3.app'
     - run: bundle install --jobs=8
     - run: ./test podspec
 
   xcode:
     name: Xcode ${{ matrix.xcode }} - ${{ matrix.platform }}
-    runs-on: macOS-10.14
+    runs-on: macos-latest
     strategy:
       matrix:
-        xcode: [10.3, 11]
+        xcode: [11, 11.1]
         platform: [macos, ios, tvos]
     steps:
     - uses: actions/checkout@v1
@@ -35,10 +34,10 @@ jobs:
 
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
-    runs-on: macOS-10.14
+    runs-on: macos-latest
     strategy:
       matrix:
-        xcode: [10.3, 11]
+        xcode: [11, 11.1]
     steps:
     - uses: actions/checkout@v1
     - run: sudo xcode-select -s '/Applications/Xcode_${{ matrix.xcode }}.app'


### PR DESCRIPTION
Github upgraded their macOS environment which
doesn’t provide access to Xcode 10.3.

https://github.blog/changelog/2019-11-06-github-actions-macos-virtual-environment-updated-to-catalina/