### PR TITLE
[9.x] Add more specific operator overloads for `equal` matcher

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
-        xcode: [11.7, 12.4]
+        xcode: [11.7, 12.4, 12.5]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
     steps:

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   xcode:
     name: Xcode ${{ matrix.xcode }} - ${{ matrix.platform }}
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
-        xcode: [11.7, 12.4]
+        xcode: [11.7, 12.4, 12.5]
         platform: [macos, ios, tvos]
       fail-fast: false
     env:

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cocoapods:
     name: CocoaPods Lint
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -102,8 +102,16 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
     }
 }
 
+public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+    lhs.to(equal(rhs))
+}
+
 public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
     lhs.to(equal(rhs))
+}
+
+public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+    lhs.toNot(equal(rhs))
 }
 
 public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
@@ -118,16 +126,32 @@ public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
     lhs.toNot(equal(rhs))
 }
 
+public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
 public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
+}
+
+public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
 }
 
 public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
+public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
 public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
+}
+
+public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
 }
 
 public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -158,6 +158,17 @@ final class EqualTest: XCTestCase {
         }
     }
 
+    // see: https://github.com/Quick/Nimble/issues/867
+    func testOperatorEqualityWithImplicitMemberSyntax() {
+        struct Xxx: Equatable {
+            let value: Int
+        }
+
+        let xxx = Xxx(value: 123)
+        expect(xxx) == .init(value: 123)
+        expect(xxx) != .init(value: 124)
+    }
+
     func testOperatorEqualityWithArrays() {
         let array1: [Int] = [1, 2, 3]
         let array2: [Int] = [1, 2, 3]


### PR DESCRIPTION
Cherry-picks #897 and #912 into `9.x-branch`.

ref: https://github.com/Quick/Nimble/issues/867#issuecomment-923026735