### PR TITLE
Adding toNever expectation

### DIFF
--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -152,6 +152,12 @@ extension Expectation {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// @discussion
+    /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
+    /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     public func toNever(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -167,6 +173,14 @@ extension Expectation {
         verify(pass, msg)
     }
 
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toNever()
+    ///
+    /// @discussion
+    /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
+    /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     public func neverTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -49,6 +49,43 @@ private func async<T>(style: ExpectationStyle, predicate: Predicate<T>, timeout:
     }
 }
 
+private func toNeverPredicate<T>(predicate: Predicate<T>, timeout: DispatchTimeInterval, poll: DispatchTimeInterval, fnName: String) -> Predicate<T> {
+    return Predicate { actualExpression in
+        let uncachedExpression = actualExpression.withoutCaching()
+        let fnName = "expect(...).\(fnName)(...)"
+        var lastPredicateResult: PredicateResult?
+        let result = pollBlock(
+            pollInterval: poll,
+            timeoutInterval: timeout,
+            file: actualExpression.location.file,
+            line: actualExpression.location.line,
+            fnName: fnName) {
+                lastPredicateResult = try predicate.satisfies(uncachedExpression)
+                return lastPredicateResult!.toBoolean(expectation: .toMatch)
+        }
+        switch result {
+            case .completed:
+                return PredicateResult(
+                    status: .fail,
+                    message: lastPredicateResult?.message ?? .fail("matched the predicate when it shouldn't have")
+                )
+            case .timedOut:
+                return PredicateResult(status: .doesNotMatch, message: .expectedTo("never match the predicate"))
+            case let .errorThrown(error):
+                return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
+            case let .raisedException(exception):
+                return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
+            case .blockedRunLoop:
+                // swiftlint:disable:next line_length
+                let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
+                    .fail("main run loop was unresponsive")
+                return PredicateResult(status: .fail, message: message)
+            case .incomplete:
+                internalError("Reached .incomplete state for \(fnName)(...).")
+        }
+    }
+}
+
 private let toEventuallyRequiresClosureError = FailureMessage(
     stringValue: """
         expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )
@@ -113,6 +150,25 @@ extension Expectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     public func toNotEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
+    }
+
+    public func toNever(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+
+        let (pass, msg) = execute(
+            expression,
+            .toNotMatch,
+            toNeverPredicate(predicate: predicate, timeout: until, poll: pollInterval, fnName: "toNever"),
+            to: "to never",
+            description: description,
+            captureExceptions: false
+        )
+        verify(pass, msg)
+    }
+
+    public func neverTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+        return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }
 

--- a/Tests/NimbleTests/AsynchronousTest.swift
+++ b/Tests/NimbleTests/AsynchronousTest.swift
@@ -250,4 +250,38 @@ final class AsyncTest: XCTestCase {
         }
     }
 
+    func testToNeverPositiveMatches() {
+
+        var value = 0
+        deferToMainQueue { value = 1 }
+        expect { value }.toNever(beGreaterThan(1))
+
+        deferToMainQueue { value = 0 }
+        expect { value }.neverTo(beGreaterThan(1))
+    }
+
+    func testToNeverNegativeMatches() {
+
+        var value = 0
+        failsWithErrorMessage("expected to never equal <0>, got <0>") {
+            expect { value }.toNever(equal(0))
+        }
+        failsWithErrorMessage("expected to never equal <0>, got <0>") {
+            expect { value }.neverTo(equal(0))
+        }
+        failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            deferToMainQueue { value = 1 }
+            expect { value }.toNever(equal(1))
+        }
+        failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            deferToMainQueue { value = 1 }
+            expect { value }.neverTo(equal(1))
+        }
+        failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toNever(equal(0))
+        }
+        failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.neverTo(equal(0))
+        }
+    }
 }


### PR DESCRIPTION
Adding a new expectation `toNever`, which will check a predicate so a value never matches that predicate. As opposed to `toEventuallyNot`, this expectation will fail if at some given point during the timeout interval the value matches the predicate.

- [X] Does this have tests? Added positive and negative matches to the new expectation
- [X] Does this have documentation?
- [ ] ~~Does this break the public API (Requires major version bump)?~~
- [X] Is this a new feature (Requires minor version bump)? Yes
