### PR TITLE
[CI] Fix GitHub Actions breakage and restore Travis build matrix for older Xcode versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,12 @@ on:
       - '*'
 
 jobs:
-  cocoapods:
-    name: CocoaPods Lint
-    runs-on: macOS-10.14
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.x'
-    - run: sudo xcode-select -s '/Applications/Xcode_10.3.app'
-    - run: bundle install --jobs=8
-    - run: ./test podspec
-
   xcode:
     name: Xcode ${{ matrix.xcode }} - ${{ matrix.platform }}
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: [10.3, 11]
+        xcode: [11, 11.1, 11.2]
         platform: [macos, ios, tvos]
     steps:
     - uses: actions/checkout@v1
@@ -35,10 +23,10 @@ jobs:
 
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: [10.3, 11]
+        xcode: [11, 11.1, 11.2]
     steps:
     - uses: actions/checkout@v1
     - run: sudo xcode-select -s '/Applications/Xcode_${{ matrix.xcode }}.app'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,25 @@ branches:
 language: generic
 matrix:
   include:
+    - &cocoapods
+      name: CocoaPods Lint
+      os: osx
+      osx_image: xcode10.3
+      install: bundle install
+      script: ./test podspec
+    - &xcode
+      name: Xcode 10.3 / Swift 5.0
+      os: osx
+      osx_image: xcode10.3
+      script:
+        - ./test macos
+        - ./test ios
+        - ./test tvos
+    - &swiftpm_darwin
+      name: SwiftPM / Darwin / Swift 5.0
+      os: osx
+      osx_image: xcode10.3
+      script: ./test swiftpm
     - &swiftpm_linux
       name: SwiftPM / Linux / Swift 5.0.3
       os: linux

--- a/test
+++ b/test
@@ -79,7 +79,7 @@ function test_podspec {
     run bundle exec pod --version
     echo "Linting podspec..."
     # Note: remove `--allow-warnings` once old Matcher API has been removed
-    run bundle exec pod lib lint Nimble.podspec --allow-warnings --skip-import-validation
+    run bundle exec pod lib lint Nimble.podspec --allow-warnings --skip-import-validation --verbose
 }
 
 function test_swiftpm {


### PR DESCRIPTION
Due to https://github.blog/changelog/2019-11-06-github-actions-macos-virtual-environment-updated-to-catalina/

Ref: https://github.com/Quick/Nimble/pull/710#issuecomment-551646061