### PR TITLE
Suppress SwiftPM build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,12 +20,13 @@ let package = Package(
                          condition: .when(platforms: [.macOS, .iOS])),
                 .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
                          condition: .when(platforms: [.tvOS]))
-            ]
+            ],
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "NimbleTests", 
             dependencies: ["Nimble"], 
-            exclude: ["objc"]
+            exclude: ["objc", "Info.plist"]
         ),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
Such as:

> warning: found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
>     /path/to/Nimble/Sources/Nimble/Info.plist