### PR TITLE
Clean up function spacing

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -6,7 +6,7 @@ internal func expressionDoesNotMatch<T, U>(_ expression: Expression<T>, matcher:
     msg.to = toNot
     do {
         let pass = try matcher.doesNotMatch(expression, failureMessage: msg)
-        if msg.actualValue == "" {
+        if "" == msg.actualValue {
             msg.actualValue = "<\(stringify(try expression.evaluate()))>"
         }
         return (pass, msg)
@@ -24,7 +24,7 @@ internal func execute<T>(_ expression: Expression<T>, _ style: ExpectationStyle,
         do {
             let result = try predicate.satisfies(expression)
             result.message.update(failureMessage: msg)
-            if msg.actualValue == "" {
+            if "" == msg.actualValue {
                 msg.actualValue = "<\(stringify(try expression.evaluate()))>"
             }
             return (result.toBoolean(expectation: style), msg)

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -182,10 +182,10 @@ extension FailureMessage {
         }
 
         var message: ExpectationMessage = .fail(userDescription ?? "")
-        if actualValue != "" && actualValue != nil {
+        if "" != actualValue && nil != actualValue {
             message = .expectedCustomValueTo(postfixMessage, actual: actualValue ?? "")
         } else if postfixMessage != defaultMessage.postfixMessage {
-            if actualValue == nil {
+            if nil == actualValue {
                 message = .expectedTo(postfixMessage)
             } else {
                 message = .expectedActualValueTo(postfixMessage)

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -3,7 +3,6 @@
 public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
     return Predicate.define { actualExpression in
         let actual = try actualExpression.evaluate() as AnyObject?
-
         let bool = actual === (expected as AnyObject?) && actual !== nil
         return PredicateResult(
             bool: bool,

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -11,7 +11,6 @@ public func contain<S: Sequence>(_ items: S.Element...) -> Predicate<S> where S.
 public func contain<S: Sequence>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
@@ -28,7 +27,6 @@ public func contain<S: SetAlgebra>(_ items: S.Element...) -> Predicate<S> where 
 public func contain<S: SetAlgebra>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
@@ -45,7 +43,6 @@ public func contain<S: Sequence & SetAlgebra>(_ items: S.Element...) -> Predicat
 public func contain<S: Sequence & SetAlgebra>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
@@ -61,7 +58,6 @@ public func contain(_ substrings: String...) -> Predicate<String> {
 public func contain(_ substrings: [String]) -> Predicate<String> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = substrings.allSatisfy {
             let range = actual.range(of: $0)
             return range != nil && !range!.isEmpty
@@ -79,7 +75,6 @@ public func contain(_ substrings: NSString...) -> Predicate<NSString> {
 public func contain(_ substrings: [NSString]) -> Predicate<NSString> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = substrings.allSatisfy { actual.range(of: $0.description).length != 0 }
         return PredicateStatus(bool: matches)
     }
@@ -94,7 +89,6 @@ public func contain(_ items: Any?...) -> Predicate<NMBContainer> {
 public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy { item in
             return item.map { actual.contains($0) } ?? false
         }

--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -3,7 +3,7 @@ public func containElementSatisfying<S: Sequence>(
 ) -> Predicate<S> {
     return Predicate.define { actualExpression in
         let message: ExpectationMessage
-        if predicateDescription == "" {
+        if "" == predicateDescription {
             message = .expectedTo("find object in collection that satisfies predicate")
         } else {
             message = .expectedTo("find object in collection \(predicateDescription)")

--- a/Sources/Nimble/Matchers/MatchError.swift
+++ b/Sources/Nimble/Matchers/MatchError.swift
@@ -6,7 +6,6 @@
 public func matchError<T: Error>(_ error: T) -> Predicate<Error> {
     return Predicate.define { actualExpression in
         let actualError = try actualExpression.evaluate()
-
         let message = messageForError(
             postfixMessageVerb: "match",
             actualError: actualError,
@@ -30,7 +29,6 @@ public func matchError<T: Error>(_ error: T) -> Predicate<Error> {
 public func matchError<T: Error & Equatable>(_ error: T) -> Predicate<Error> {
     return Predicate.define { actualExpression in
         let actualError = try actualExpression.evaluate()
-
         let message = messageForError(
             postfixMessageVerb: "match",
             actualError: actualError,
@@ -51,7 +49,6 @@ public func matchError<T: Error & Equatable>(_ error: T) -> Predicate<Error> {
 public func matchError<T: Error>(_ errorType: T.Type) -> Predicate<Error> {
     return Predicate.define { actualExpression in
         let actualError = try actualExpression.evaluate()
-
         let message = messageForError(
             postfixMessageVerb: "match",
             actualError: actualError,


### PR DESCRIPTION
I have cleaned up some of the function spacing in the code and changed a few instances of `variable != literal` to `literal != variable` to be more consistent.