### PR TITLE
Disambiguate `postNotifications` overloads

### DIFF
--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -90,7 +90,7 @@ public func postNotifications(
 @available(*, deprecated, renamed: "postNotifications(_:from:)")
 public func postNotifications(
     _ predicate: Predicate<[Notification]>,
-    fromNotificationCenter center: NotificationCenter = .default
+    fromNotificationCenter center: NotificationCenter
 ) -> Predicate<Any> {
     postNotifications(predicate, from: center)
 }
@@ -140,7 +140,7 @@ public func postNotifications<T>(
 @available(*, deprecated, renamed: "postNotifications(_:from:)")
 public func postNotifications<T>(
     _ notificationsMatcher: T,
-    fromNotificationCenter center: NotificationCenter = .default
+    fromNotificationCenter center: NotificationCenter
 ) -> Predicate<Any> where T: Matcher, T.ValueType == [Notification] {
     return postNotifications(notificationsMatcher, from: center)
 }

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -9,7 +9,7 @@ final class PostNotificationTest: XCTestCase {
         expect {
             // no notifications here!
             return nil
-        }.to(postNotifications(beEmpty(), from: notificationCenter))
+        }.to(postNotifications(beEmpty()))
     }
 
     func testPassesWhenExpectedNotificationIsPosted() {


### PR DESCRIPTION
Fixes #792. Cherry-picks #793.