### PR TITLE
Add spaces between code and return statements

### DIFF
--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -103,6 +103,7 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
 
     let dispatcher = AssertionDispatcher(handlers: handlers)
     withAssertionHandler(dispatcher, closure: closure)
+    
     return recorder.assertions
 }
 
@@ -119,6 +120,7 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
 /// @see raiseException source for an example use case.
 public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let assertions = gatherExpectations(silently: silently, closure: closure)
+    
     return assertions.filter { assertion in
         !assertion.success
     }

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -68,6 +68,7 @@ public class NMBExpectation: NSObject {
             } else {
                 self.expectValue.to(from(matcher: matcher, style: .toMatch))
             }
+            
             return self
         }
     }
@@ -79,6 +80,7 @@ public class NMBExpectation: NSObject {
             } else {
                 self.expectValue.to(from(matcher: matcher, style: .toMatch), description: description)
             }
+            
             return self
         }
     }
@@ -90,6 +92,7 @@ public class NMBExpectation: NSObject {
             } else {
                 self.expectValue.toNot(from(matcher: matcher, style: .toNotMatch))
             }
+            
             return self
         }
     }
@@ -101,6 +104,7 @@ public class NMBExpectation: NSObject {
             } else {
                 self.expectValue.toNot(from(matcher: matcher, style: .toNotMatch), description: description)
             }
+            
             return self
         }
     }

--- a/Sources/Nimble/Adapters/NMBObjCMatcher.swift
+++ b/Sources/Nimble/Adapters/NMBObjCMatcher.swift
@@ -47,13 +47,16 @@ public class NMBObjCMatcher: NSObject, NMBMatcher {
             if !canMatchNil {
                 if try actualExpression.evaluate() == nil {
                     failureMessage.postfixActual = " (use beNil() to match nils)"
+                    
                     return false
                 }
             }
         } catch let error {
             failureMessage.actualValue = "an unexpected error thrown: \(error)"
+            
             return false
         }
+        
         return true
     }
 
@@ -64,6 +67,7 @@ public class NMBObjCMatcher: NSObject, NMBMatcher {
             result = try _match(expr, failureMessage)
         } catch let error {
             failureMessage.stringValue = "unexpected error thrown: <\(error)>"
+            
             return false
         }
 
@@ -81,6 +85,7 @@ public class NMBObjCMatcher: NSObject, NMBMatcher {
             result = try _doesNotMatch(expr, failureMessage)
         } catch let error {
             failureMessage.stringValue = "unexpected error thrown: <\(error)>"
+            
             return false
         }
 

--- a/Sources/Nimble/Adapters/NimbleEnvironment.swift
+++ b/Sources/Nimble/Adapters/NimbleEnvironment.swift
@@ -13,6 +13,7 @@ internal class NimbleEnvironment: NSObject {
             } else {
                 let newEnv = NimbleEnvironment()
                 self.activeInstance = newEnv
+                
                 return newEnv
             }
         }

--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -9,9 +9,11 @@ internal func expressionDoesNotMatch<T, U>(_ expression: Expression<T>, matcher:
         if msg.actualValue == "" {
             msg.actualValue = "<\(stringify(try expression.evaluate()))>"
         }
+        
         return (pass, msg)
     } catch let error {
         msg.stringValue = "unexpected error thrown: <\(error)>"
+        
         return (false, msg)
     }
 }
@@ -27,9 +29,11 @@ internal func execute<T>(_ expression: Expression<T>, _ style: ExpectationStyle,
             if msg.actualValue == "" {
                 msg.actualValue = "<\(stringify(try expression.evaluate()))>"
             }
+            
             return (result.toBoolean(expectation: style), msg)
         } catch let error {
             msg.stringValue = "unexpected error thrown: <\(error)>"
+            
             return (false, msg)
         }
     }
@@ -80,6 +84,7 @@ public struct Expectation<T> {
                 captureExceptions: false
             )
             verify(pass, msg)
+        
             return self
     }
 
@@ -91,6 +96,7 @@ public struct Expectation<T> {
         // swiftlint:disable:next line_length
         let (pass, msg) = expressionDoesNotMatch(expression, matcher: matcher, toNot: "to not", description: description)
         verify(pass, msg)
+        
         return self
     }
 
@@ -111,6 +117,7 @@ public struct Expectation<T> {
     public func to(_ predicate: Predicate<T>, description: String? = nil) -> Self {
         let (pass, msg) = execute(expression, .toMatch, predicate, to: "to", description: description)
         verify(pass, msg)
+        
         return self
     }
 
@@ -119,6 +126,7 @@ public struct Expectation<T> {
     public func toNot(_ predicate: Predicate<T>, description: String? = nil) -> Self {
         let (pass, msg) = execute(expression, .toNotMatch, predicate, to: "to not", description: description)
         verify(pass, msg)
+        
         return self
     }
 

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -90,6 +90,7 @@ public indirect enum ExpectationMessage {
                 return msg
             }
         }
+        
         return visitLeafs(walk)
     }
 
@@ -113,6 +114,7 @@ public indirect enum ExpectationMessage {
                 return msg.visitLeafs(walk)
             }
         }
+        
         return visitLeafs(walk)
     }
 
@@ -197,6 +199,7 @@ extension FailureMessage {
         if let extended = extendedMessage {
             message = .details(message, extended)
         }
+        
         return message
     }
 }

--- a/Sources/Nimble/Expression.swift
+++ b/Sources/Nimble/Expression.swift
@@ -6,6 +6,7 @@ internal func memoizedClosure<T>(_ closure: @escaping () throws -> T) -> (Bool) 
         if withoutCaching || cache == nil {
             cache = try closure()
         }
+        
         return cache!
     }
 }

--- a/Sources/Nimble/FailureMessage.swift
+++ b/Sources/Nimble/FailureMessage.swift
@@ -43,6 +43,7 @@ public class FailureMessage: NSObject {
 
     internal func stripNewlines(_ str: String) -> String {
         let whitespaces = CharacterSet.whitespacesAndNewlines
+        
         return str
             .components(separatedBy: "\n")
             .map { line in line.trimmingCharacters(in: whitespaces) }

--- a/Sources/Nimble/Matchers/AllPass.swift
+++ b/Sources/Nimble/Matchers/AllPass.swift
@@ -4,6 +4,7 @@ public func allPass<S: Sequence>(
     let matcher = Predicate.simpleNilable("pass a condition") { actualExpression in
         return PredicateStatus(bool: try passFunc(try actualExpression.evaluate()))
     }
+    
     return createPredicate(matcher)
 }
 
@@ -14,6 +15,7 @@ public func allPass<S: Sequence>(
     let matcher = Predicate.simpleNilable(passName) { actualExpression in
         return PredicateStatus(bool: try passFunc(try actualExpression.evaluate()))
     }
+    
     return createPredicate(matcher)
 }
 
@@ -50,12 +52,14 @@ private func createPredicate<S: Sequence>(_ elementMatcher: Predicate<S.Element>
                         after: ", but failed first at element <\(stringify(currentElement))>"
                             + " in <\(stringify(actualValue))>"
                 )
+                
                 return PredicateResult(status: .doesNotMatch, message: failure)
             }
         }
         failure = failure.replacedExpectation({ expectation in
             return .expectedTo(expectation.expectedMessage)
         })
+        
         return PredicateResult(status: .matches, message: failure)
     }
 }
@@ -110,12 +114,14 @@ extension NMBPredicate {
                         location: expr.location
                     )
                     let expectationMsg = failureMessage.toExpectationMessage()
+                    
                     return PredicateResult(
                         bool: result,
                         message: expectationMsg
                     )
                 }
             })
+            
             return try pred.satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -30,7 +30,8 @@ private func async<T>(style: ExpectationStyle, predicate: Predicate<T>, timeout:
                 return lastPredicateResult!.toBoolean(expectation: style)
         }
         switch result {
-        case .completed: return lastPredicateResult!
+        case .completed:
+            return lastPredicateResult!
         case .timedOut:
             let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
             return PredicateResult(status: .fail, message: message)

--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -13,6 +13,7 @@ public func beAKindOf<T>(_ expectedType: T.Type) -> Predicate<Any> {
         let instance = try actualExpression.evaluate()
         guard let validInstance = instance else {
             message = .expectedCustomValueTo(matcherMessage(forType: expectedType), actual: "<nil>")
+            
             return PredicateResult(status: .fail, message: message)
         }
         message = .expectedCustomValueTo(

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -38,6 +38,7 @@ public func beAnInstanceOf(_ expectedClass: AnyClass) -> Predicate<NSObject> {
         #else
             let matches = instance != nil && type(of: instance!) == expectedClass
         #endif
+        
         return PredicateResult(
             status: PredicateStatus(bool: matches),
             message: .expectedCustomValueTo(errorMessage, actual: actualString)

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -8,6 +8,7 @@ internal func isCloseTo(_ actualValue: NMBDoubleConvertible?,
                         delta: Double)
     -> PredicateResult {
         let errorMessage = "be close to <\(stringify(expectedValue))> (within \(stringify(delta)))"
+    
         return PredicateResult(
             bool: actualValue != nil &&
                 abs(actualValue!.doubleValue - expectedValue.doubleValue) < delta,
@@ -63,6 +64,7 @@ extension NMBPredicate {
 
 public func beCloseTo(_ expectedValues: [Double], within delta: Double = DefaultDelta) -> Predicate<[Double]> {
     let errorMessage = "be close to <\(stringify(expectedValues))> (each within \(stringify(delta)))"
+    
     return Predicate.simple(errorMessage) { actualExpression in
         if let actual = try actualExpression.evaluate() {
             if actual.count != expectedValues.count {
@@ -73,9 +75,11 @@ public func beCloseTo(_ expectedValues: [Double], within delta: Double = Default
                         return .doesNotMatch
                     }
                 }
+                
                 return .matches
             }
         }
+        
         return .doesNotMatch
     }
 }

--- a/Sources/Nimble/Matchers/BeEmpty.swift
+++ b/Sources/Nimble/Matchers/BeEmpty.swift
@@ -5,8 +5,8 @@ import Foundation
 public func beEmpty<S: Sequence>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         var generator = actual.makeIterator()
+        
         return PredicateStatus(bool: generator.next() == nil)
     }
 }
@@ -16,6 +16,7 @@ public func beEmpty<S: Sequence>() -> Predicate<S> {
 public func beEmpty<S: SetAlgebra>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.isEmpty)
     }
 }
@@ -25,6 +26,7 @@ public func beEmpty<S: SetAlgebra>() -> Predicate<S> {
 public func beEmpty<S: Sequence & SetAlgebra>() -> Predicate<S> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.isEmpty)
     }
 }
@@ -34,6 +36,7 @@ public func beEmpty<S: Sequence & SetAlgebra>() -> Predicate<S> {
 public func beEmpty() -> Predicate<String> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.isEmpty)
     }
 }
@@ -43,6 +46,7 @@ public func beEmpty() -> Predicate<String> {
 public func beEmpty() -> Predicate<NSString> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.length == 0)
     }
 }
@@ -55,6 +59,7 @@ public func beEmpty() -> Predicate<NSString> {
 public func beEmpty() -> Predicate<NSDictionary> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.count == 0)
     }
 }
@@ -64,6 +69,7 @@ public func beEmpty() -> Predicate<NSDictionary> {
 public func beEmpty() -> Predicate<NSArray> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.count == 0)
     }
 }
@@ -73,6 +79,7 @@ public func beEmpty() -> Predicate<NSArray> {
 public func beEmpty() -> Predicate<NMBCollection> {
     return Predicate.simple("be empty") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        
         return PredicateStatus(bool: actual.count == 0)
     }
 }
@@ -86,13 +93,16 @@ extension NMBPredicate {
 
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value }), location: location)
+                
                 return try beEmpty().satisfies(expr).toObjectiveC()
             } else if let value = actualValue as? NSString {
                 let expr = Expression(expression: ({ value }), location: location)
+                
                 return try beEmpty().satisfies(expr).toObjectiveC()
             } else if let actualValue = actualValue {
                 // swiftlint:disable:next line_length
                 let badTypeErrorMsg = "be empty (only works for NSArrays, NSSets, NSIndexSets, NSDictionaries, NSHashTables, and NSStrings)"
+                
                 return NMBPredicateResult(
                     status: NMBPredicateStatus.fail,
                     message: NMBExpectationMessage(
@@ -101,6 +111,7 @@ extension NMBPredicate {
                     )
                 )
             }
+            
             return NMBPredicateResult(
                 status: NMBPredicateStatus.fail,
                 message: NMBExpectationMessage(expectedActualValueTo: "be empty").appendedBeNilHint()

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -18,10 +18,12 @@ import enum Foundation.ComparisonResult
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 public func beGreaterThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
     let errorMessage = "be greater than <\(stringify(expectedValue))>"
+    
     return Predicate.simple(errorMessage) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil
             && actualValue!.NMB_compare(expectedValue) == ComparisonResult.orderedDescending
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -34,6 +36,7 @@ extension NMBPredicate {
     @objc public class func beGreaterThanMatcher(_ expected: NMBComparable?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
+            
             return try beGreaterThan(expected).satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -20,9 +20,11 @@ import enum Foundation.ComparisonResult
 /// or equal to the expected value.
 public func beGreaterThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
     let message = "be greater than or equal to <\(stringify(expectedValue))>"
+    
     return Predicate.simple(message) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) != ComparisonResult.orderedAscending
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -35,6 +37,7 @@ extension NMBPredicate {
     @objc public class func beGreaterThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
+            
             return try beGreaterThanOrEqualTo(expected).satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -3,8 +3,8 @@
 public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
     return Predicate.define { actualExpression in
         let actual = try actualExpression.evaluate() as AnyObject?
-
         let bool = actual === (expected as AnyObject?) && actual !== nil
+        
         return PredicateResult(
             bool: bool,
             message: .expectedCustomValueTo(
@@ -40,6 +40,7 @@ extension NMBPredicate {
     @objc public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let aExpr = actualExpression.cast { $0 as Any? }
+            
             return try beIdenticalTo(expected).satisfies(aExpr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -21,6 +21,7 @@ public func beLessThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparab
     return Predicate.simple(message) { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue != nil && actualValue!.NMB_compare(expectedValue) == ComparisonResult.orderedAscending
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -33,6 +34,7 @@ extension NMBPredicate {
     @objc public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
+            
             return try beLessThan(expected).satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -21,6 +21,7 @@ public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predic
     return Predicate.simple("be less than or equal to <\(stringify(expectedValue))>") { actualExpression in
         let actualValue = try actualExpression.evaluate()
         let matches = actualValue.map { $0.NMB_compare(expectedValue) != .orderedDescending } ?? false
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -33,6 +34,7 @@ extension NMBPredicate {
     @objc public class func beLessThanOrEqualToMatcher(_ expected: NMBComparable?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { $0 as? NMBComparable }
+            
             return try beLessThanOrEqualTo(expected).satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -75,6 +75,7 @@ extension UInt: ExpressibleByBooleanLiteral {
 internal func rename<T>(_ matcher: Predicate<T>, failureMessage message: ExpectationMessage) -> Predicate<T> {
     return Predicate { actualExpression in
         let result = try matcher.satisfies(actualExpression)
+        
         return PredicateResult(status: result.status, message: message)
     }.requireNonNil
 }
@@ -102,6 +103,7 @@ public func beTruthy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<
         if let actualValue = actualValue {
             return PredicateStatus(bool: actualValue == (true as T))
         }
+        
         return PredicateStatus(bool: actualValue != nil)
     }
 }
@@ -114,6 +116,7 @@ public func beFalsy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<T
         if let actualValue = actualValue {
             return PredicateStatus(bool: actualValue == (false as T))
         }
+        
         return PredicateStatus(bool: actualValue == nil)
     }
 }
@@ -123,6 +126,7 @@ extension NMBPredicate {
     @objc public class func beTruthyMatcher() -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
+            
             return try beTruthy().satisfies(expr).toObjectiveC()
         }
     }
@@ -130,6 +134,7 @@ extension NMBPredicate {
     @objc public class func beFalsyMatcher() -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
+            
             return try beFalsy().satisfies(expr).toObjectiveC()
         }
     }
@@ -137,6 +142,7 @@ extension NMBPredicate {
     @objc public class func beTrueMatcher() -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { ($0 as? NSNumber)?.boolValue ?? false }
+            
             return try beTrue().satisfies(expr).toObjectiveC()
         }
     }
@@ -145,8 +151,10 @@ extension NMBPredicate {
         return NMBPredicate { actualExpression in
             let expr = actualExpression.cast { value -> Bool? in
                 guard let value = value else { return nil }
+                
                 return (value as? NSNumber)?.boolValue ?? false
             }
+            
             return try beFalse().satisfies(expr).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -2,6 +2,7 @@
 public func beNil<T>() -> Predicate<T> {
     return Predicate.simpleNilable("be nil") { actualExpression in
         let actualValue = try actualExpression.evaluate()
+        
         return PredicateStatus(bool: actualValue == nil)
     }
 }

--- a/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Sources/Nimble/Matchers/BeVoid.swift
@@ -2,6 +2,7 @@
 public func beVoid() -> Predicate<()> {
     return Predicate.simpleNilable("be void") { actualExpression in
         let actualValue: ()? = try actualExpression.evaluate()
+        
         return PredicateStatus(bool: actualValue != nil)
     }
 }

--- a/Sources/Nimble/Matchers/BeginWith.swift
+++ b/Sources/Nimble/Matchers/BeginWith.swift
@@ -5,8 +5,8 @@ import Foundation
 public func beginWith<S: Sequence>(_ startingElement: S.Element) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("begin with <\(startingElement)>") { actualExpression in
         guard let actualValue = try actualExpression.evaluate() else { return .fail }
-
         var actualGenerator = actualValue.makeIterator()
+        
         return PredicateStatus(bool: actualGenerator.next() == startingElement)
     }
 }
@@ -24,6 +24,7 @@ public func beginWith(_ startingElement: Any) -> Predicate<NMBOrderedCollection>
         #else
             let collectionValue = collection.object(at: 0) as AnyObject
         #endif
+        
         return PredicateStatus(bool: collectionValue.isEqual(startingElement))
     }
 }
@@ -49,6 +50,7 @@ extension NMBPredicate {
                 return try beginWith(expected as! String).satisfies(expr).toObjectiveC()
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
+                
                 return try beginWith(expected).satisfies(expr).toObjectiveC()
             }
         }

--- a/Sources/Nimble/Matchers/BeginWithPrefix.swift
+++ b/Sources/Nimble/Matchers/BeginWithPrefix.swift
@@ -12,6 +12,7 @@ public func beginWith<Seq1: Sequence, Seq2: Sequence>(prefix expectedPrefix: Seq
             return PredicateResult(status: .fail, message: msg)
         case (let expected?, let actual?):
             let matches = actual.starts(with: expected)
+            
             return PredicateResult(bool: matches, message: msg)
         }
     }
@@ -33,6 +34,7 @@ public func beginWith<Seq1: Sequence, Seq2: Sequence>(
             return PredicateResult(status: .fail, message: msg)
         case (let expected?, let actual?):
             let matches = actual.starts(with: expected, by: areEquivalent)
+            
             return PredicateResult(bool: matches, message: msg)
         }
     }

--- a/Sources/Nimble/Matchers/Contain.swift
+++ b/Sources/Nimble/Matchers/Contain.swift
@@ -11,10 +11,10 @@ public func contain<S: Sequence>(_ items: S.Element...) -> Predicate<S> where S.
 public func contain<S: Sequence>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -28,10 +28,10 @@ public func contain<S: SetAlgebra>(_ items: S.Element...) -> Predicate<S> where 
 public func contain<S: SetAlgebra>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -45,10 +45,10 @@ public func contain<S: Sequence & SetAlgebra>(_ items: S.Element...) -> Predicat
 public func contain<S: Sequence & SetAlgebra>(_ items: [S.Element]) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy {
             return actual.contains($0)
         }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -61,11 +61,12 @@ public func contain(_ substrings: String...) -> Predicate<String> {
 public func contain(_ substrings: [String]) -> Predicate<String> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = substrings.allSatisfy {
             let range = actual.range(of: $0)
+            
             return range != nil && !range!.isEmpty
         }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -79,8 +80,8 @@ public func contain(_ substrings: NSString...) -> Predicate<NSString> {
 public func contain(_ substrings: [NSString]) -> Predicate<NSString> {
     return Predicate.simple("contain <\(arrayAsString(substrings))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = substrings.allSatisfy { actual.range(of: $0.description).length != 0 }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -94,10 +95,10 @@ public func contain(_ items: Any?...) -> Predicate<NMBContainer> {
 public func contain(_ items: [Any?]) -> Predicate<NMBContainer> {
     return Predicate.simple("contain <\(arrayAsString(items))>") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-
         let matches = items.allSatisfy { item in
             return item.map { actual.contains($0) } ?? false
         }
+        
         return PredicateStatus(bool: matches)
     }
 }
@@ -131,6 +132,7 @@ extension NMBPredicate {
                     .expectedActualValueTo("contain <\(arrayAsString(expected))>")
                     .appendedBeNilHint()
             }
+            
             return NMBPredicateResult(status: .fail, message: message.toObjectiveC())
         }
     }

--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -36,6 +36,7 @@ extension NMBPredicate {
                 let message = ExpectationMessage.fail(
                     "containElementSatisfying must be provided an NSFastEnumeration object"
                 )
+                
                 return NMBPredicateResult(status: .fail, message: message.toObjectiveC())
             }
 

--- a/Sources/Nimble/Matchers/ElementsEqual.swift
+++ b/Sources/Nimble/Matchers/ElementsEqual.swift
@@ -14,6 +14,7 @@ public func elementsEqual<Seq1: Sequence, Seq2: Sequence>(
             return PredicateResult(status: .fail, message: msg)
         case (let expected?, let actual?):
             let matches = expected.elementsEqual(actual)
+            
             return PredicateResult(bool: matches, message: msg)
         }
     }
@@ -36,6 +37,7 @@ public func elementsEqual<Seq1: Sequence, Seq2: Sequence>(
             return PredicateResult(status: .fail, message: msg)
         case (let expected?, let actual?):
             let matches = actual.elementsEqual(expected, by: areEquivalent)
+            
             return PredicateResult(bool: matches, message: msg)
         }
     }

--- a/Sources/Nimble/Matchers/EndWith.swift
+++ b/Sources/Nimble/Matchers/EndWith.swift
@@ -5,7 +5,6 @@ import Foundation
 public func endWith<S: Sequence>(_ endingElement: S.Element) -> Predicate<S> where S.Element: Equatable {
     return Predicate.simple("end with <\(endingElement)>") { actualExpression in
         guard let actualValue = try actualExpression.evaluate() else { return .fail }
-
         var actualGenerator = actualValue.makeIterator()
         var lastItem: S.Element?
         var item: S.Element?
@@ -59,6 +58,7 @@ extension NMBPredicate {
                 return try endWith(expected as! String).satisfies(expr).toObjectiveC()
             } else {
                 let expr = actualExpression.cast { $0 as? NMBOrderedCollection }
+                
                 return try endWith(expected).satisfies(expr).toObjectiveC()
             }
         }

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -28,6 +28,7 @@ public func equal<T: Equatable>(_ expectedValue: [T?]) -> Predicate<[T?]> {
         }
 
         let matches = expectedValue == actualValue
+        
         return PredicateResult(bool: matches, message: msg)
     }
 }
@@ -88,6 +89,7 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
         if extra.count > 0 {
             errorMessage = errorMessage.appended(message: ", extra <\(stringify(extra))>")
         }
+        
         return  PredicateResult(
             status: .doesNotMatch,
             message: errorMessage

--- a/Sources/Nimble/Matchers/HaveCount.swift
+++ b/Sources/Nimble/Matchers/HaveCount.swift
@@ -16,6 +16,7 @@ public func haveCount<T: Collection>(_ expectedValue: Int) -> Predicate<T> {
                 .appended(details: "Actual Value: \(stringify(actualValue))")
 
             let result = expectedValue == actualValue.count
+            
             return PredicateResult(bool: result, message: message)
         } else {
             return PredicateResult(status: .fail, message: .fail(""))
@@ -36,6 +37,7 @@ public func haveCount(_ expectedValue: Int) -> Predicate<NMBCollection> {
                 .appended(details: "Actual Value: \(stringify(actualValue))")
 
             let result = expectedValue == actualValue.count
+            
             return PredicateResult(bool: result, message: message)
         } else {
             return PredicateResult(status: .fail, message: .fail(""))
@@ -53,6 +55,7 @@ extension NMBPredicate {
             let actualValue = try actualExpression.evaluate()
             if let value = actualValue as? NMBCollection {
                 let expr = Expression(expression: ({ value as NMBCollection}), location: location)
+                
                 return try haveCount(expected.intValue).satisfies(expr).toObjectiveC()
             }
 
@@ -67,6 +70,7 @@ extension NMBPredicate {
                     .expectedActualValueTo("have a collection with count \(stringify(expected.intValue))")
                     .appendedBeNilHint()
             }
+            
             return NMBPredicateResult(status: .fail, message: message.toObjectiveC())
         }
     }

--- a/Sources/Nimble/Matchers/Match.swift
+++ b/Sources/Nimble/Matchers/Match.swift
@@ -5,6 +5,7 @@ public func match(_ expectedValue: String?) -> Predicate<String> {
         guard let actual = try actualExpression.evaluate(), let regexp = expectedValue else { return .fail }
 
         let bool = actual.range(of: regexp, options: .regularExpression) != nil
+        
         return PredicateStatus(bool: bool)
     }
 }
@@ -16,6 +17,7 @@ extension NMBPredicate {
     @objc public class func matchMatcher(_ expected: NSString) -> NMBPredicate {
         return NMBPredicate { actualExpression in
             let actual = actualExpression.cast { $0 as? String }
+            
             return try match(expected.description).satisfies(actual).toObjectiveC()
         }
     }

--- a/Sources/Nimble/Matchers/MatcherFunc.swift
+++ b/Sources/Nimble/Matchers/MatcherFunc.swift
@@ -72,8 +72,10 @@ public struct NonNilMatcherFunc<T>: Matcher {
     internal func attachNilErrorIfNeeded(_ actualExpression: Expression<T>, failureMessage: FailureMessage) throws -> Bool {
         if try actualExpression.evaluate() == nil {
             failureMessage.postfixActual = " (use beNil() to match nils)"
+            
             return true
         }
+        
         return false
     }
 

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -76,6 +76,7 @@ private func _postNotifications<Out>(
         result.message = result.message.replacedExpectation { message in
             return .expectedCustomValueTo(message.expectedMessage, actual: actualValue)
         }
+        
         return result
     }
 }
@@ -133,6 +134,7 @@ public func postNotifications<T>(
         } else {
             failureMessage.actualValue = "<\(stringify(collector.observedNotifications))>"
         }
+        
         return PredicateResult(bool: match, message: failureMessage.toExpectationMessage())
     }
 }

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -189,6 +189,7 @@ extension Predicate: Matcher {
         return Predicate { actual in
             let failureMessage = FailureMessage()
             let result = try matcher(actual, failureMessage, true)
+            
             return PredicateResult(
                 status: PredicateStatus(bool: result),
                 message: failureMessage.toExpectationMessage()
@@ -245,6 +246,7 @@ extension Predicate {
                     message: result.message.appendedBeNilHint()
                 )
             }
+            
             return result
         }
     }
@@ -276,12 +278,14 @@ extension NMBPredicate: NMBMatcher {
     public func matches(_ actualBlock: @escaping () -> NSObject?, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let result = satisfies(actualBlock, location: location).toSwift()
         result.message.update(failureMessage: failureMessage)
+        
         return result.status.toBoolean(expectation: .toMatch)
     }
 
     public func doesNotMatch(_ actualBlock: @escaping () -> NSObject?, failureMessage: FailureMessage, location: SourceLocation) -> Bool {
         let result = satisfies(actualBlock, location: location).toSwift()
         result.message.update(failureMessage: failureMessage)
+        
         return result.status.toBoolean(expectation: .toNotMatch)
     }
 }
@@ -333,9 +337,12 @@ final public class NMBPredicateStatus: NSObject {
 
     public static func from(status: PredicateStatus) -> NMBPredicateStatus {
         switch status {
-        case .matches: return self.matches
-        case .doesNotMatch: return self.doesNotMatch
-        case .fail: return self.fail
+        case .matches:
+            return self.matches
+        case .doesNotMatch:
+            return self.doesNotMatch
+        case .fail:
+            return self.fail
         }
     }
 
@@ -345,9 +352,12 @@ final public class NMBPredicateStatus: NSObject {
 
     public func toSwift() -> PredicateStatus {
         switch status {
-        case NMBPredicateStatus.matches.status: return .matches
-        case NMBPredicateStatus.doesNotMatch.status: return .doesNotMatch
-        case NMBPredicateStatus.fail.status: return .fail
+        case NMBPredicateStatus.matches.status:
+            return .matches
+        case NMBPredicateStatus.doesNotMatch.status:
+            return .doesNotMatch
+        case NMBPredicateStatus.fail.status:
+            return .fail
         default:
             internalError("Unhandle status for NMBPredicateStatus")
         }

--- a/Sources/Nimble/Matchers/RaisesException.swift
+++ b/Sources/Nimble/Matchers/RaisesException.swift
@@ -66,6 +66,7 @@ public func raiseException<Out>(
             userInfo: userInfo,
             closure: closure
         )
+        
         return PredicateResult(bool: matches, message: message)
     }
 }
@@ -162,6 +163,7 @@ public class NMBObjCRaiseExceptionPredicate: NMBPredicate {
         let predicateBlock: PredicateBlock = { actualExpression in
             return try predicate.satisfies(actualExpression).toObjectiveC()
         }
+        
         super.init(predicate: predicateBlock)
     }
 

--- a/Sources/Nimble/Utils/Await.swift
+++ b/Sources/Nimble/Utils/Await.swift
@@ -79,15 +79,19 @@ internal enum AwaitResult<T> {
 
     func isIncomplete() -> Bool {
         switch self {
-        case .incomplete: return true
-        default: return false
+        case .incomplete:
+            return true
+        default:
+            return false
         }
     }
 
     func isCompleted() -> Bool {
         switch self {
-        case .completed: return true
-        default: return false
+        case .completed:
+            return true
+        default:
+            return false
         }
     }
 }
@@ -114,6 +118,7 @@ internal final class AwaitPromise<T> {
     func resolveResult(_ result: AwaitResult<T>) -> Bool {
         if signal.wait(timeout: .now()) == .success {
             self.asyncResult = result
+            
             return true
         } else {
             return false
@@ -364,6 +369,7 @@ internal func pollBlock(
             if try expression() {
                 return true
             }
+            
             return nil
         }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided).wait(fnName, file: file, line: line)
 

--- a/Sources/Nimble/Utils/DispatchTimeInterval.swift
+++ b/Sources/Nimble/Utils/DispatchTimeInterval.swift
@@ -8,22 +8,33 @@ extension DispatchTimeInterval {
     // ** Note: We cannot simply divide the time interval because DispatchTimeInterval associated value type is Int
     var divided: DispatchTimeInterval {
         switch self {
-        case let .seconds(val): return val < 2 ? .milliseconds(Int(Float(val)/2*1000)) : .seconds(val/2)
-        case let .milliseconds(val): return .milliseconds(val/2)
-        case let .microseconds(val): return .microseconds(val/2)
-        case let .nanoseconds(val): return .nanoseconds(val/2)
-        case .never: return .never
-        @unknown default: fatalError("Unknown DispatchTimeInterval value")
+        case let .seconds(val):
+            return val < 2 ? .milliseconds(Int(Float(val)/2*1000)) : .seconds(val/2)
+        case let .milliseconds(val):
+            return .milliseconds(val/2)
+        case let .microseconds(val):
+            return .microseconds(val/2)
+        case let .nanoseconds(val):
+            return .nanoseconds(val/2)
+        case .never:
+            return .never
+        @unknown default:
+            fatalError("Unknown DispatchTimeInterval value")
         }
     }
 
     var description: String {
         switch self {
-        case let .seconds(val): return val == 1 ? "\(Float(val)) second" : "\(Float(val)) seconds"
-        case let .milliseconds(val): return "\(Float(val)/1_000) seconds"
-        case let .microseconds(val): return "\(Float(val)/1_000_000) seconds"
-        case let .nanoseconds(val): return "\(Float(val)/1_000_000_000) seconds"
-        default: fatalError("Unknown DispatchTimeInterval value")
+        case let .seconds(val):
+            return val == 1 ? "\(Float(val)) second" : "\(Float(val)) seconds"
+        case let .milliseconds(val):
+            return "\(Float(val)/1_000) seconds"
+        case let .microseconds(val):
+            return "\(Float(val)/1_000_000) seconds"
+        case let .nanoseconds(val):
+            return "\(Float(val)/1_000_000_000) seconds"
+        default:
+            fatalError("Unknown DispatchTimeInterval value")
         }
     }
 }

--- a/Sources/Nimble/Utils/Stringers.swift
+++ b/Sources/Nimble/Utils/Stringers.swift
@@ -12,6 +12,7 @@ internal func identityAsString(_ value: Any?) -> String {
 internal func arrayAsString<T>(_ items: [T], joiner: String = ", ") -> String {
     return items.reduce("") { accum, item in
         let prefix = (accum.isEmpty ? "" : joiner)
+        
         return accum + prefix + "\(stringify(item))"
     }
 }
@@ -64,6 +65,7 @@ extension NSNumber: TestOutputStringConvertible {
 extension Array: TestOutputStringConvertible {
     public var testDescription: String {
         let list = self.map(Nimble.stringify).joined(separator: ", ")
+        
         return "[\(list)]"
     }
 }
@@ -82,6 +84,7 @@ extension AnySequence: TestOutputStringConvertible {
         } while value != nil
 
         let list = strings.joined(separator: ", ")
+        
         return "[\(list)]"
     }
 }
@@ -89,6 +92,7 @@ extension AnySequence: TestOutputStringConvertible {
 extension NSArray: TestOutputStringConvertible {
     public var testDescription: String {
         let list = Array(self).map(Nimble.stringify).joined(separator: ", ")
+        
         return "(\(list))"
     }
 }
@@ -96,6 +100,7 @@ extension NSArray: TestOutputStringConvertible {
 extension NSIndexSet: TestOutputStringConvertible {
     public var testDescription: String {
         let list = Array(self).map(Nimble.stringify).joined(separator: ", ")
+        
         return "(\(list))"
     }
 }


### PR DESCRIPTION
I noticed that a lot of the code had an extra empty line before a return statement so I've gone through and added them where they were missing. Makes the code more consistent.