### PR TITLE
Make public the satisfyAnyOf and satisfyAllOf matchers that take arrays of matchers

### DIFF
--- a/Sources/Nimble/Matchers/SatisfyAllOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAllOf.swift
@@ -12,6 +12,8 @@ public func satisfyAllOf<T, U>(_ matchers: U...) -> Predicate<T>
         return satisfyAllOf(matchers.map { $0.predicate })
 }
 
+/// A Nimble matcher that succeeds when the actual value matches with all of the matchers
+/// provided in the variable list of matchers.
 public func satisfyAllOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
 	return Predicate.define { actualExpression in
         var postfixMessages = [String]()

--- a/Sources/Nimble/Matchers/SatisfyAllOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAllOf.swift
@@ -12,7 +12,7 @@ public func satisfyAllOf<T, U>(_ matchers: U...) -> Predicate<T>
         return satisfyAllOf(matchers.map { $0.predicate })
 }
 
-internal func satisfyAllOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
+public func satisfyAllOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
 	return Predicate.define { actualExpression in
         var postfixMessages = [String]()
         var matches = true

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -12,7 +12,7 @@ public func satisfyAnyOf<T, U>(_ matchers: U...) -> Predicate<T>
         return satisfyAnyOf(matchers.map { $0.predicate })
 }
 
-internal func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
+public func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
         return Predicate.define { actualExpression in
             var postfixMessages = [String]()
             var matches = false

--- a/Sources/Nimble/Matchers/SatisfyAnyOf.swift
+++ b/Sources/Nimble/Matchers/SatisfyAnyOf.swift
@@ -12,6 +12,8 @@ public func satisfyAnyOf<T, U>(_ matchers: U...) -> Predicate<T>
         return satisfyAnyOf(matchers.map { $0.predicate })
 }
 
+/// A Nimble matcher that succeeds when the actual value matches with any of the matchers
+/// provided in the variable list of matchers.
 public func satisfyAnyOf<T>(_ predicates: [Predicate<T>]) -> Predicate<T> {
         return Predicate.define { actualExpression in
             var postfixMessages = [String]()


### PR DESCRIPTION
This will make it easier/possible to matchers that wrap `satisfyAnyOf` and `satisfyAllOf`.

# Rationale of PR

In one of my projects, I have the pattern of the `FakeCall<T>` to test if callbacks were called and what the calls are. ([gist of implementation from it, for reference](https://gist.github.com/younata/18bd56aac306a9e0a84954108bfd6f90). The relevant part is [`beCalled<T>(_ expectations: [FakeCallPredicate<T>]) -> Predicate<FakeCall<T>>`](https://gist.github.com/younata/18bd56aac306a9e0a84954108bfd6f90#file-fakecall-swift-L133-L200)). One of the matchers essentially takes an array of `(KeyPath, Predicate)`s and processes them to just an array of Predicates before passing them off to a copy-paste-edit of `satisfyAllOf`.

After the second time where I used a similar pattern (wrapping an array of predicates), I started to really wish that `satisfyAllOf` would be public, to better support this. I'm probably not the only one with this kind of idea, so I figure it would help others with this implementation.

I don't have a similar use-case for `satisfyAnyOf`, but it seemed like a good idea to give `satisfyAnyOf` the same treatment.

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

- What behavior was changed?
- What code was refactored / updated to support this change?
- What issues are related to this PR? Or why was this change introduced?

- [x] Is this a new feature (Requires minor version bump)?
