### PR TITLE
Fix a swiftlint violation

### DIFF
--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -70,8 +70,7 @@ public func postNotifications<T>(
     _ notificationsMatcher: T,
     fromNotificationCenter center: NotificationCenter = .default)
     -> Predicate<Any>
-    where T: Matcher, T.ValueType == [Notification]
-{
+    where T: Matcher, T.ValueType == [Notification] {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center)
     collector.startObserving()


### PR DESCRIPTION
> Nimble/Sources/Nimble/Matchers/PostNotification.swift:74:1: warning: Opening Brace Spacing Violation: Opening braces should be preceded by a single space and on the same line as the declaration. (opening_brace)