### PR TITLE
Specify header_dir in the podspec

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -20,6 +20,8 @@ Pod::Spec.new do |s|
     "Carthage/Checkouts/CwlPreconditionTesting/Sources/**/*.{swift,h,m,c}",
   ]
 
+  s.header_dir = "Nimble"
+
   s.osx.exclude_files = [
     "Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPosixPreconditionTesting/CwlCatchBadInstructionPosix.swift",
   ]


### PR DESCRIPTION
Followup https://github.com/Quick/Quick/pull/1091

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
