### PR TITLE
Revert "Remove unnecessary `throws` from the autoclosure variant of `expect`"

### DIFF
--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,5 +1,5 @@
 /// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(_ expression: @autoclosure @escaping () -> T?, file: FileString = #file, line: UInt = #line) -> Expectation<T> {
+public func expect<T>(_ expression: @autoclosure @escaping () throws -> T?, file: FileString = #file, line: UInt = #line) -> Expectation<T> {
     return Expectation(
         expression: Expression(
             expression: expression,


### PR DESCRIPTION
Reverts Quick/Nimble#821

That change was not correct.

refs:
- https://github.com/Quick/Nimble/issues/809#issuecomment-693008578
- https://github.com/Quick/Nimble/issues/809#issuecomment-693095773