### PR TITLE
Unpin the cocoapods instructions from Nimble 6.0.0 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1707,7 +1707,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'YOUR_APP_NAME_HERE_Tests', :exclusive => true do
   use_frameworks!
-  pod 'Nimble', '~> 6.0.0'
+  pod 'Nimble'
 end
 ```
 


### PR DESCRIPTION
As this leads to confusion when the library won't build in newer versions of swift!
