### PR TITLE
[BREAKING] Make `raiseException` generic and usable with non-void closures

### DIFF
--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -12,11 +12,11 @@ import Foundation
 ///
 /// nil arguments indicates that the matcher should not attempt to match against
 /// that parameter.
-public func raiseException(
+public func raiseException<Out>(
     named: String? = nil,
     reason: String? = nil,
     userInfo: NSDictionary? = nil,
-    closure: ((NSException) -> Void)? = nil) -> Predicate<Any> {
+    closure: ((NSException) -> Void)? = nil) -> Predicate<Out> {
         return Predicate { actualExpression in
             var exception: NSException?
             let capture = NMBExceptionCapture(handler: ({ e in
@@ -141,7 +141,7 @@ public class NMBObjCRaiseExceptionMatcher: NSObject, NMBMatcher {
         let expr = Expression(expression: block, location: location)
 
         do {
-            let predicate = raiseException(
+            let predicate: Predicate<Any> = raiseException(
                 named: _name,
                 reason: _reason,
                 userInfo: _userInfo,

--- a/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
+++ b/Tests/NimbleTests/Matchers/RaisesExceptionTest.swift
@@ -152,5 +152,17 @@ final class RaisesExceptionTest: XCTestCase {
             })
         }
     }
+
+    func testNonVoidClosure() {
+        expect { return 1 }.toNot(raiseException())
+        expect { return 2 }.toNot(raiseException(named: "laugh"))
+        expect { return 3 }.toNot(raiseException(named: "laugh", reason: "Lulz"))
+        expect { return 4 }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
+        expect { return 5 }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { _ in })
+    }
+
+    func testChainOnRaiseException() {
+        expect { () -> Int in return 5 }.toNot(raiseException()).to(equal(5))
+    }
 }
 #endif


### PR DESCRIPTION
Related to #493, #698 and #742.