### PR TITLE
Fix hanging toEventually when build with swift package manager (SPM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         xcode: [11, 11.1, 11.2]
-        platform: [macos, ios, tvos]
+        platform: [macos, ios, tvos, macos_xcodespm, ios_xcodespm]
     steps:
     - uses: actions/checkout@v1
     - run: sudo xcode-select -s '/Applications/Xcode_${{ matrix.xcode }}.app'

--- a/Sources/Nimble/Utils/Await.swift
+++ b/Sources/Nimble/Utils/Await.swift
@@ -98,7 +98,7 @@ internal enum AwaitResult<T> {
 
 /// Holds the resulting value from an asynchronous expectation.
 /// This class is thread-safe at receiving an "response" to this promise.
-internal class AwaitPromise<T> {
+internal final class AwaitPromise<T> {
     private(set) internal var asyncResult: AwaitResult<T> = .incomplete
     private var signal: DispatchSemaphore
 

--- a/test
+++ b/test
@@ -74,6 +74,19 @@ function test_macos {
     run set -o pipefail && xcodebuild -project Nimble.xcodeproj -scheme "Nimble-macOS" -configuration "Debug" -sdk "macosx$BUILD_MACOS_SDK_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
 }
 
+function test_xcode_spm_macos {
+    mv Nimble.xcodeproj Nimble.xcodeproj.bak    
+    trap 'mv Nimble.xcodeproj.bak Nimble.xcodeproj' EXIT
+    run set -o pipefail && xcodebuild -scheme "Nimble" -configuration "Debug" -sdk "macosx$BUILD_MACOS_SDK_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
+}
+
+function test_xcode_spm_ios {
+    run osascript -e 'tell app "Simulator" to quit'
+    mv Nimble.xcodeproj Nimble.xcodeproj.bak
+    trap 'mv Nimble.xcodeproj.bak Nimble.xcodeproj' EXIT
+    run set -o pipefail && xcodebuild -scheme "Nimble" -configuration "Debug" -sdk "iphonesimulator$BUILD_IOS_SDK_VERSION" -destination "name=iPhone 8,OS=$RUNTIME_IOS_SDK_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
+}
+
 function test_podspec {
     echo "Gathering CocoaPods installation information..."
     run bundle exec pod --version
@@ -98,6 +111,13 @@ function test() {
     test_ios
     test_tvos
     test_macos
+
+    if xcodebuild --help 2>&1 | grep xcframework > /dev/null; then
+        test_xcode_spm_ios
+        test_xcode_spm_macos
+    else
+        echo "Not testing with Swift Package Manager version of Xcode because it requires at least Xcode 11"
+    fi
 
     if which swift-test; then
         test_swiftpm
@@ -124,7 +144,9 @@ function help {
     echo " clean           - Cleans the derived data directory of Xcode. Assumes default location"
     echo " help            - Displays this help"
     echo " macos           - Runs the tests on macOS 10.10 (Yosemite and newer only)"
+    echo " macos_xcodespm  - Runs the tests on macOS using the Swift Package Manager version of Xcode"
     echo " ios             - Runs the tests as an iOS device"
+    echo " ios_xcodespm    - Runs the tests as an iOS device using the Swift Package Manager version of Xcode"
     echo " tvos            - Runs the tests as an tvOS device"
     echo " podspec         - Runs pod lib lint against the podspec to detect breaking changes"
     echo " swiftpm         - Runs the tests built by the Swift Package Manager"
@@ -140,8 +162,10 @@ function main {
         case "$arg" in
             clean) clean ;;
             ios) test_ios ;;
+            ios_xcodespm) test_xcode_spm_ios ;;
             tvos) test_tvos ;;
             macos) test_macos ;;
+            macos_xcodespm) test_xcode_spm_macos ;;
             podspec) test_podspec ;;
             test) test ;;
             all) test ;;


### PR DESCRIPTION
Swift package manager uses -dead_strip as a linker flag
which falsefully strips away a method that is actually not
dead code (https://bugs.swift.org/browse/SR-11564).

Making AwaitPromise final fixes the problem for now
and shouldn’t have a negative effect.

Xcode has a different version of SPM that is also able to build for iOS and has a slightly different behavior to the command line SPM.

AFAIK the only way to force Xcode to use the internal SPM is to delete the xcodeproj file before calling xcodebuild which is why the Nimble.xcodeproj is temporarily renamed.

Specifically this adds an automated test for issue #708
Until the issue is resolved (and I'm currently not sure how it could be resolve) the build hangs for a long time and eventually times out (after 360 minutes).

Fixes #708

 - [x] Does this have tests? Yes
 - [x] Does this break the public API (Requires major version bump)? -> No
 - [x] Is this a new feature (Requires minor version bump)? -> It's a bugfix