### PR TITLE
Use target dependency condition instead of build machine info

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,9 @@ let package = Package(
             name: "Nimble", 
             dependencies: [
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS])),
+                         condition: .when(platforms: [.macOS, .iOS, .tvOS])),
                 .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS]))
+                         condition: .when(platforms: [.macOS, .iOS, .tvOS]))
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,9 @@ let package = Package(
             name: "Nimble", 
             dependencies: [
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS, .iOS, .tvOS])),
+                         condition: .when(platforms: [.macOS, .iOS])),
                 .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS, .iOS, .tvOS]))
+                         condition: .when(platforms: [.tvOS]))
             ]
         ),
         .testTarget(

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -15,12 +15,16 @@ let package = Package(
     targets: [
         .target(
             name: "Nimble", 
-            dependencies: [
-                .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS])),
-                .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS]))
-            ]
+            dependencies: {
+                #if os(macOS)
+                return [
+                    "CwlPreconditionTesting",
+                    .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting")
+                ]
+                #else
+                return []
+                #endif
+            }()
         ),
         .testTarget(
             name: "NimbleTests", 


### PR DESCRIPTION
Since swift-tools-version 5.3, SwiftPM allows us to declare conditional target dependencies in Package.swift. This is an important part when cross-building a package.

For example, when building a binary for Linux on macOS (currently it's impossible), Package.swift is evaluated as `os(macOS) == true`, but produced binary will run on Linux.

So, the platform we build on does not always match the platform a produced binary will run on.

The `condition: .when(...)` will be resolved based on the target platform a produced binary will run on.


Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
