### PR TITLE
[BREAKING] Use FloatingPoint protocol in `beCloseTo` matcher

### DIFF
--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -43,24 +43,6 @@ public protocol NMBDoubleConvertible {
     var doubleValue: CDouble { get }
 }
 
-extension Double: NMBDoubleConvertible {
-    public var doubleValue: CDouble {
-        return self
-    }
-}
-
-extension Float: NMBDoubleConvertible {
-    public var doubleValue: CDouble {
-        return CDouble(self)
-    }
-}
-
-extension CGFloat: NMBDoubleConvertible {
-    public var doubleValue: CDouble {
-        return CDouble(self)
-    }
-}
-
 extension NSNumber: NMBDoubleConvertible {
 }
 


### PR DESCRIPTION
Resolves #394.