### PR TITLE
Fix equal compilation optionals

### DIFF
--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -117,7 +117,7 @@ private func equal<T>(_ expectedValue: Set<T>?, stringify: @escaping (Set<T>?) -
 }
 
 /// A Nimble matcher that succeeds when the actual dictionary is equal to the expected dictionary
-public func equal<K: Hashable, V: Equatable>(_ expectedValue: Dictionary<K, V?>) -> Predicate<Dictionary<K, V>> {
+public func equal<K: Hashable, V: Equatable>(_ expectedValue: [K: V?]) -> Predicate<[K: V]> {
     Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, msg in
         guard let actualValue = try actualExpression.evaluate() else {
             return PredicateResult(

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import XCTest
 import Nimble
 
-final class EqualTest: XCTestCase {
+final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
     func testEquality() {
         expect(1 as CInt).to(equal(1 as CInt))
         expect(1 as CInt).to(equal(1))
@@ -55,12 +55,12 @@ final class EqualTest: XCTestCase {
     }
 
     func testDictEqualityWithOptionalElement() {
-        let dict: [String : String] = ["" : ""]
+        let dict: [String: String] = ["": ""]
         let getString: () -> String? = { return "" }
 
         expect(dict) == ["": getString()] as [String: String?]
         expect(dict) == (["": getString()] as [String: String?])
-        expect(dict).to(equal(["": getString()])) 
+        expect(dict).to(equal(["": getString()]))
         expect(dict) == ["": getString()]
 
         let optionalString = getString()

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -40,6 +40,44 @@ final class EqualTest: XCTestCase {
         }
     }
 
+    func testArrayEqualityWithOptionalElement() {
+        let array: [String] = [""]
+        let getString: () -> String? = { return "" }
+
+        // Compiles
+        expect(array) == [getString()] as [String?]
+
+        expect(array) == ([getString()] as [String?])
+
+        // Does not compile with the error:
+        // Cannot convert value of type 'String?' to expected element type 'Array<String>.ArrayLiteralElement' (aka 'String')
+        expect(array).to(equal([getString()]))
+
+        expect(array) == [getString()]
+
+        let optionalString = getString()
+        expect(array) == [optionalString]
+    }
+
+    func testDictEqualityWithOptionalElement() {
+        let dict: [String : String] = ["" : ""]
+        let getString: () -> String? = { return "" }
+
+        // Compiles
+        expect(dict) == ["": getString()] as [String: String?]
+
+        expect(dict) == (["": getString()] as [String: String?])
+
+        // Does not compile with the error:
+        // Cannot convert value of type 'String?' to expected dictionary value type 'String'
+        expect(dict).to(equal(["": getString()])) // This also does not work in latest version v2.9.1
+
+        expect(dict) == ["": getString()]
+
+        let optionalString = getString()
+        expect(dict) == ["": optionalString]
+    }
+
     func testSetEquality() {
         expect(Set([1, 2])).to(equal(Set([1, 2])))
         expect(Set<Int>()).to(equal(Set<Int>()))

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -44,15 +44,10 @@ final class EqualTest: XCTestCase {
         let array: [String] = [""]
         let getString: () -> String? = { return "" }
 
-        // Compiles
         expect(array) == [getString()] as [String?]
-
         expect(array) == ([getString()] as [String?])
 
-        // Does not compile with the error:
-        // Cannot convert value of type 'String?' to expected element type 'Array<String>.ArrayLiteralElement' (aka 'String')
         expect(array).to(equal([getString()]))
-
         expect(array) == [getString()]
 
         let optionalString = getString()
@@ -63,15 +58,9 @@ final class EqualTest: XCTestCase {
         let dict: [String : String] = ["" : ""]
         let getString: () -> String? = { return "" }
 
-        // Compiles
         expect(dict) == ["": getString()] as [String: String?]
-
         expect(dict) == (["": getString()] as [String: String?])
-
-        // Does not compile with the error:
-        // Cannot convert value of type 'String?' to expected dictionary value type 'String'
-        expect(dict).to(equal(["": getString()])) // This also does not work in latest version v2.9.1
-
+        expect(dict).to(equal(["": getString()])) 
         expect(dict) == ["": getString()]
 
         let optionalString = getString()
@@ -83,6 +72,12 @@ final class EqualTest: XCTestCase {
         expect(Set<Int>()).to(equal(Set<Int>()))
         expect(Set<Int>()) == Set<Int>()
         expect(Set([1, 2])) != Set<Int>()
+
+        let optionalSet: Set<Int?> = [1, 2]
+        expect(Set([1, 2])).to(equal(optionalSet))
+        expect(Set([1, 2, 3])).toNot(equal(optionalSet))
+        expect(Set([1, 2])) == optionalSet
+        expect(optionalSet) != Set([1, 2, 3])
 
         failsWithErrorMessageForNil("expected to equal <[1, 2]>, got <nil>") {
             expect(nil as Set<Int>?).to(equal(Set([1, 2])))


### PR DESCRIPTION
This extends and solves https://github.com/Quick/Nimble/pull/962 by doing what @ikesyo suggests as the fix.

Another possible fix would be to add public extensions of Array, Set, and Dictionary such that they can also use `==` or `!=` with Optionals. I elected not to do that because I'd rather not change the behavior of these very common types just for Nimble. It felt way less riskier to bring back these matchers.

Maybe in the future, Swift will be enhanced again so that we can actually simplify these matchers.

Thanks @acecilia for bringing up this issue!