### PR TITLE
Add default message to Predicate's convenience factory methods

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -378,6 +378,9 @@
 		CD79C9B51D2CC848004B6F9A /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		CD79C9B61D2CC848004B6F9A /* ObjCAllPassTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DDEFAEB31A93CBE6005CA37A /* ObjCAllPassTest.m */; };
 		CD79C9B71D2CC848004B6F9A /* ObjCSatisfyAnyOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */; };
+		CDBC39B92462EA7D00069677 /* PredicateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBC39B82462EA7D00069677 /* PredicateTest.swift */; };
+		CDBC39BA2462EA7D00069677 /* PredicateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBC39B82462EA7D00069677 /* PredicateTest.swift */; };
+		CDBC39BB2462EA7D00069677 /* PredicateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBC39B82462EA7D00069677 /* PredicateTest.swift */; };
 		CDD80B831F2030790002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		CDD80B841F20307A0002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
 		CDD80B851F20307B0002CD65 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */; };
@@ -615,6 +618,7 @@
 		B20058C020E92C7500C1264D /* ElementsEqual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsEqual.swift; sourceTree = "<group>"; };
 		B20058C420E92CE400C1264D /* ElementsEqualTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsEqualTest.swift; sourceTree = "<group>"; };
 		CD3D9A78232647BC00802581 /* CwlCatchBadInstructionPosix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlCatchBadInstructionPosix.swift; sourceTree = "<group>"; };
+		CDBC39B82462EA7D00069677 /* PredicateTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicateTest.swift; sourceTree = "<group>"; };
 		CDFB6A1E1F7E07C600AD8CC7 /* CwlCatchException.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlCatchException.swift; sourceTree = "<group>"; };
 		CDFB6A201F7E07C600AD8CC7 /* CwlCatchException.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CwlCatchException.m; sourceTree = "<group>"; };
 		CDFB6A221F7E07C600AD8CC7 /* CwlCatchException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CwlCatchException.h; sourceTree = "<group>"; };
@@ -766,8 +770,9 @@
 		1F1A74381940169200FFFC47 /* NimbleTests */ = {
 			isa = PBXGroup;
 			children = (
-				1F925EE5195C121200ED456B /* AsynchronousTest.swift */,
+				CDBC39B82462EA7D00069677 /* PredicateTest.swift */,
 				1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */,
+				1F925EE5195C121200ED456B /* AsynchronousTest.swift */,
 				965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */,
 				6CAEDD091CAEA86F003F1584 /* LinuxSupport.swift */,
 				1FFD729A1963FC8200CD29A2 /* objc */,
@@ -1386,6 +1391,7 @@
 				1F925EFF195C187600ED456B /* EndWithTest.swift in Sources */,
 				1F1B5AD41963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */,
 				1F925F0E195C18F500ED456B /* BeLessThanOrEqualToTest.swift in Sources */,
+				CDBC39BA2462EA7D00069677 /* PredicateTest.swift in Sources */,
 				1F4A56661A3B305F009E1637 /* ObjCAsyncTest.m in Sources */,
 				1F925EFC195C186800ED456B /* BeginWithTest.swift in Sources */,
 				1F14FB64194180C5009F2A08 /* utils.swift in Sources */,
@@ -1522,6 +1528,7 @@
 				1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */,
 				1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */,
 				CD79C9B01D2CC848004B6F9A /* ObjCEndWithTest.m in Sources */,
+				CDBC39BB2462EA7D00069677 /* PredicateTest.swift in Sources */,
 				CD79C9B21D2CC848004B6F9A /* ObjCHaveCountTest.m in Sources */,
 				CD79C9A41D2CC848004B6F9A /* ObjCBeFalsyTest.m in Sources */,
 				1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */,
@@ -1663,6 +1670,7 @@
 				1F925F00195C187600ED456B /* EndWithTest.swift in Sources */,
 				1F1B5AD51963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */,
 				1F925F0F195C18F500ED456B /* BeLessThanOrEqualToTest.swift in Sources */,
+				CDBC39B92462EA7D00069677 /* PredicateTest.swift in Sources */,
 				1F4A56671A3B305F009E1637 /* ObjCAsyncTest.m in Sources */,
 				1F925EFD195C186800ED456B /* BeginWithTest.swift in Sources */,
 				1F925EE2195C0DFD00ED456B /* utils.swift in Sources */,

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -45,17 +45,17 @@ extension Predicate {
 
     /// Defines a predicate with a default message that can be returned in the closure
     /// Also ensures the predicate's actual value cannot pass with `nil` given.
-    public static func define(_ msg: String, matcher: @escaping (Expression<T>, ExpectationMessage) throws -> PredicateResult) -> Predicate<T> {
+    public static func define(_ message: String = "match", matcher: @escaping (Expression<T>, ExpectationMessage) throws -> PredicateResult) -> Predicate<T> {
         return Predicate<T> { actual in
-            return try matcher(actual, .expectedActualValueTo(msg))
+            return try matcher(actual, .expectedActualValueTo(message))
         }.requireNonNil
     }
 
     /// Defines a predicate with a default message that can be returned in the closure
     /// Unlike `define`, this allows nil values to succeed if the given closure chooses to.
-    public static func defineNilable(_ msg: String, matcher: @escaping (Expression<T>, ExpectationMessage) throws -> PredicateResult) -> Predicate<T> {
+    public static func defineNilable(_ message: String = "match", matcher: @escaping (Expression<T>, ExpectationMessage) throws -> PredicateResult) -> Predicate<T> {
         return Predicate<T> { actual in
-            return try matcher(actual, .expectedActualValueTo(msg))
+            return try matcher(actual, .expectedActualValueTo(message))
         }
     }
 }
@@ -65,9 +65,9 @@ extension Predicate {
     /// error message.
     ///
     /// Also ensures the predicate's actual value cannot pass with `nil` given.
-    public static func simple(_ msg: String, matcher: @escaping (Expression<T>) throws -> PredicateStatus) -> Predicate<T> {
+    public static func simple(_ message: String = "match", matcher: @escaping (Expression<T>) throws -> PredicateStatus) -> Predicate<T> {
         return Predicate<T> { actual in
-            return PredicateResult(status: try matcher(actual), message: .expectedActualValueTo(msg))
+            return PredicateResult(status: try matcher(actual), message: .expectedActualValueTo(message))
         }.requireNonNil
     }
 
@@ -75,9 +75,9 @@ extension Predicate {
     /// error message.
     ///
     /// Unlike `simple`, this allows nil values to succeed if the given closure chooses to.
-    public static func simpleNilable(_ msg: String, matcher: @escaping (Expression<T>) throws -> PredicateStatus) -> Predicate<T> {
+    public static func simpleNilable(_ message: String = "match", matcher: @escaping (Expression<T>) throws -> PredicateStatus) -> Predicate<T> {
         return Predicate<T> { actual in
-            return PredicateResult(status: try matcher(actual), message: .expectedActualValueTo(msg))
+            return PredicateResult(status: try matcher(actual), message: .expectedActualValueTo(message))
         }
     }
 }

--- a/Tests/NimbleTests/PredicateTest.swift
+++ b/Tests/NimbleTests/PredicateTest.swift
@@ -1,0 +1,28 @@
+import XCTest
+import Nimble
+
+final class PredicateTest: XCTestCase {
+    func testDefineDefaultMessage() {
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(Predicate.define { _, msg in PredicateResult(status: .fail, message: msg) })
+        }
+    }
+
+    func testDefineNilableDefaultMessage() {
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(Predicate.defineNilable { _, msg in PredicateResult(status: .fail, message: msg) })
+        }
+    }
+
+    func testSimpleDefaultMessage() {
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(Predicate.simple { _ in .fail })
+        }
+    }
+
+    func testSimpleNilableDefaultMessage() {
+        failsWithErrorMessage("expected to match, got <1>") {
+            expect(1).to(Predicate.simpleNilable { _ in .fail })
+        }
+    }
+}

--- a/Tests/NimbleTests/SynchronousTest.swift
+++ b/Tests/NimbleTests/SynchronousTest.swift
@@ -35,8 +35,8 @@ final class SynchronousTest: XCTestCase {
         expect(1).to(MatcherFunc { _, _ in true }.predicate)
         expect {1}.to(MatcherFunc { _, _ in true }.predicate)
 
-        expect(1).to(Predicate.simple("match") { _ in .matches })
-        expect {1}.to(Predicate.simple("match") { _ in .matches })
+        expect(1).to(Predicate.simple { _ in .matches })
+        expect {1}.to(Predicate.simple { _ in .matches })
     }
 
     func testToProvidesActualValueExpression() {
@@ -80,8 +80,8 @@ final class SynchronousTest: XCTestCase {
         expect(1).toNot(MatcherFunc { _, _ in false }.predicate)
         expect {1}.toNot(MatcherFunc { _, _ in false }.predicate)
 
-        expect(1).toNot(Predicate.simple("match") { _ in .doesNotMatch })
-        expect {1}.toNot(Predicate.simple("match") { _ in .doesNotMatch })
+        expect(1).toNot(Predicate.simple { _ in .doesNotMatch })
+        expect {1}.toNot(Predicate.simple { _ in .doesNotMatch })
     }
 
     func testToNotProvidesActualValueExpression() {
@@ -118,7 +118,7 @@ final class SynchronousTest: XCTestCase {
             expect(1).to(MatcherFunc { _, _ in false }.predicate)
         }
         failsWithErrorMessage("expected to match, got <1>") {
-            expect(1).to(Predicate.simple("match") { _ in .doesNotMatch })
+            expect(1).to(Predicate.simple { _ in .doesNotMatch })
         }
     }
 
@@ -130,13 +130,13 @@ final class SynchronousTest: XCTestCase {
             expect(1).toNot(MatcherFunc { _, _ in true }.predicate)
         }
         failsWithErrorMessage("expected to not match, got <1>") {
-            expect(1).toNot(Predicate.simple("match") { _ in .matches })
+            expect(1).toNot(Predicate.simple { _ in .matches })
         }
     }
 
     func testNotToMatchesLikeToNot() {
         expect(1).notTo(MatcherFunc { _, _ in false })
         expect(1).notTo(MatcherFunc { _, _ in false }.predicate)
-        expect(1).notTo(Predicate.simple("match") { _ in .doesNotMatch })
+        expect(1).notTo(Predicate.simple { _ in .doesNotMatch })
     }
 }


### PR DESCRIPTION
The default message is same as the default value of `FailureMessage.postfixMessage`.

---

Checklist - While not every PR needs it, new features should consider this list:

- [x] Does this have tests?
- [ ] Does this have documentation?
- [x] Does this break the public API (Requires major version bump)?
  - While this is source-compatible, this is not binary-compatible due to the introduction of default argument
- [ ] Is this a new feature (Requires minor version bump)?
