### PR TITLE
Add toAlways, the inverse of toNever.

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,22 @@ contains dolphins and whales, the expectation passes. If `ocean` still
 doesn't contain them, even after being continuously re-evaluated for one
 whole second, the expectation fails.
 
+You can also test that a value always or never matches throughout the length of the timeout. Use `toNever` and `toAlways` for this:
+
+```swift
+// Swift
+ocean.add("dolphins")
+expect(ocean).toAlways(contain("dolphins"))
+expect(ocean).toNever(contain("hares"))
+```
+
+```objc
+// Objective-C
+[ocean add:@"dolphins"]
+expect(ocean).toAlways(contain(@"dolphins"))
+expect(ocean).toNever(contain(@"hares"))
+```
+
 Sometimes it takes more than a second for a value to update. In those
 cases, use the `timeout` parameter:
 

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -146,6 +146,34 @@ public class NMBExpectation: NSObject {
         return toNeverWithDescription
     }
 
+    @objc public var toAlways: (NMBPredicate) -> Void {
+        return { predicate in
+            self.expectValue.toAlways(
+                from(objcPredicate: predicate),
+                until: self._timeout,
+                description: nil
+            )
+        }
+    }
+
+    @objc public var toAlwaysWithDescription: (NMBPredicate, String) -> Void {
+        return { predicate, description in
+            self.expectValue.toAlways(
+                from(objcPredicate: predicate),
+                until: self._timeout,
+                description: description
+            )
+        }
+    }
+
+    @objc public var alwaysTo: (NMBPredicate) -> Void {
+        return toAlways
+    }
+
+    @objc public var alwaysToWithDescription: (NMBPredicate, String) -> Void {
+        return toAlwaysWithDescription
+    }
+
     @objc public class func failWithMessage(_ message: String, file: FileString, line: UInt) {
         fail(message, location: SourceLocation(file: file, line: line))
     }

--- a/Tests/NimbleTests/AsynchronousTest.swift
+++ b/Tests/NimbleTests/AsynchronousTest.swift
@@ -284,6 +284,39 @@ final class AsyncTest: XCTestCase {
             expect { try self.doThrowError() }.neverTo(equal(0))
         }
     }
+
+    func testToAlwaysPositiveMatches() {
+        var value = 1
+        deferToMainQueue { value = 2 }
+        expect { value }.toAlways(beGreaterThan(0))
+
+        deferToMainQueue { value = 2 }
+        expect { value }.alwaysTo(beGreaterThan(1))
+    }
+
+    func testToAlwaysNegativeMatches() {
+        var value = 1
+        failsWithErrorMessage("expected to always equal <0>, got <1>") {
+            expect { value }.toAlways(equal(0))
+        }
+        failsWithErrorMessage("expected to always equal <0>, got <1>") {
+            expect { value }.alwaysTo(equal(0))
+        }
+        failsWithErrorMessage("expected to always equal <1>, got <0>") {
+            deferToMainQueue { value = 0 }
+            expect { value }.toAlways(equal(1))
+        }
+        failsWithErrorMessage("expected to always equal <1>, got <0>") {
+            deferToMainQueue { value = 0 }
+            expect { value }.alwaysTo(equal(1))
+        }
+        failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.toAlways(equal(0))
+        }
+        failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            expect { try self.doThrowError() }.alwaysTo(equal(0))
+        }
+    }
 }
 
 #endif // #if !os(WASI)

--- a/Tests/NimbleTests/objc/ObjCAsyncTest.m
+++ b/Tests/NimbleTests/objc/ObjCAsyncTest.m
@@ -92,4 +92,43 @@
     });
 }
 
+- (void)testToAlwaysPositiveMatches {
+    __block id value = @2;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        value = @3;
+    });
+    expect(value).toAlways(beGreaterThan(1));
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        value = @2;
+    });
+    expect(value).alwaysTo(beGreaterThan(1));
+}
+
+- (void)testToAlwaysNegativeMatches {
+    __block id value = @0;
+    expectFailureMessage(@"expected to always equal <0>, got <1>", ^{
+        value = @1;
+        expect(value).toAlways(equal(0));
+    });
+    expectFailureMessage(@"expected to always equal <0>, got <1>", ^{
+        value = @1;
+        expect(value).alwaysTo(equal(0));
+    });
+    expectFailureMessage(@"expected to always equal <1>, got <2>", ^{
+        value = @1;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            value = @2;
+        });
+        expect(value).toAlways(equal(1));
+    });
+    expectFailureMessage(@"expected to always equal <1>, got <2>", ^{
+        value = @1;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            value = @2;
+        });
+        expect(value).alwaysTo(equal(1));
+    });
+}
+
 @end


### PR DESCRIPTION
`toNever` was added somewhat recently, where we verify that a matcher continues to fail until the timeout happens. It felt odd to me that there wasn't a way to verify that a watcher continues to succeed until the timeout happens. So I added `toAlways` to capture that.

This adjusts how the private `async` function works, to also take in the behavior that we want the predicate to always match. I briefly looked into consolidating `AsyncMatchStyle.never` and `AsyncMatchStyle.always` because they are very similar, but decided against DRY'ing that up because it would unnecessarily add complexity.

This also adds documentation in the README around how to use `toNever` and `toAlways`. It's not great documentation, but I hope this gets the idea across.

- [x] Does this have tests?
- [x] Does this have documentation?
- Does not break the public API.
- [x] Is this a new feature (Requires minor version bump)?
