### PR TITLE
`beIdenticalTo` / `===`: disallow comparing non-objects

### DIFF
--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -1,10 +1,10 @@
 /// A Nimble matcher that succeeds when the actual value is the same instance
 /// as the expected instance.
-public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
+public func beIdenticalTo(_ expected: AnyObject?) -> Predicate<AnyObject> {
     return Predicate.define { actualExpression in
-        let actual = try actualExpression.evaluate() as AnyObject?
+        let actual = try actualExpression.evaluate()
 
-        let bool = actual === (expected as AnyObject?) && actual !== nil
+        let bool = actual === expected && actual !== nil
         return PredicateResult(
             bool: bool,
             message: .expectedCustomValueTo(
@@ -15,12 +15,12 @@ public func beIdenticalTo(_ expected: Any?) -> Predicate<Any> {
     }
 }
 
-extension Expectation where T == Any {
-    public static func === (lhs: Expectation, rhs: Any?) {
+extension Expectation where T == AnyObject {
+    public static func === (lhs: Expectation, rhs: AnyObject?) {
         lhs.to(beIdenticalTo(rhs))
     }
 
-    public static func !== (lhs: Expectation, rhs: Any?) {
+    public static func !== (lhs: Expectation, rhs: AnyObject?) {
         lhs.toNot(beIdenticalTo(rhs))
     }
 }
@@ -29,7 +29,7 @@ extension Expectation where T == Any {
 /// as the expected instance.
 ///
 /// Alias for "beIdenticalTo".
-public func be(_ expected: Any?) -> Predicate<Any> {
+public func be(_ expected: AnyObject?) -> Predicate<AnyObject> {
     return beIdenticalTo(expected)
 }
 
@@ -39,7 +39,7 @@ import class Foundation.NSObject
 extension NMBPredicate {
     @objc public class func beIdenticalToMatcher(_ expected: NSObject?) -> NMBPredicate {
         return NMBPredicate { actualExpression in
-            let aExpr = actualExpression.cast { $0 as Any? }
+            let aExpr = actualExpression.cast { $0 as AnyObject? }
             return try beIdenticalTo(expected).satisfies(aExpr).toObjectiveC()
         }
     }

--- a/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToTest.swift
@@ -41,7 +41,6 @@ final class BeIdenticalToTest: XCTestCase {
         let value = NSDate()
         expect(value).to(be(value))
         expect(1 as NSNumber).toNot(be("turtles" as NSString))
-        expect([1]).toNot(be([1]))
         expect([1 as NSNumber] as NSArray).toNot(be([1 as NSNumber] as NSArray))
 
         let value1 = NSArray()


### PR DESCRIPTION
Equality comparisons don't make sense for anything other than objects, and they will always fail.
Using `===` with `struct`s for example is likely a programmer error, so to avoid it, a compile-time error is better.

This is potentially a breaking change.