### PR TITLE
Support Xcode 12 / Swift 5.3

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -76,7 +76,8 @@ public func recordFailure(_ message: String, location: SourceLocation) {
 #if SWIFT_PACKAGE
     XCTFail("\(message)", file: location.file, line: location.line)
 #else
-    if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase {
+    if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase,
+       #available(OSXApplicationExtension 10.13, *) {
         let line = Int(location.line)
         testCase.recordFailure(withDescription: message, inFile: location.file, atLine: line, expected: true)
     } else {


### PR DESCRIPTION
Fixes this error: 

> 'recordFailure(withDescription:inFile:atLine:expected:)' is only available in application extensions for macOS 10.13 or newer