### PR TITLE
[8.x] Switch back to use `+[NSObject load]` for registering CurrentTestCaseTracker

### DIFF
--- a/Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m
+++ b/Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m
@@ -6,7 +6,12 @@
 #import <Nimble/Nimble-Swift.h>
 #endif
 
-__attribute__((constructor))
-static void registerCurrentTestCaseTracker(void) {
+#pragma mark - Private
+
+@implementation XCTestObservationCenter (Register)
+
++ (void)load {
     [[XCTestObservationCenter sharedTestObservationCenter] addTestObserver:[CurrentTestCaseTracker sharedInstance]];
 }
+
+@end


### PR DESCRIPTION
This would fix a static linking issue. Possibly closes #795.