### PR TITLE
[9.x] Suppress SwiftPM build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,12 +20,13 @@ let package = Package(
                          condition: .when(platforms: [.macOS, .iOS])),
                 .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
                          condition: .when(platforms: [.tvOS]))
-            ]
+            ],
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "NimbleTests", 
             dependencies: ["Nimble"], 
-            exclude: ["objc"]
+            exclude: ["objc", "Info.plist"]
         ),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
Cherry-picks #878 into `9.x-branch`.

Closes #881.