### PR TITLE
[8.x] Rename `postNotifications(_:fromNotificationCenter:)` to `postNotifications(_:from:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,7 +1186,7 @@ expect {
 let notificationCenter = NotificationCenter()
 expect {
     notificationCenter.postNotification(testNotification)
-}.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+}.to(postNotifications(equal([testNotification]), from: notificationCenter))
 ```
 
 > This matcher is only available in Swift.

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -29,7 +29,7 @@ private let mainThread = pthread_self()
 
 public func postNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: NotificationCenter = .default
+    from center: NotificationCenter = .default
 ) -> Predicate<Any> {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center)
@@ -66,12 +66,18 @@ public func postNotifications(
     }
 }
 
+@available(*, deprecated, renamed: "postNotifications(_:from:)")
+public func postNotifications(
+    _ predicate: Predicate<[Notification]>,
+    fromNotificationCenter center: NotificationCenter = .default
+) -> Predicate<Any> {
+    return postNotifications(predicate, from: center)
+}
+
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = .default)
-    -> Predicate<Any>
-    where T: Matcher, T.ValueType == [Notification]
-{
+    from center: NotificationCenter = .default
+)-> Predicate<Any> where T: Matcher, T.ValueType == [Notification] {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center)
     collector.startObserving()
@@ -97,4 +103,12 @@ public func postNotifications<T>(
         }
         return PredicateResult(bool: match, message: failureMessage.toExpectationMessage())
     }
+}
+
+@available(*, deprecated, renamed: "postNotifications(_:from:)")
+public func postNotifications<T>(
+    _ notificationsMatcher: T,
+    fromNotificationCenter center: NotificationCenter = .default
+)-> Predicate<Any> where T: Matcher, T.ValueType == [Notification] {
+    return postNotifications(notificationsMatcher, from: center)
 }

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -9,14 +9,14 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
         expect {
             // no notifications here!
             return nil
-        }.to(postNotifications(beEmpty(), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(beEmpty(), from: notificationCenter))
     }
 
     func testPassesWhenExpectedNotificationIsPosted() {
         let testNotification = Notification(name: Notification.Name("Foo"), object: nil)
         expect {
             self.notificationCenter.post(testNotification)
-        }.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([testNotification]), from: notificationCenter))
     }
 
     func testPassesWhenAllExpectedNotificationsArePosted() {
@@ -28,7 +28,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
             self.notificationCenter.post(n1)
             self.notificationCenter.post(n2)
             return nil
-        }.to(postNotifications(equal([n1, n2]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([n1, n2]), from: notificationCenter))
     }
 
     func testFailsWhenNoNotificationsArePosted() {
@@ -37,7 +37,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
             expect {
                 // no notifications here!
                 return nil
-            }.to(postNotifications(equal([testNotification]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([testNotification]), from: self.notificationCenter))
         }
     }
 
@@ -48,7 +48,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
 
@@ -59,7 +59,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
 
@@ -70,6 +70,6 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
                 self.notificationCenter.post(testNotification)
             }
             return nil
-        }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+        }.toEventually(postNotifications(equal([testNotification]), from: notificationCenter))
     }
 }


### PR DESCRIPTION
Cherry-picks #788 into `8.x-branch`.

---

`postNotifications(_:fromNotificationCenter:)` is deprecated and will be removed.

ref: https://swift.org/documentation/api-design-guidelines