### PR TITLE
Fixed Use Predicate directly instead warning when passing in a Predicate

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -1,21 +1,3 @@
-@available(*, deprecated)
-internal func expressionDoesNotMatch<T, U>(_ expression: Expression<T>, matcher: U, toNot: String, description: String?) -> (Bool, FailureMessage)
-    where U: Matcher, U.ValueType == T {
-    let msg = FailureMessage()
-    msg.userDescription = description
-    msg.to = toNot
-    do {
-        let pass = try matcher.doesNotMatch(expression, failureMessage: msg)
-        if msg.actualValue == "" {
-            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
-        }
-        return (pass, msg)
-    } catch let error {
-        msg.stringValue = "unexpected error thrown: <\(error)>"
-        return (false, msg)
-    }
-}
-
 internal func execute<T>(_ expression: Expression<T>, _ style: ExpectationStyle, _ predicate: Predicate<T>, to: String, description: String?, captureExceptions: Bool = true) -> (Bool, FailureMessage) {
     func run() -> (Bool, FailureMessage) {
         let msg = FailureMessage()
@@ -89,7 +71,14 @@ public struct Expectation<T> {
     public func toNot<U>(_ matcher: U, description: String? = nil) -> Self
         where U: Matcher, U.ValueType == T {
         // swiftlint:disable:next line_length
-        let (pass, msg) = expressionDoesNotMatch(expression, matcher: matcher, toNot: "to not", description: description)
+        let (pass, msg) = execute(
+            expression,
+            .toNotMatch,
+            matcher.predicate,
+            to: "to not",
+            description: description,
+            captureExceptions: false
+        )
         verify(pass, msg)
         return self
     }

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -156,17 +156,19 @@ extension Expectation {
     public func toEventuallyNot<U>(_ matcher: U, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil)
         where U: Matcher, U.ValueType == T {
         if expression.isClosure {
-            let (pass, msg) = expressionDoesNotMatch(
+            let (pass, msg) = execute(
                 expression,
-                matcher: async(
+                .toNotMatch,
+                async(
                     style: .toNotMatch,
                     predicate: matcher.predicate,
                     timeout: timeout,
                     poll: pollInterval,
                     fnName: "toEventuallyNot"
                 ),
-                toNot: "to eventually not",
-                description: description
+                to: "to eventually not",
+                description: description,
+                captureExceptions: false
             )
             verify(pass, msg)
         } else {

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -183,7 +183,7 @@ extension Predicate {
 
 // Backwards compatibility until Old Matcher API removal
 @available(*, deprecated, message: "Use Predicate directly instead")
-extension Predicate: Matcher {
+extension Predicate {
     /// Compatibility layer for old Matcher API, deprecated
     public static func fromDeprecatedFullClosure(_ matcher: @escaping (Expression<T>, FailureMessage, Bool) throws -> Bool) -> Predicate {
         return Predicate { actual in


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

- What behavior was changed?
Fixed "use Predicate directly instead" warning when passing in a Predicate

- What code was refactored / updated to support this change?
Deprecated code that causes warnings due to changes in Swift 5.3 

- What issues are related to this PR? Or why was this change introduced?
https://github.com/Quick/Nimble/issues/834

Checklist - While not every PR needs it, new features should consider this list:
- [ ] Does this have tests?
Old tests should be enough
- [ ] Does this have documentation?
Old documentation should be enough
- [ ] Does this break the public API (Requires major version bump)?
nope
- [ ] Is this a new feature (Requires minor version bump)?
nope, but a patch release would be nice :)
