### PR TITLE
Update Custom Validation readme and `ToSucceed` test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,19 +1266,19 @@ Note: This matcher allows you to chain any number of matchers together. This pro
 // passes if .succeeded is returned from the closure
 expect {
     guard case .enumCaseWithAssociatedValueThatIDontCareAbout = actual else {
-        return .failed(reason: "wrong enum case")
+        return { .failed(reason: "wrong enum case") }
     }
 
-    return .succeeded
+    return { .succeeded }
 }.to(succeed())
 
 // passes if .failed is returned from the closure
 expect {
     guard case .enumCaseWithAssociatedValueThatIDontCareAbout = actual else {
-        return .failed(reason: "wrong enum case")
+        return { .failed(reason: "wrong enum case") }
     }
 
-    return .succeeded
+    return { .succeeded }
 }.notTo(succeed())
 ```
 

--- a/Tests/NimbleTests/Matchers/ToSucceedTest.swift
+++ b/Tests/NimbleTests/Matchers/ToSucceedTest.swift
@@ -3,28 +3,39 @@ import Nimble
 
 final class ToSucceedTest: XCTestCase {
     func testToSucceed() {
-        expect({
-            return .succeeded
-        }).to(succeed())
+        expect {
+            let result: Result<Bool, Error> = .success(true)
+            
+            switch result {
+            case .success:
+                return { .succeeded }
+            default:
+                return { .failed(reason: "") }
+            }
+        }.to(succeed())
+                
+        expect {
+            .succeeded
+        }.to(succeed())
 
-        expect({
-            return .failed(reason: "")
-        }).toNot(succeed())
+        expect {
+            .failed(reason: "")
+        } .toNot(succeed())
 
         failsWithErrorMessageForNil("expected a closure, got <nil>") {
             expect(nil as (() -> ToSucceedResult)?).to(succeed())
         }
 
         failsWithErrorMessage("expected to succeed, got <failed> because <something went wrong>") {
-            expect({
+            expect {
                 .failed(reason: "something went wrong")
-            }).to(succeed())
+            } .to(succeed())
         }
 
         failsWithErrorMessage("expected to not succeed, got <succeeded>") {
-            expect({
-                return .succeeded
-            }).toNot(succeed())
+            expect {
+                .succeeded
+            } .toNot(succeed())
         }
     }
 }


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

- Closes #963.
- Updates readme with working sample code.
- Adds a `ToSucceed` test with a switch statement.
- Updates `ToSucceed` tests to use trailing closure syntax.

Checklist - While not every PR needs it, new features should consider this list:

- [X] Does this have tests?
- [X] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
