### PR TITLE
Add `-Xlinker -no_application_extension` to `OTHER_LDFLAGS` at project level

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1848,6 +1848,11 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Xlinker",
+					"-no_application_extension",
+				);
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -1904,6 +1909,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Xlinker",
+					"-no_application_extension",
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -suppress-warnings";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1944,8 +1954,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -1985,8 +1993,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2071,8 +2077,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2113,8 +2117,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2201,8 +2203,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2243,8 +2243,6 @@
 					"-weak_framework",
 					XCTest,
 					"-weak-lswiftXCTest",
-					"-Xlinker",
-					"-no_application_extension",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;


### PR DESCRIPTION
Ref: #541 

This silences the "linking against a dylib which is not safe for use in application extensions: ..." linker warning for all targets.