### PR TITLE
Add postDistributedNotifications matcher for testing DistributedNotificationCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,18 +1174,28 @@ For Objective-C, the actual value must be one of the following classes, or their
 // Swift
 let testNotification = Notification(name: Notification.Name("Foo"), object: nil)
 
-// passes if the closure in expect { ... } posts a notification to the default
+// Passes if the closure in expect { ... } posts a notification to the default
 // notification center.
 expect {
     NotificationCenter.default.post(testNotification)
 }.to(postNotifications(equal([testNotification])))
 
-// passes if the closure in expect { ... } posts a notification to a given
+// Passes if the closure in expect { ... } posts a notification to a given
 // notification center
 let notificationCenter = NotificationCenter()
 expect {
     notificationCenter.post(testNotification)
 }.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+
+// Passes if the closure in expect { ... } posts a notification with the provided names to a given
+// notification center. Make sure to use this when running tests on Catalina, 
+// as there is currently no way of observing notifications without providing specific names.
+let notificationCenter = NotificationCenter()
+expect {
+    notificationCenter.post(testNotification)
+}.to(postNotifications(equal([testNotification]), 
+                       fromNotificationCenter: notificationCenter, 
+                       names: [testNotification.name]))
 ```
 
 > This matcher is only available in Swift.

--- a/README.md
+++ b/README.md
@@ -1189,13 +1189,14 @@ expect {
 
 // Passes if the closure in expect { ... } posts a notification with the provided names to a given
 // notification center. Make sure to use this when running tests on Catalina, 
-// as there is currently no way of observing notifications without providing specific names.
-let notificationCenter = NotificationCenter()
+// using DistributedNotificationCenter as there is currently no way 
+// of observing notifications without providing specific names.
+let distributedNotificationCenter = DistributedNotificationCenter()
 expect {
-    notificationCenter.post(testNotification)
-}.to(postNotifications(equal([testNotification]), 
-                       fromNotificationCenter: notificationCenter, 
-                       names: [testNotification.name]))
+    distributedNotificationCenter.post(testNotification)
+}.toEventually(postDistributedNotifications(equal([testNotification]), 
+                                  fromNotificationCenter: distributedNotificationCenter, 
+                                  names: [testNotification.name]))
 ```
 
 > This matcher is only available in Swift.

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -4,23 +4,35 @@ import Foundation
 internal class NotificationCollector {
     private(set) var observedNotifications: [Notification]
     private let notificationCenter: NotificationCenter
-    private var token: NSObjectProtocol?
+    private let names: Set<Notification.Name>?
+    private var tokens: [NSObjectProtocol]
 
-    required init(notificationCenter: NotificationCenter) {
+    required init(notificationCenter: NotificationCenter, names: Set<Notification.Name>?) {
         self.notificationCenter = notificationCenter
         self.observedNotifications = []
+        self.names = names?.isEmpty == true ? nil : names
+        self.tokens = []
     }
 
     func startObserving() {
-        // swiftlint:disable:next line_length
-        self.token = self.notificationCenter.addObserver(forName: nil, object: nil, queue: nil) { [weak self] notification in
-            // linux-swift gets confused by .append(n)
-            self?.observedNotifications.append(notification)
+        if let names = self.names {
+            self.tokens.append(contentsOf: names.map { name in
+                self.notificationCenter.addObserver(forName: name, object: nil, queue: nil) { [weak self] notification in
+                    // linux-swift gets confused by .append(n)
+                    self?.observedNotifications.append(notification)
+                }
+            })
+        } else {
+            // swiftlint:disable:next line_length
+            self.tokens.append(self.notificationCenter.addObserver(forName: nil, object: nil, queue: nil) { [weak self] notification in
+                // linux-swift gets confused by .append(n)
+                self?.observedNotifications.append(notification)
+            })
         }
     }
 
     deinit {
-        if let token = self.token {
+        self.tokens.forEach { token in
             self.notificationCenter.removeObserver(token)
         }
     }
@@ -30,10 +42,11 @@ private let mainThread = pthread_self()
 
 public func postNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: NotificationCenter = .default
+    fromNotificationCenter center: NotificationCenter = .default,
+    names: Set<Notification.Name>? = nil
 ) -> Predicate<Any> {
     _ = mainThread // Force lazy-loading of this value
-    let collector = NotificationCollector(notificationCenter: center)
+    let collector = NotificationCollector(notificationCenter: center, names: names)
     collector.startObserving()
     var once: Bool = false
 
@@ -70,11 +83,12 @@ public func postNotifications(
 @available(*, deprecated, message: "Use Predicate instead")
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = .default)
+    fromNotificationCenter center: NotificationCenter = .default,
+    names: Set<Notification.Name>? = nil)
     -> Predicate<Any>
     where T: Matcher, T.ValueType == [Notification] {
     _ = mainThread // Force lazy-loading of this value
-    let collector = NotificationCollector(notificationCenter: center)
+        let collector = NotificationCollector(notificationCenter: center, names: names)
     collector.startObserving()
     var once: Bool = false
 

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -42,8 +42,15 @@ private let mainThread = pthread_self()
 
 public func postNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: NotificationCenter = .default,
-    names: Set<Notification.Name>? = nil
+    fromNotificationCenter center: NotificationCenter = .default
+) -> Predicate<Any> {
+    _postNotifications(predicate, fromNotificationCenter: center, names: nil)
+}
+
+private func _postNotifications(
+    _ predicate: Predicate<[Notification]>,
+    fromNotificationCenter center: NotificationCenter,
+    names: Set<Notification.Name>?
 ) -> Predicate<Any> {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center, names: names)
@@ -80,15 +87,24 @@ public func postNotifications(
     }
 }
 
+#if os(OSX)
+public func postDistributedNotifications(
+    _ predicate: Predicate<[Notification]>,
+    fromNotificationCenter center: DistributedNotificationCenter = .default(),
+    names: Set<Notification.Name>
+) -> Predicate<Any> {
+    _postNotifications(predicate, fromNotificationCenter: center, names: names)
+}
+#endif
+
 @available(*, deprecated, message: "Use Predicate instead")
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = .default,
-    names: Set<Notification.Name>? = nil)
+    fromNotificationCenter center: NotificationCenter = .default)
     -> Predicate<Any>
     where T: Matcher, T.ValueType == [Notification] {
     _ = mainThread // Force lazy-loading of this value
-        let collector = NotificationCollector(notificationCenter: center, names: names)
+        let collector = NotificationCollector(notificationCenter: center, names: nil)
     collector.startObserving()
     var once: Bool = false
 

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -73,18 +73,16 @@ final class PostNotificationTest: XCTestCase {
         }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
     }
     
-    func testPassesWhenOnlySubscribedNotificationsArePosted() {
-        let foo = 1 as NSNumber
-        let bar = 2 as NSNumber
-        let baz = 3 as NSNumber
-        let n1 = Notification(name: Notification.Name("Foo"), object: foo)
-        let n2 = Notification(name: Notification.Name("Bar"), object: bar)
-        let n3 = Notification(name: Notification.Name("Baz"), object: baz)
+    #if os(OSX)
+    func testPassesWhenAllExpectedNotificationsarePostedInDistributedNotificationCenter() {
+        let center = DistributedNotificationCenter()
+        let n1 = Notification(name: Notification.Name("Foo"), object: "1")
+        let n2 = Notification(name: Notification.Name("Bar"), object: "2")
         expect {
-            self.notificationCenter.post(n1)
-            self.notificationCenter.post(n2)
-            self.notificationCenter.post(n3)
+            center.post(n1)
+            center.post(n2)
             return nil
-        }.to(postNotifications(equal([n1, n3]), fromNotificationCenter: notificationCenter, names: [n1.name, n3.name]))
+        }.toEventually(postDistributedNotifications(equal([n1, n2]), fromNotificationCenter: center, names: [n1.name, n2.name]))
     }
+    #endif
 }

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -72,4 +72,19 @@ final class PostNotificationTest: XCTestCase {
             return nil
         }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
     }
+    
+    func testPassesWhenOnlySubscribedNotificationsArePosted() {
+        let foo = 1 as NSNumber
+        let bar = 2 as NSNumber
+        let baz = 3 as NSNumber
+        let n1 = Notification(name: Notification.Name("Foo"), object: foo)
+        let n2 = Notification(name: Notification.Name("Bar"), object: bar)
+        let n3 = Notification(name: Notification.Name("Baz"), object: baz)
+        expect {
+            self.notificationCenter.post(n1)
+            self.notificationCenter.post(n2)
+            self.notificationCenter.post(n3)
+            return nil
+        }.to(postNotifications(equal([n1, n3]), fromNotificationCenter: notificationCenter, names: [n1.name, n3.name]))
+    }
 }


### PR DESCRIPTION
This is a workaround for postNotification not working at all on Catalina, due to Catalina not calling any observers subscribed to "nil" name.

Checklist - While not every PR needs it, new features should consider this list:

- [X] Does this have tests?
- [X] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [X] Is this a new feature (Requires minor version bump)?
