### PR TITLE
[BREAKING] `passFunc` of `allPass` matcher now takes `S.Element` over `S.Element?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ In Swift, the collection must be an instance of a type conforming to
 // Swift
 
 // Providing a custom function:
-expect([1, 2, 3, 4]).to(allPass { $0! < 5 })
+expect([1, 2, 3, 4]).to(allPass { $0 < 5 })
 
 // Composing the expectation with another matcher:
 expect([1, 2, 3, 4]).to(allPass(beLessThan(5)))

--- a/Tests/NimbleTests/Matchers/AllPassTest.swift
+++ b/Tests/NimbleTests/Matchers/AllPassTest.swift
@@ -44,15 +44,15 @@ extension Optional where Wrapped: Comparable {
 
 final class AllPassTest: XCTestCase {
     func testAllPassArray() {
-        expect([1, 2, 3, 4]).to(allPass({$0 < 5}))
-        expect([1, 2, 3, 4]).toNot(allPass({$0 > 5}))
+        expect([1, 2, 3, 4]).to(allPass { $0 < 5 })
+        expect([1, 2, 3, 4]).toNot(allPass { $0 > 5 })
 
         failsWithErrorMessage(
             "expected to all pass a condition, but failed first at element <3> in <[1, 2, 3, 4]>") {
-                expect([1, 2, 3, 4]).to(allPass({$0 < 3}))
+                expect([1, 2, 3, 4]).to(allPass { $0 < 3 })
         }
         failsWithErrorMessage("expected to not all pass a condition") {
-            expect([1, 2, 3, 4]).toNot(allPass({$0 < 5}))
+            expect([1, 2, 3, 4]).toNot(allPass { $0 < 5 })
         }
         failsWithErrorMessage(
             "expected to all be something, but failed first at element <3> in <[1, 2, 3, 4]>") {
@@ -78,31 +78,24 @@ final class AllPassTest: XCTestCase {
 
     func testAllPassCollectionsWithOptionals() {
         expect([nil, nil, nil] as [Int?]).to(allPass(beNil()))
-
-        failsWithErrorMessage("expected to all pass a condition, but failed first at element <nil> in <[nil, nil, nil]>") {
-            expect([nil, nil, nil] as [Int?]).to(allPass({$0 == nil}))
-        }
-    }
-
-    func testAllPassCollectionsWithOptionalsUnwrappingOneOptionalLayer() {
-        expect([nil, nil, nil] as [Int?]).to(allPass({$0! == nil}))
-        expect([nil, 1, nil] as [Int?]).toNot(allPass({$0! == nil}))
-        expect([1, 1, 1] as [Int?]).to(allPass({$0! == 1}))
-        expect([1, 1, nil] as [Int?]).toNot(allPass({$0! == 1}))
-        expect([1, 2, 3] as [Int?]).to(allPass({$0! < 4}))
-        expect([1, 2, 3] as [Int?]).toNot(allPass({$0! < 3}))
-        expect([1, 2, nil] as [Int?]).to(allPass({$0! < 3}))
+        expect([nil, nil, nil] as [Int?]).to(allPass { $0 == nil })
+        expect([nil, 1, nil] as [Int?]).toNot(allPass { $0 == nil })
+        expect([1, 1, 1] as [Int?]).to(allPass { $0 == 1 })
+        expect([1, 1, nil] as [Int?]).toNot(allPass { $0 == 1 })
+        expect([1, 2, 3] as [Int?]).to(allPass { $0 < 4 })
+        expect([1, 2, 3] as [Int?]).toNot(allPass { $0 < 3 })
+        expect([1, 2, nil] as [Int?]).to(allPass { $0 < 3 })
     }
 
     func testAllPassSet() {
-        expect(Set([1, 2, 3, 4])).to(allPass({$0 < 5}))
-        expect(Set([1, 2, 3, 4])).toNot(allPass({$0 > 5}))
+        expect(Set([1, 2, 3, 4])).to(allPass { $0 < 5 })
+        expect(Set([1, 2, 3, 4])).toNot(allPass { $0 > 5 })
 
         failsWithErrorMessage("expected to not all pass a condition") {
-            expect(Set([1, 2, 3, 4])).toNot(allPass({$0 < 5}))
+            expect(Set([1, 2, 3, 4])).toNot(allPass { $0 < 5 })
         }
         failsWithErrorMessage("expected to not all be something") {
-            expect(Set([1, 2, 3, 4])).toNot(allPass("be something", {$0 < 5}))
+            expect(Set([1, 2, 3, 4])).toNot(allPass("be something") { $0 < 5 })
         }
     }
 


### PR DESCRIPTION
This a bit related to #894.