### PR TITLE
Expose whether an expectation has passed and provide an option to throw

### DIFF
--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -152,7 +152,7 @@ extension Expectation {
     ///            unconditionally log an error.
     ///
     /// - Remark: Similar functionality can be achieved using the `status` property.
-    func onFailure(`throw` error: Error) throws {
+    public func onFailure(`throw` error: Error) throws {
         switch status {
         case .pending:
             let msg = """

--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -160,7 +160,8 @@ extension Expectation {
                 Try using `expect(...).to(...).onFailure(throw: ...`) instead.
                 """
             
-            recordFailure(msg, location: expression.location)
+            let handler = NimbleEnvironment.activeInstance.assertionHandler
+            handler.assert(false, message: .init(stringValue: msg), location: expression.location)
         case .passed:
             break
         case .failed, .mixed:

--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -34,32 +34,72 @@ internal func execute<T>(_ expression: Expression<T>, _ style: ExpectationStyle,
 }
 
 public struct Expectation<T> {
-
-    public let expression: Expression<T>
-
-    public init(expression: Expression<T>) {
-        self.expression = expression
+    
+    public enum Status: Equatable {
+        
+        /// No predicates have been performed.
+        case pending
+        
+        /// All predicates have passed.
+        case passed
+        
+        /// All predicates have failed.
+        case failed
+        
+        /// Multiple predicates have been peformed, with at least one passing and one failing.
+        case mixed
     }
 
-    public func verify(_ pass: Bool, _ message: FailureMessage) {
+    public let expression: Expression<T>
+    
+    /// The status of the test after predicates have been evaluated.
+    ///
+    /// This property can be used for changing test behavior based whether an expectation has
+    /// passed.
+    ///
+    /// In the below example, we perform additional tests on an array only if it has enough
+    /// elements.
+    ///
+    /// ```
+    /// if expect(array).to(haveCount(10)).status == .passed {
+    ///    expect(array[9]).to(...)
+    /// }
+    /// ```
+    public let status: Status
+
+    private init(expression: Expression<T>, status: Status) {
+        self.expression = expression
+        self.status = status
+    }
+
+    public init(expression: Expression<T>) {
+        self.init(expression: expression, status: .pending)
+    }
+    
+    /// Takes the result of a test and passes it to the assertion handler.
+    ///
+    /// - Returns: An updated `Expression` with the result of the test applied to the `status`
+    ///            property.
+    @discardableResult
+    public func verify(_ pass: Bool, _ message: FailureMessage) -> Self {
         let handler = NimbleEnvironment.activeInstance.assertionHandler
         handler.assert(pass, message: message, location: expression.location)
+        
+        return .init(expression: expression, status: status.applying(pass ? .passed : .failed))
     }
 
     /// Tests the actual value using a matcher to match.
     @discardableResult
     public func to(_ predicate: Predicate<T>, description: String? = nil) -> Self {
         let (pass, msg) = execute(expression, .toMatch, predicate, to: "to", description: description)
-        verify(pass, msg)
-        return self
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match.
     @discardableResult
     public func toNot(_ predicate: Predicate<T>, description: String? = nil) -> Self {
         let (pass, msg) = execute(expression, .toNotMatch, predicate, to: "to not", description: description)
-        verify(pass, msg)
-        return self
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match.
@@ -73,4 +113,18 @@ public struct Expectation<T> {
     // see:
     // - `async` for extension
     // - NMBExpectation for Objective-C interface
+}
+
+extension Expectation.Status {
+    
+    /// Applies a new status to the current one to produce a combined status.
+    ///
+    /// This method is meant to advance the state from `.pending` to either `.passed` or`.failed`.
+    /// When called multiple times with different values, the result will be `.mixed`.
+    /// E.g., `status.applying(.passed).applying(.failed) == .mixed`.
+    func applying(_ newerStatus: Expectation.Status) -> Expectation.Status {
+        if newerStatus == .pending { return self }
+        if self == .pending || self == newerStatus { return newerStatus }
+        return .mixed
+    }
 }

--- a/Sources/Nimble/Matchers/Async.swift
+++ b/Sources/Nimble/Matchers/Async.swift
@@ -90,7 +90,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func toEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -108,7 +109,7 @@ extension Expectation {
             description: description,
             captureExceptions: false
         )
-        verify(pass, msg)
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match by checking
@@ -117,7 +118,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toEventuallyNot(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func toEventuallyNot(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -135,7 +137,7 @@ extension Expectation {
             description: description,
             captureExceptions: false
         )
-        verify(pass, msg)
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to not match by checking
@@ -146,7 +148,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toNotEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func toNotEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
@@ -156,7 +159,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toNever(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func toNever(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -174,7 +178,7 @@ extension Expectation {
             description: description,
             captureExceptions: false
         )
-        verify(pass, msg)
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to never match by checking
@@ -185,7 +189,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func neverTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func neverTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
@@ -195,7 +200,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func toAlways(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func toAlways(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -213,7 +219,7 @@ extension Expectation {
             description: description,
             captureExceptions: false
         )
-        verify(pass, msg)
+        return verify(pass, msg)
     }
 
     /// Tests the actual value using a matcher to always match by checking
@@ -224,7 +230,8 @@ extension Expectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-    public func alwaysTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) {
+    @discardableResult
+    public func alwaysTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -66,6 +66,21 @@ func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, li
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
+func suppressErrors(closure: () throws -> Void) {
+    let recorder = AssertionRecorder()
+    withAssertionHandler(recorder, closure: closure)
+}
+
+func producesStatus<T>(_ status: Expectation<T>.Status, file: FileString = #file, line: UInt = #line, closure: () -> Expectation<T>) {
+    var result: Expectation<T>.Status = .pending
+    
+    suppressErrors {
+        result = closure().status
+    }
+    
+    expect(file: file, line: line, result).to(equal(status))
+}
+
 #if !os(WASI)
 func deferToMainQueue(action: @escaping () -> Void) {
     DispatchQueue.main.async {

--- a/Tests/NimbleTests/OnFailureThrowsTest.swift
+++ b/Tests/NimbleTests/OnFailureThrowsTest.swift
@@ -1,0 +1,39 @@
+import XCTest
+import Nimble
+
+final class OnFailureThrowsTest: XCTestCase {
+    
+    enum MyError: Error, Equatable {
+        case error1
+    }
+    
+    func testUnexecutedLogsAnError() {
+        
+        failsWithErrorMessage("Attempted to call `Expectation.onFailure(throw:) before a predicate has been applied.\nTry using `expect(...).to(...).onFailure(throw: ...`) instead.") {
+            try expect(true).onFailure(throw: MyError.error1)
+        }
+    }
+    
+    func testPassedDoesNotThrow() {
+        
+        let expectation = expect(true).to(beTrue())
+        
+        expect(try expectation.onFailure(throw: MyError.error1)).notTo(throwError())
+    }
+
+    func testFailedThrowsAnError() {
+        let expectation = suppressErrors {
+            expect(true).to(beFalse())
+        }
+
+        expect(try expectation.onFailure(throw: MyError.error1)).to(throwError(MyError.error1))
+    }
+    
+    func testMixedThrowsAnError() {
+        let expectation = suppressErrors {
+            expect(true).to(beTrue()).to(beFalse())
+        }
+
+        expect(try expectation.onFailure(throw: MyError.error1)).to(throwError(MyError.error1))
+    }
+}

--- a/Tests/NimbleTests/StatusTest.swift
+++ b/Tests/NimbleTests/StatusTest.swift
@@ -1,0 +1,49 @@
+import XCTest
+import Nimble
+
+final class StatusTest: XCTestCase {
+    
+    func testUnexecuted() {
+        producesStatus(.pending) {
+            expect(true)
+        }
+    }
+    
+    func testSingleExecution() {
+        producesStatus(.passed) {
+            expect(true).to(beTrue())
+        }
+        
+        producesStatus(.failed) {
+            expect(true).to(beFalse())
+        }
+    }
+
+    func testChainedExecution() {
+        producesStatus(.passed) {
+            expect(true).to(beTrue()).to(beTrue())
+        }
+        
+        producesStatus(.failed) {
+            expect(true).to(beFalse()).to(beFalse())
+        }
+        
+        producesStatus(.mixed) {
+            expect(true).to(beTrue()).to(beFalse())
+        }
+        
+        producesStatus(.mixed) {
+            expect(true).to(beFalse()).to(beTrue())
+        }
+    }
+    
+    func testAsync() {
+        producesStatus(.passed) {
+            expect(true).toEventually(beTrue())
+        }
+        
+        producesStatus(.failed) {
+            expect(true).toEventually(beFalse())
+        }
+    }
+}


### PR DESCRIPTION
This PR is based on this comment https://github.com/Quick/Quick/pull/1165#pullrequestreview-1087781240 for a related feature in Quick.

Each `Expectation<T>` structure now has a `status` property that represents the results of any tests that had been run.  This provides the ability to make decisions in the test based on any previous expectation's results.

I.e.:

```
expect(true).status == .pending
expect(true).to(beTrue()).status == .passed
expect(true).to(beFalse()).status == .failed
expect(true).to(beTrue()).to(beFalse()).status == .mixed
```

Additionally, I added a method to `Expectation<T>` called `onFailure(throw:) throws` which will throw the passed in error if the expectation is `.failed` or `.mixed`.  This method must be called after a predicate so it logs an error if called in the `.pending` state.  It would probably be better to not expose `onFailure(throws:)` on unevaluated expectations, but that would require adding a new type like `EvaluatedExpecation<T>` which would require a breaking change to the return type of methods like `to`.

One change of note that was made is that several methods have gone from returning `Void` to `@discardableResult Expression<T>` which I'm really hoping is API/ABI compatible with Swift.

I've not looked at documentation yet since there are a million ways that `status` could be represented so I'd like to get that pinned down first.

Checklist - While not every PR needs it, new features should consider this list:

- [x] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [x] Is this a new feature (Requires minor version bump)?
