### PR TITLE
NimbleXCTestHandler: replace deprecated recordFailure api with XCTIssue.

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -78,7 +78,16 @@ public func recordFailure(_ message: String, location: SourceLocation) {
 #else
     if let testCase = CurrentTestCaseTracker.sharedInstance.currentTestCase {
         let line = Int(location.line)
+#if swift(>=5.3)
+        let location = XCTSourceCodeLocation(filePath: location.file, lineNumber: line)
+        let sourceCodeContext = XCTSourceCodeContext(location: location)
+        let issue = XCTIssue(type: .assertionFailure, compactDescription: message,
+                             detailedDescription: message, sourceCodeContext: sourceCodeContext,
+                             associatedError: nil, attachments: [])
+        testCase.record(issue)
+#else
         testCase.recordFailure(withDescription: message, inFile: location.file, atLine: line, expected: true)
+#endif
     } else {
         let msg = """
             Attempted to report a test failure to XCTest while no test case was running. The failure was:

--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -81,9 +81,7 @@ public func recordFailure(_ message: String, location: SourceLocation) {
 #if swift(>=5.3)
         let location = XCTSourceCodeLocation(filePath: location.file, lineNumber: line)
         let sourceCodeContext = XCTSourceCodeContext(location: location)
-        let issue = XCTIssue(type: .assertionFailure, compactDescription: message,
-                             detailedDescription: message, sourceCodeContext: sourceCodeContext,
-                             associatedError: nil, attachments: [])
+        let issue = XCTIssue(type: .assertionFailure, compactDescription: message, sourceCodeContext: sourceCodeContext)
         testCase.record(issue)
 #else
         testCase.recordFailure(withDescription: message, inFile: location.file, atLine: line, expected: true)


### PR DESCRIPTION
For swift 5.3 and above `XCTIssue` is used with `record:` api.
It solves https://github.com/Quick/Nimble/issues/829.