### PR TITLE
Reduce `#if canImport(Darwin)` usages in tests

### DIFF
--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -49,27 +49,29 @@ final class BeAKindOfSwiftTest: XCTestCase {
 
 final class BeAKindOfObjCTest: XCTestCase {
     func testPositiveMatch() {
-#if canImport(Darwin)
         expect(TestNull()).to(beAKindOf(NSNull.self))
         expect(NSObject()).to(beAKindOf(NSObject.self))
         expect(NSNumber(value: 1)).toNot(beAKindOf(NSDate.self))
-#endif
     }
 
     func testFailureMessages() {
-#if canImport(Darwin)
         failsWithErrorMessageForNil("expected to not be a kind of NSNull, got <nil>") {
             expect(nil as NSNull?).toNot(beAKindOf(NSNull.self))
         }
         failsWithErrorMessageForNil("expected to be a kind of NSString, got <nil>") {
             expect(nil as NSString?).to(beAKindOf(NSString.self))
         }
-        failsWithErrorMessage("expected to be a kind of NSString, got <__NSCFNumber instance>") {
+
+        #if canImport(Darwin)
+        let numberTypeName = "__NSCFNumber"
+        #else
+        let numberTypeName = "NSNumber"
+        #endif
+        failsWithErrorMessage("expected to be a kind of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(value: 1)).to(beAKindOf(NSString.self))
         }
-        failsWithErrorMessage("expected to not be a kind of NSNumber, got <__NSCFNumber instance>") {
+        failsWithErrorMessage("expected to not be a kind of NSNumber, got <\(numberTypeName) instance>") {
             expect(NSNumber(value: 1)).toNot(beAKindOf(NSNumber.self))
         }
-#endif
     }
 }

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -40,11 +40,12 @@ final class BeAnInstanceOfTest: XCTestCase {
         failsWithErrorMessageForNil("expected to be an instance of NSString, got <nil>") {
             expect(nil as NSString?).to(beAnInstanceOf(NSString.self))
         }
-#if canImport(Darwin)
+
+        #if canImport(Darwin)
         let numberTypeName = "__NSCFNumber"
-#else
+        #else
         let numberTypeName = "NSNumber"
-#endif
+        #endif
         failsWithErrorMessage("expected to be an instance of NSString, got <\(numberTypeName) instance>") {
             expect(NSNumber(value: 1)).to(beAnInstanceOf(NSString.self))
         }

--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -13,18 +13,14 @@ final class BeEmptyTest: XCTestCase {
         expect([] as Set<Int>).to(beEmpty())
         expect([1] as Set<Int>).toNot(beEmpty())
 
-#if canImport(Darwin)
         expect(NSDictionary() as? [Int: Int]).to(beEmpty())
         expect(([1: 1] as NSDictionary) as? [Int: Int]).toNot(beEmpty())
-#endif
 
         expect([Int: Int]()).to(beEmpty())
         expect(["hi": 1]).toNot(beEmpty())
 
-#if canImport(Darwin)
         expect(NSArray() as? [Int]).to(beEmpty())
         expect(([1] as NSArray) as? [Int]).toNot(beEmpty())
-#endif
 
         expect(NSSet()).to(beEmpty())
         expect(NSSet(array: [NSNumber(value: 1)])).toNot(beEmpty())
@@ -57,14 +53,12 @@ final class BeEmptyTest: XCTestCase {
             expect([1] as Set<Int>).to(beEmpty())
         }
 
-#if canImport(Darwin)
         failsWithErrorMessage("expected to not be empty, got <{()}>") {
             expect(NSSet()).toNot(beEmpty())
         }
         failsWithErrorMessage("expected to be empty, got <{(1)}>") {
             expect(NSSet(object: NSNumber(value: 1))).to(beEmpty())
         }
-#endif
 
         failsWithErrorMessage("expected to not be empty, got <()>") {
             expect(NSIndexSet()).toNot(beEmpty())

--- a/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -41,11 +41,8 @@ final class BeIdenticalToTest: XCTestCase {
         let value = NSDate()
         expect(value).to(be(value))
         expect(NSNumber(value: 1)).toNot(be("turtles" as NSString))
-        #if canImport(Darwin)
-            expect([1]).toNot(be([1]))
-        #else
-            expect([NSNumber(value: 1)] as NSArray).toNot(beIdenticalTo([NSNumber(value: 1)] as NSArray))
-        #endif
+        expect([1]).toNot(be([1]))
+        expect([NSNumber(value: 1)] as NSArray).toNot(be([NSNumber(value: 1)] as NSArray))
 
         let value1 = NSArray()
         let value2 = value1

--- a/Tests/NimbleTests/Matchers/MatchErrorTest.swift
+++ b/Tests/NimbleTests/Matchers/MatchErrorTest.swift
@@ -19,12 +19,10 @@ final class MatchErrorTest: XCTestCase {
     }
 
     func testMatchNSErrorPositive() {
-#if canImport(Darwin)
         let error1 = NSError(domain: "err", code: 0, userInfo: nil)
         let error2 = NSError(domain: "err", code: 0, userInfo: nil)
 
         expect(error1).to(matchError(error2))
-#endif
     }
 
     func testMatchNSErrorNegative() {
@@ -45,13 +43,11 @@ final class MatchErrorTest: XCTestCase {
             expect(CustomDebugStringConvertibleError.a).to(matchError(CustomDebugStringConvertibleError.b))
         }
 
-#if canImport(Darwin)
         failsWithErrorMessage("expected to match error <Error Domain=err Code=1 \"(null)\">, got <Error Domain=err Code=0 \"(null)\">") {
             let error1 = NSError(domain: "err", code: 0, userInfo: nil)
             let error2 = NSError(domain: "err", code: 1, userInfo: nil)
             expect(error1).to(matchError(error2))
         }
-#endif
     }
 
     func testMatchNegativeMessage() {


### PR DESCRIPTION
refs:
- #777 
- #778 
- #779 
- #780 