### PR TITLE
Remove now-unnecessary compiler version check

### DIFF
--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -14,7 +14,7 @@ public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beGreaterThan(rhs))
 }
 
-#if canImport(Darwin) || !compiler(>=5.1)
+#if canImport(Darwin)
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 public func beGreaterThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
     let errorMessage = "be greater than <\(stringify(expectedValue))>"

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -15,7 +15,7 @@ public func >=<T: Comparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
-#if canImport(Darwin) || !compiler(>=5.1)
+#if canImport(Darwin)
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -16,7 +16,7 @@ public func <<T: Comparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beLessThan(rhs))
 }
 
-#if canImport(Darwin) || !compiler(>=5.1)
+#if canImport(Darwin)
 /// A Nimble matcher that succeeds when the actual value is less than the expected value.
 public func beLessThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
     let message = "be less than <\(stringify(expectedValue))>"

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -16,7 +16,7 @@ public func <=<T: Comparable>(lhs: Expectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 
-#if canImport(Darwin) || !compiler(>=5.1)
+#if canImport(Darwin)
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -137,14 +137,9 @@ extension NSDate: TestOutputStringConvertible {
 @objc public protocol NMBComparable {
     func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult
 }
-#elseif !compiler(>=5.1)
-// This should become obsolete once Corelibs Foundation adds Comparable conformance to NSNumber
-public protocol NMBComparable {
-    func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult
-}
 #endif
 
-#if canImport(Darwin) || !compiler(>=5.1)
+#if canImport(Darwin)
 extension NSNumber: NMBComparable {
     public func NMB_compare(_ otherObject: NMBComparable!) -> ComparisonResult {
         // swiftlint:disable:next force_cast


### PR DESCRIPTION
refs:

- #659 
  - https://bugs.swift.org/browse/SR-10798
- #728 