### PR TITLE
Add support for precondition testing on Apple Silicon

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 github "mattgallagher/CwlCatchException" ~> 2.0
-github "mattgallagher/CwlPreconditionTesting" ~> 2.0.1
+github "mattgallagher/CwlPreconditionTesting" ~> 2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "mattgallagher/CwlCatchException" "2.0.0"
-github "mattgallagher/CwlPreconditionTesting" "2.0.1"
+github "mattgallagher/CwlPreconditionTesting" "2.1.0"

--- a/Carthage/Checkouts/CwlPreconditionTesting/README.md
+++ b/Carthage/Checkouts/CwlPreconditionTesting/README.md
@@ -10,17 +10,25 @@ For an extended discussion of this code, please see the Cocoa with Love article:
 
 ## Requirements
 
-From version 2.0.0-beta.1, building CwlPreconditionTesting requires Swift 5 or newer and the Swift Package Manager.
+From version 2.0.0-beta.1, building CwlPreconditionTesting requires Swift 5 or newer and the Swift Package Manager, or CocoaPods.
 
 For use with older versions of Swift or other package managers, [use version 1.2.0 or older](https://github.com/mattgallagher/CwlPreconditionTesting/tree/1.2.0).
 
 ## Adding to your project
 
+### Swift Package Manager
+
 Add the following to the `dependencies` array in your "Package.swift" file:
 
-	 .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: Version("2.0.0-beta.1"))
+	 .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: Version("2.0.0"))
 
-Or by adding `https://github.com/mattgallagher/CwlPreconditionTesting.git`, version 2.0.0-beta.1 or later, to the list of Swift packages for any project in Xcode.
+Or by adding `https://github.com/mattgallagher/CwlPreconditionTesting.git`, version 2.0.0 or later, to the list of Swift packages for any project in Xcode.
+
+### CocoaPods
+
+CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate CwlPreconditionTesting into your Xcode project using CocoaPods, specify it in your Podfile:
+
+pod 'CwlPreconditionTesting', '~> 2.0'
 
 ## Usage
 
@@ -45,3 +53,7 @@ let e = catchBadInstruction {
 ```
 
 **Warning**: this POSIX version can't be used when lldb is attached since lldb's Mach exception handler blocks the SIGILL from ever occurring. You should disable the "Debug Executable" setting for the tests in Xcode. The POSIX version of the signal handler is also whole process (rather than correctly scoped to the thread where the "catch" occurs).
+
+## Thanks
+
+Includes contributions from @abbeycode, @dnkoutso, @jeffh and @ikesyo. Extra thanks to @saagarjha for help with the ARM64 additions.

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
@@ -26,15 +26,14 @@
 #import "CwlMachBadInstructionHandler.h"
 
 @protocol BadInstructionReply <NSObject>
-+(NSNumber *)receiveReply:(NSValue *)value;
++(int)receiveReply:(bad_instruction_exception_reply_t)reply;
 @end
 
 /// A basic function that receives callbacks from mach_exc_server and relays them to the Swift implemented BadInstructionException.catch_mach_exception_raise_state.
 kern_return_t catch_mach_exception_raise_state(mach_port_t exception_port, exception_type_t exception, const mach_exception_data_t code, mach_msg_type_number_t codeCnt, int *flavor, const thread_state_t old_state, mach_msg_type_number_t old_stateCnt, thread_state_t new_state, mach_msg_type_number_t *new_stateCnt) {
 	bad_instruction_exception_reply_t reply = { exception_port, exception, code, codeCnt, flavor, old_state, old_stateCnt, new_state, new_stateCnt };
 	Class badInstructionClass = NSClassFromString(@"BadInstructionException");
-	NSValue *value = [NSValue valueWithBytes: &reply objCType: @encode(bad_instruction_exception_reply_t)];
-	return [[badInstructionClass performSelector: @selector(receiveReply:) withObject: value] intValue];
+	return [badInstructionClass receiveReply:reply];
 }
 
 // The mach port should be configured so that this function is never used.

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -18,17 +18,17 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && arch(x86_64)
+#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
 import Foundation
 
-#if SWIFT_PACKAGE
+#if SWIFT_PACKAGE || COCOAPODS
 	import CwlMachBadInstructionHandler
 #endif
 
-private func raiseBadInstructionException() {
+var raiseBadInstructionException = {
 	BadInstructionException().raise()
-}
+} as @convention(c) () -> Void
 
 /// A simple NSException subclass. It's not required to subclass NSException (since the exception type is represented in the name) but this helps for identifying the exception through runtime type.
 @objc(BadInstructionException)
@@ -45,44 +45,47 @@ public class BadInstructionException: NSException {
 	
 	/// An Objective-C callable function, invoked from the `mach_exc_server` callback function `catch_mach_exception_raise_state` to push the `raiseBadInstructionException` function onto the stack.
 	@objc(receiveReply:)
-	public class func receiveReply(_ value: NSValue) -> NSNumber {
-		var reply = bad_instruction_exception_reply_t(exception_port: 0, exception: 0, code: nil, codeCnt: 0, flavor: nil, old_state: nil, old_stateCnt: 0, new_state: nil, new_stateCnt: nil)
-		withUnsafeMutablePointer(to: &reply) { value.getValue(UnsafeMutableRawPointer($0)) }
-		
-		let old_state: UnsafePointer<natural_t> = reply.old_state!
+	public class func receiveReply(_ reply: bad_instruction_exception_reply_t) -> CInt {
+		let old_state = UnsafeRawPointer(reply.old_state!).bindMemory(to: NativeThreadState.self, capacity: 1)
 		let old_stateCnt: mach_msg_type_number_t = reply.old_stateCnt
-		let new_state: thread_state_t = reply.new_state!
+		let new_state = UnsafeMutableRawPointer(reply.new_state!).bindMemory(to: NativeThreadState.self, capacity: 1)
 		let new_stateCnt: UnsafeMutablePointer<mach_msg_type_number_t> = reply.new_stateCnt!
 		
 		// Make sure we've been given enough memory
-		if old_stateCnt != x86_THREAD_STATE64_COUNT || new_stateCnt.pointee < x86_THREAD_STATE64_COUNT {
-			return NSNumber(value: KERN_INVALID_ARGUMENT)
+		guard
+			old_stateCnt == nativeThreadStateCount,
+			new_stateCnt.pointee >= nativeThreadStateCount
+		else {
+			return KERN_INVALID_ARGUMENT
 		}
 		
-		// Read the old thread state
-		var state = old_state.withMemoryRebound(to: x86_thread_state64_t.self, capacity: 1) { return $0.pointee }
+		// 0. Copy over the state.
+		new_state.pointee = old_state.pointee
 		
+#if arch(x86_64)
 		// 1. Decrement the stack pointer
-		state.__rsp -= __uint64_t(MemoryLayout<Int>.size)
+		new_state.pointee.__rsp -= UInt64(MemoryLayout<Int>.size)
 		
 		// 2. Save the old Instruction Pointer to the stack.
-		if let pointer = UnsafeMutablePointer<__uint64_t>(bitPattern: UInt(state.__rsp)) {
-			pointer.pointee = state.__rip
-		} else {
-			return NSNumber(value: KERN_INVALID_ARGUMENT)
+		guard let pointer = UnsafeMutablePointer<UInt64>(bitPattern: UInt(new_state.pointee.__rsp)) else {
+			return KERN_INVALID_ARGUMENT
 		}
-		
+		pointer.pointee = old_state.pointee.__rip
+				
 		// 3. Set the Instruction Pointer to the new function's address
-		var f: @convention(c) () -> Void = raiseBadInstructionException
-		withUnsafePointer(to: &f) {
-			state.__rip = $0.withMemoryRebound(to: __uint64_t.self, capacity: 1) { return $0.pointee }
-		}
+		new_state.pointee.__rip = unsafeBitCast(raiseBadInstructionException, to: UInt64.self)
 		
-		// Write the new thread state
-		new_state.withMemoryRebound(to: x86_thread_state64_t.self, capacity: 1) { $0.pointee = state }
-		new_stateCnt.pointee = x86_THREAD_STATE64_COUNT
+#elseif arch(arm64)
+		// 1. Set the link register to the current address.
+		new_state.pointee.__lr = old_state.pointee.__pc
 		
-		return NSNumber(value: KERN_SUCCESS)
+		// 2. Set the Instruction Pointer to the new function's address.
+		new_state.pointee.__pc = unsafeBitCast(raiseBadInstructionException, to: UInt64.self)
+#endif
+
+		new_stateCnt.pointee = nativeThreadStateCount
+		
+		return KERN_SUCCESS
 	}
 }
 

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-#if SWIFT_PACKAGE || COCOAPODS
+#if SWIFT_PACKAGE
 	import CwlMachBadInstructionHandler
 #endif
 

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -18,12 +18,13 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && arch(x86_64)
+#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
+import CwlCatchException
 import Foundation
 import Swift
 
-#if SWIFT_PACKAGE
+#if SWIFT_PACKAGE || COCOAPODS
 	import CwlMachBadInstructionHandler
 #endif
 
@@ -108,8 +109,8 @@ private func machMessageHandler(_ arg: UnsafeMutableRawPointer) -> UnsafeMutable
 		reply.Head.msgh_local_port = UInt32(MACH_PORT_NULL)
 		reply.Head.msgh_remote_port = request.Head.msgh_remote_port
 		reply.Head.msgh_size = UInt32(MemoryLayout<reply_mach_exception_raise_state_t>.size)
-        reply.NDR = mach_ndr_record()
-
+		reply.NDR = mach_ndr_record()
+		
 		if !handledfirstException {
 			// Use the MiG generated server to invoke our handler for the request and fill in the rest of the reply structure
 			guard request.withMsgHeaderPointer(in: { requestPtr in reply.withMsgHeaderPointer { replyPtr in
@@ -181,12 +182,12 @@ public func catchBadInstruction(in block: @escaping () -> Void) -> BadInstructio
 		let currentExceptionPtr = context.currentExceptionPort
 		try kernCheck { context.withUnsafeMutablePointers { masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr in
 			// 3. Apply the mach port as the handler for this thread
-			thread_swap_exception_ports(mach_thread_self(), EXC_MASK_BAD_INSTRUCTION, currentExceptionPtr, Int32(bitPattern: UInt32(EXCEPTION_STATE) | MACH_EXCEPTION_CODES), x86_THREAD_STATE64, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
+			thread_swap_exception_ports(mach_thread_self(), nativeMachExceptionMask, currentExceptionPtr, Int32(bitPattern: UInt32(EXCEPTION_STATE) | MACH_EXCEPTION_CODES), nativeThreadState, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
 		} }
 		
 		defer { context.withUnsafeMutablePointers { masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr in
 			// 6. Unapply the mach port
-			_ = thread_swap_exception_ports(mach_thread_self(), EXC_MASK_BAD_INSTRUCTION, 0, EXCEPTION_DEFAULT, THREAD_STATE_NONE, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
+			_ = thread_swap_exception_ports(mach_thread_self(), nativeMachExceptionMask, 0, EXCEPTION_DEFAULT, THREAD_STATE_NONE, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
 		} }
 		
 		try withUnsafeMutablePointer(to: &context) { c throws in

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -23,7 +23,7 @@
 import Foundation
 import Swift
 
-#if SWIFT_PACKAGE || COCOAPODS
+#if SWIFT_PACKAGE
 	import CwlMachBadInstructionHandler
 #endif
 

--- a/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -20,7 +20,6 @@
 
 #if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
-import CwlCatchException
 import Foundation
 import Swift
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "0630439888c94657a235ffcd5977d6047ef3c87b",
-          "version": "2.0.1"
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Nimble", targets: ["Nimble"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", .upToNextMajor(from: "2.0.1")),
+        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", .upToNextMajor(from: "2.1.0")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -837,7 +837,6 @@ expect(reachedPoint2) == false
 Notes:
 
 * This feature is only available in Swift.
-* It is only supported for `x86_64` binaries, meaning _you cannot run this matcher on iOS devices, only simulators_.
 * The tvOS simulator is supported, but using a different mechanism, requiring you to turn off the `Debug executable` scheme setting for your tvOS scheme's Test configuration.
 
 ## Swift Error Handling

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -84,7 +84,7 @@ public func catchBadInstruction(block: @escaping () -> Void) -> BadInstructionEx
 
 public func throwAssertion<Out>() -> Predicate<Out> {
     return Predicate { actualExpression in
-    #if arch(x86_64) && (canImport(Darwin) || canImport(Glibc))
+    #if (arch(x86_64) || arch(arm64)) && (canImport(Darwin) || canImport(Glibc))
         let message = ExpectationMessage.expectedTo("throw an assertion")
 
         var actualError: Error?
@@ -122,8 +122,9 @@ public func throwAssertion<Out>() -> Predicate<Out> {
         }
     #else
         let message = """
-            The throwAssertion Nimble matcher can only run on x86_64 platforms.
-            You can silence this error by placing the test case inside an #if arch(x86_64) conditional statement.
+            The throwAssertion Nimble matcher can only run on x86_64 and arm64 platforms.
+            You can silence this error by placing the test case inside an #if arch(x86_64) || arch(arm64) conditional \
+            statement.
             """
         fatalError(message)
     #endif

--- a/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
+++ b/Tests/NimbleTests/Matchers/ThrowAssertionTest.swift
@@ -6,19 +6,19 @@ private let error: Error = NSError(domain: "test", code: 0, userInfo: nil)
 
 final class ThrowAssertionTest: XCTestCase {
     func testPositiveMatch() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         expect { () -> Void in fatalError() }.to(throwAssertion())
         #endif
     }
 
     func testErrorThrown() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         expect { throw error }.toNot(throwAssertion())
         #endif
     }
 
     func testPostAssertionCodeNotRun() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         var reachedPoint1 = false
         var reachedPoint2 = false
 
@@ -34,7 +34,7 @@ final class ThrowAssertionTest: XCTestCase {
     }
 
     func testNegativeMatch() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         var reachedPoint1 = false
 
         expect { reachedPoint1 = true }.toNot(throwAssertion())
@@ -44,7 +44,7 @@ final class ThrowAssertionTest: XCTestCase {
     }
 
     func testPositiveMessage() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         failsWithErrorMessage("expected to throw an assertion") {
             expect { () -> Void? in return }.to(throwAssertion())
         }
@@ -56,7 +56,7 @@ final class ThrowAssertionTest: XCTestCase {
     }
 
     func testNegativeMessage() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         failsWithErrorMessage("expected to not throw an assertion") {
             expect { () -> Void in fatalError() }.toNot(throwAssertion())
         }
@@ -64,13 +64,13 @@ final class ThrowAssertionTest: XCTestCase {
     }
 
     func testNonVoidClosure() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         expect { () -> Int in fatalError() }.to(throwAssertion())
         #endif
     }
 
     func testChainOnThrowAssertion() {
-        #if arch(x86_64)
+        #if arch(x86_64) || arch(arm64)
         expect { () -> Int in return 5 }.toNot(throwAssertion()).to(equal(5))
         #endif
     }


### PR DESCRIPTION
This updates the dependency `mattgallagher/CwlPreconditionTesting` to v2.1.0 and thereby fixes precondition testing for Macs running on Apple Silicon.

Closes https://github.com/Quick/Nimble/issues/851