### PR TITLE
Add more specific operator overloads for `equal` matcher

### DIFF
--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -102,8 +102,16 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
     }
 }
 
+public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+    lhs.to(equal(rhs))
+}
+
 public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
     lhs.to(equal(rhs))
+}
+
+public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+    lhs.toNot(equal(rhs))
 }
 
 public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
@@ -118,16 +126,32 @@ public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
     lhs.toNot(equal(rhs))
 }
 
+public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
 public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
+}
+
+public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
 }
 
 public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
+public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
 public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
+}
+
+public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
 }
 
 public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -158,6 +158,17 @@ final class EqualTest: XCTestCase {
         }
     }
 
+    // see: https://github.com/Quick/Nimble/issues/867
+    func testOperatorEqualityWithImplicitMemberSyntax() {
+        struct Xxx: Equatable {
+            let value: Int
+        }
+
+        let xxx = Xxx(value: 123)
+        expect(xxx) == .init(value: 123)
+        expect(xxx) != .init(value: 124)
+    }
+
     func testOperatorEqualityWithArrays() {
         let array1: [Int] = [1, 2, 3]
         let array2: [Int] = [1, 2, 3]


### PR DESCRIPTION
To improve compatibility with implicit member syntax.

ref: https://github.com/apple/swift-evolution/blob/master/proposals/0287-implicit-member-chains.md

---

Fixes #867.