### PR TITLE
[BREAKING] Make `postNotifications` generic and usable with non-void closures

### DIFF
--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -40,11 +40,11 @@ internal class NotificationCollector {
 
 private let mainThread = pthread_self()
 
-private func _postNotifications(
+private func _postNotifications<Out>(
     _ predicate: Predicate<[Notification]>,
     from center: NotificationCenter,
     names: Set<Notification.Name> = []
-) -> Predicate<Any> {
+) -> Predicate<Out> {
     _ = mainThread // Force lazy-loading of this value
     let collector = NotificationCollector(notificationCenter: center, names: names)
     collector.startObserving()
@@ -80,27 +80,27 @@ private func _postNotifications(
     }
 }
 
-public func postNotifications(
+public func postNotifications<Out>(
     _ predicate: Predicate<[Notification]>,
     from center: NotificationCenter = .default
-) -> Predicate<Any> {
+) -> Predicate<Out> {
     _postNotifications(predicate, from: center)
 }
 
 @available(*, deprecated, renamed: "postNotifications(_:from:)")
-public func postNotifications(
+public func postNotifications<Out>(
     _ predicate: Predicate<[Notification]>,
     fromNotificationCenter center: NotificationCenter
-) -> Predicate<Any> {
+) -> Predicate<Out> {
     postNotifications(predicate, from: center)
 }
 
 #if os(macOS)
-public func postDistributedNotifications(
+public func postDistributedNotifications<Out>(
     _ predicate: Predicate<[Notification]>,
     from center: DistributedNotificationCenter = .default(),
     names: Set<Notification.Name>
-) -> Predicate<Any> {
+) -> Predicate<Out> {
     _postNotifications(predicate, from: center, names: names)
 }
 #endif

--- a/Tests/NimbleTests/Matchers/PostNotificationTest.swift
+++ b/Tests/NimbleTests/Matchers/PostNotificationTest.swift
@@ -8,7 +8,6 @@ final class PostNotificationTest: XCTestCase {
     func testPassesWhenNoNotificationsArePosted() {
         expect {
             // no notifications here!
-            return nil
         }.to(postNotifications(beEmpty()))
     }
 
@@ -24,10 +23,9 @@ final class PostNotificationTest: XCTestCase {
         let bar = 2 as NSNumber
         let n1 = Notification(name: Notification.Name("Foo"), object: foo)
         let n2 = Notification(name: Notification.Name("Bar"), object: bar)
-        expect {
+        expect { () -> Void in
             self.notificationCenter.post(n1)
             self.notificationCenter.post(n2)
-            return nil
         }.to(postNotifications(equal([n1, n2]), from: notificationCenter))
     }
 
@@ -36,7 +34,6 @@ final class PostNotificationTest: XCTestCase {
         failsWithErrorMessage("expected to equal <[\(testNotification)]>, got no notifications") {
             expect {
                 // no notifications here!
-                return nil
             }.to(postNotifications(equal([testNotification]), from: self.notificationCenter))
         }
     }
@@ -47,7 +44,6 @@ final class PostNotificationTest: XCTestCase {
         failsWithErrorMessage("expected to equal <[\(n1)]>, got <[\(n2)]>") {
             expect {
                 self.notificationCenter.post(n2)
-                return nil
             }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
@@ -58,7 +54,6 @@ final class PostNotificationTest: XCTestCase {
         failsWithErrorMessage("expected to equal <[\(n1)]>, got <[\(n2)]>") {
             expect {
                 self.notificationCenter.post(n2)
-                return nil
             }.to(postNotifications(equal([n1]), from: self.notificationCenter))
         }
     }
@@ -69,7 +64,6 @@ final class PostNotificationTest: XCTestCase {
             deferToMainQueue {
                 self.notificationCenter.post(testNotification)
             }
-            return nil
         }.toEventually(postNotifications(equal([testNotification]), from: notificationCenter))
     }
 


### PR DESCRIPTION
Related to #493, #698, #742 and #752.