### PR TITLE
Simplify the implementations of beTruthy and beFalsy

### DIFF
--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -99,10 +99,7 @@ public func beFalse() -> Predicate<Bool> {
 public func beTruthy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<T> {
     return Predicate.simpleNilable("be truthy") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        if let actualValue = actualValue {
-            return PredicateStatus(bool: actualValue == (true as T))
-        }
-        return PredicateStatus(bool: actualValue != nil)
+        return PredicateStatus(bool: actualValue == (true as T))
     }
 }
 
@@ -111,10 +108,7 @@ public func beTruthy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<
 public func beFalsy<T: ExpressibleByBooleanLiteral & Equatable>() -> Predicate<T> {
     return Predicate.simpleNilable("be falsy") { actualExpression in
         let actualValue = try actualExpression.evaluate()
-        if let actualValue = actualValue {
-            return PredicateStatus(bool: actualValue == (false as T))
-        }
-        return PredicateStatus(bool: actualValue == nil)
+        return PredicateStatus(bool: actualValue != (true as T))
     }
 }
 


### PR DESCRIPTION
This was pointed out by @amomchilov in https://github.com/Quick/Nimble/issues/917. Thanks!

Basically, we don't need to be doing the `if let` in these matchers. So, let's take them out.

This isn't even a minor version bump.