### PR TITLE
Wrap NimbleXCTestHandler in canImport

### DIFF
--- a/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
+++ b/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(XCTest)
 import XCTest
 
 /// Default handler for Nimble. This assertion handler passes failures along to
@@ -92,3 +93,4 @@ public func recordFailure(_ message: String, location: SourceLocation) {
     }
 #endif
 }
+#endif // canImport(XCTest)


### PR DESCRIPTION
#986

This wraps our NimbleXCTestHandler declarations around `#if canImport(XCTest)`. This will make it a little easier to use Nimble without XCTest.

This is a minor version bump.