### PR TITLE
Rename `postNotifications(_:fromNotificationCenter:)` to `postNotifications(_:from:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,7 +1185,7 @@ expect {
 let notificationCenter = NotificationCenter()
 expect {
     notificationCenter.post(testNotification)
-}.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+}.to(postNotifications(equal([testNotification]), from: notificationCenter))
 
 // Passes if the closure in expect { ... } posts a notification with the provided names to a given
 // notification center. Make sure to use this when running tests on Catalina, 
@@ -1194,8 +1194,8 @@ expect {
 let distributedNotificationCenter = DistributedNotificationCenter()
 expect {
     distributedNotificationCenter.post(testNotification)
-}.toEventually(postDistributedNotifications(equal([testNotification]), 
-                                  fromNotificationCenter: distributedNotificationCenter, 
+}.toEventually(postDistributedNotifications(equal([testNotification]),
+                                  from: distributedNotificationCenter,
                                   names: [testNotification.name]))
 ```
 

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -42,7 +42,7 @@ private let mainThread = pthread_self()
 
 private func _postNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: NotificationCenter,
+    from center: NotificationCenter,
     names: Set<Notification.Name> = []
 ) -> Predicate<Any> {
     _ = mainThread // Force lazy-loading of this value
@@ -82,25 +82,33 @@ private func _postNotifications(
 
 public func postNotifications(
     _ predicate: Predicate<[Notification]>,
+    from center: NotificationCenter = .default
+) -> Predicate<Any> {
+    _postNotifications(predicate, from: center)
+}
+
+@available(*, deprecated, renamed: "postNotifications(_:from:)")
+public func postNotifications(
+    _ predicate: Predicate<[Notification]>,
     fromNotificationCenter center: NotificationCenter = .default
 ) -> Predicate<Any> {
-    _postNotifications(predicate, fromNotificationCenter: center)
+    postNotifications(predicate, from: center)
 }
 
 #if os(macOS)
 public func postDistributedNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: DistributedNotificationCenter = .default(),
+    from center: DistributedNotificationCenter = .default(),
     names: Set<Notification.Name>
 ) -> Predicate<Any> {
-    _postNotifications(predicate, fromNotificationCenter: center, names: names)
+    _postNotifications(predicate, from: center, names: names)
 }
 #endif
 
 @available(*, deprecated, message: "Use Predicate instead")
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = .default
+    from center: NotificationCenter = .default
 ) -> Predicate<Any> where T: Matcher, T.ValueType == [Notification] {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center)
@@ -127,5 +135,13 @@ public func postNotifications<T>(
         }
         return PredicateResult(bool: match, message: failureMessage.toExpectationMessage())
     }
+}
+
+@available(*, deprecated, renamed: "postNotifications(_:from:)")
+public func postNotifications<T>(
+    _ notificationsMatcher: T,
+    fromNotificationCenter center: NotificationCenter = .default
+) -> Predicate<Any> where T: Matcher, T.ValueType == [Notification] {
+    return postNotifications(notificationsMatcher, from: center)
 }
 #endif

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -9,14 +9,14 @@ final class PostNotificationTest: XCTestCase {
         expect {
             // no notifications here!
             return nil
-        }.to(postNotifications(beEmpty(), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(beEmpty(), from: notificationCenter))
     }
 
     func testPassesWhenExpectedNotificationIsPosted() {
         let testNotification = Notification(name: Notification.Name("Foo"), object: nil)
         expect {
             self.notificationCenter.post(testNotification)
-        }.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([testNotification]), from: notificationCenter))
     }
 
     func testPassesWhenAllExpectedNotificationsArePosted() {
@@ -28,7 +28,7 @@ final class PostNotificationTest: XCTestCase {
             self.notificationCenter.post(n1)
             self.notificationCenter.post(n2)
             return nil
-        }.to(postNotifications(equal([n1, n2]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([n1, n2]), from: notificationCenter))
     }
 
     func testFailsWhenNoNotificationsArePosted() {
@@ -37,7 +37,7 @@ final class PostNotificationTest: XCTestCase {
             expect {
                 // no notifications here!
                 return nil
-            }.to(postNotifications(equal([testNotification]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([testNotification]), from: self.notificationCenter))
         }
     }
 
@@ -48,7 +48,7 @@ final class PostNotificationTest: XCTestCase {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
 
@@ -59,7 +59,7 @@ final class PostNotificationTest: XCTestCase {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
 
@@ -70,7 +70,7 @@ final class PostNotificationTest: XCTestCase {
                 self.notificationCenter.post(testNotification)
             }
             return nil
-        }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+        }.toEventually(postNotifications(equal([testNotification]), from: notificationCenter))
     }
 
     #if os(macOS)
@@ -81,7 +81,7 @@ final class PostNotificationTest: XCTestCase {
         expect { () -> Void in
             center.post(n1)
             center.post(n2)
-        }.toEventually(postDistributedNotifications(equal([n1, n2]), fromNotificationCenter: center, names: [n1.name, n2.name]))
+        }.toEventually(postDistributedNotifications(equal([n1, n2]), from: center, names: [n1.name, n2.name]))
     }
     #endif
 }


### PR DESCRIPTION
`postNotifications(_:fromNotificationCenter:)` is deprecated and will be removed.

ref: https://swift.org/documentation/api-design-guidelines