### PR TITLE
[BREAKING] Add label to the second associated value of `ExpectationMessage.expectedCustomValueTo` for readability and understandability

### DIFF
--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -5,7 +5,7 @@ public indirect enum ExpectationMessage {
     /// includes actual value in output ("expected to <message>, got <actual>")
     case expectedActualValueTo(/* message: */ String)
     /// uses a custom actual value string in output ("expected to <message>, got <actual>")
-    case expectedCustomValueTo(/* message: */ String, /* actual: */ String)
+    case expectedCustomValueTo(/* message: */ String, actual: String)
     /// excludes actual value in output ("expected to <message>")
     case expectedTo(/* message: */ String)
     /// allows any free-form message ("<message>")
@@ -118,7 +118,7 @@ public indirect enum ExpectationMessage {
             case let .expectedActualValueTo(msg):
                 return .expectedActualValueTo(message + msg)
             case let .expectedCustomValueTo(msg, actual):
-                return .expectedCustomValueTo(message + msg, actual)
+                return .expectedCustomValueTo(message + msg, actual: actual)
             default:
                 return msg.visitLeafs(walk)
             }
@@ -193,7 +193,7 @@ extension FailureMessage {
 
         var message: ExpectationMessage = .fail(userDescription ?? "")
         if actualValue != "" && actualValue != nil {
-            message = .expectedCustomValueTo(postfixMessage, actualValue ?? "")
+            message = .expectedCustomValueTo(postfixMessage, actual: actualValue ?? "")
         } else if postfixMessage != defaultMessage.postfixMessage {
             if actualValue == nil {
                 message = .expectedTo(postfixMessage)
@@ -228,7 +228,7 @@ public class NMBExpectationMessage: NSObject {
     }
 
     public init(expectedActualValueTo message: String, customActualValue actual: String) {
-        self.msg = .expectedCustomValueTo(message, actual)
+        self.msg = .expectedCustomValueTo(message, actual: actual)
     }
 
     public init(fail message: String) {

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -14,12 +14,12 @@ public func beAKindOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
 
         let instance = try actualExpression.evaluate()
         guard let validInstance = instance else {
-            message = .expectedCustomValueTo(matcherMessage(forType: expectedType), "<nil>")
+            message = .expectedCustomValueTo(matcherMessage(forType: expectedType), actual: "<nil>")
             return PredicateResult(status: .fail, message: message)
         }
         message = .expectedCustomValueTo(
             "be a kind of \(String(describing: expectedType))",
-            "<\(String(describing: type(of: validInstance))) instance>"
+            actual: "<\(String(describing: type(of: validInstance))) instance>"
         )
 
         return PredicateResult(
@@ -43,13 +43,13 @@ public func beAKindOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
             status = PredicateStatus(bool: instance != nil && instance!.isKind(of: expectedClass))
             message = .expectedCustomValueTo(
                 matcherMessage(forClass: expectedClass),
-                "<\(String(describing: type(of: validInstance))) instance>"
+                actual: "<\(String(describing: type(of: validInstance))) instance>"
             )
         } else {
             status = .fail
             message = .expectedCustomValueTo(
                 matcherMessage(forClass: expectedClass),
-                "<nil>"
+                actual: "<nil>"
             )
         }
 

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -16,7 +16,7 @@ public func beAnInstanceOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
 
         return PredicateResult(
             status: PredicateStatus(bool: type(of: validInstance) == expectedType),
-            message: .expectedCustomValueTo(errorMessage, actualString)
+            message: .expectedCustomValueTo(errorMessage, actual: actualString)
         )
     }
 }
@@ -40,7 +40,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
         #endif
         return PredicateResult(
             status: PredicateStatus(bool: matches),
-            message: .expectedCustomValueTo(errorMessage, actualString)
+            message: .expectedCustomValueTo(errorMessage, actual: actualString)
         )
     }
 }

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -11,7 +11,7 @@ internal func isCloseTo(_ actualValue: NMBDoubleConvertible?,
         return PredicateResult(
             bool: actualValue != nil &&
                 abs(actualValue!.doubleValue - expectedValue.doubleValue) < delta,
-            message: .expectedCustomValueTo(errorMessage, "<\(stringify(actualValue))>")
+            message: .expectedCustomValueTo(errorMessage, actual: "<\(stringify(actualValue))>")
         )
 }
 

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -11,7 +11,7 @@ public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
             bool: bool,
             message: .expectedCustomValueTo(
                 "be identical to \(identityAsString(expected))",
-                "\(identityAsString(actual))"
+                actual: "\(identityAsString(actual))"
             )
         )
     }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -71,7 +71,7 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
 
         errorMessage = .expectedCustomValueTo(
             "equal <\(stringify(expectedValue))>",
-            "<\(stringify(actualValue))>"
+            actual: "<\(stringify(actualValue))>"
         )
 
         if expectedValue == actualValue {

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -13,7 +13,7 @@ public func haveCount<T: Collection>(_ expectedValue: Int) -> Predicate<T> {
             let message = ExpectationMessage
                 .expectedCustomValueTo(
                     "have \(prettyCollectionType(actualValue)) with count \(stringify(expectedValue))",
-                    "\(actualValue.count)"
+                    actual: "\(actualValue.count)"
                 )
                 .appended(details: "Actual Value: \(stringify(actualValue))")
 
@@ -33,7 +33,7 @@ public func haveCount(_ expectedValue: Int) -> Predicate<NMBCollection> {
             let message = ExpectationMessage
                 .expectedCustomValueTo(
                     "have \(prettyCollectionType(actualValue)) with count \(stringify(expectedValue))",
-                    "\(actualValue.count)"
+                    actual: "\(actualValue.count)"
                 )
                 .appended(details: "Actual Value: \(stringify(actualValue))")
 
@@ -60,7 +60,7 @@ extension NMBObjCMatcher {
             if let actualValue = actualValue {
                 message = ExpectationMessage.expectedCustomValueTo(
                     "get type of NSArray, NSSet, NSDictionary, or NSHashTable",
-                    "\(String(describing: type(of: actualValue)))"
+                    actual: "\(String(describing: type(of: actualValue)))"
                 )
             } else {
                 message = ExpectationMessage

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -60,7 +60,7 @@ public func postNotifications(
 
         var result = try predicate.satisfies(collectorNotificationsExpression)
         result.message = result.message.replacedExpectation { message in
-            return .expectedCustomValueTo(message.expectedMessage, actualValue)
+            return .expectedCustomValueTo(message.expectedMessage, actual: actualValue)
         }
         return result
     }

--- a/Sources/Nimble/Matchers/SatisfyAllOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAllOf.swift
@@ -29,7 +29,7 @@ internal func satisfyAllOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
         if let actualValue = try actualExpression.evaluate() {
             msg = .expectedCustomValueTo(
                 "match all of: " + postfixMessages.joined(separator: ", and "),
-                "\(actualValue)"
+                actual: "\(actualValue)"
             )
         } else {
             msg = .expectedActualValueTo(

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -29,7 +29,7 @@ internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
             if let actualValue = try actualExpression.evaluate() {
                 msg = .expectedCustomValueTo(
                     "match one of: " + postfixMessages.joined(separator: ", or "),
-                    "\(actualValue)"
+                    actual: "\(actualValue)"
                 )
             } else {
                 msg = .expectedActualValueTo(

--- a/Sources/Nimble/Matchers/ThrowError.swift
+++ b/Sources/Nimble/Matchers/ThrowError.swift
@@ -21,9 +21,15 @@ public func throwError<Out>() -> Predicate<Out> {
         }
 
         if let actualError = actualError {
-            return PredicateResult(bool: true, message: .expectedCustomValueTo("throw any error", "<\(actualError)>"))
+            return PredicateResult(
+                bool: true,
+                message: .expectedCustomValueTo("throw any error", actual: "<\(actualError)>")
+            )
         } else {
-            return PredicateResult(bool: false, message: .expectedCustomValueTo("throw any error", "no error"))
+            return PredicateResult(
+                bool: false,
+                message: .expectedCustomValueTo("throw any error", actual: "no error")
+            )
         }
     }
 }

--- a/Sources/Nimble/Matchers/ToSucceed.swift
+++ b/Sources/Nimble/Matchers/ToSucceed.swift
@@ -25,12 +25,12 @@ public func succeed() -> Predicate<() -> ToSucceedResult> {
         case .succeeded:
             return PredicateResult(
                 bool: true,
-                message: .expectedCustomValueTo("succeed", "<succeeded>")
+                message: .expectedCustomValueTo("succeed", actual: "<succeeded>")
             )
         case .failed(let reason):
             return PredicateResult(
                 bool: false,
-                message: .expectedCustomValueTo("succeed", "<failed> because <\(reason)>")
+                message: .expectedCustomValueTo("succeed", actual: "<failed> because <\(reason)>")
             )
         }
     }


### PR DESCRIPTION
`case expectedCustomValueTo(String, String)` was difficult to understand the roles of the two Strings.