### PR TITLE
Raise minimum required OS and Swift Versions to Async-Support versions.

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         xcode: ["13.3.1", "14.0.1"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
     steps:
       - uses: actions/checkout@v3
       - run: ./test swiftpm

--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         xcode: ["13.3.1", "14.0.1"]

--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: ["12.5", "13.0"]
+        xcode: ["13.3.1", "14.0.1"]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
     steps:
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         container:
-          - swift:5.4
-          - swift:5.5
+          - swift:5.6
+          - swift:5.7
           # - swiftlang/swift:nightly
       fail-fast: false
     container: ${{ matrix.container }}

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   xcode:
     name: Xcode ${{ matrix.xcode }} (Xcode Project)
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         xcode: ["13.3.1", "14.0.1"]
@@ -29,7 +29,7 @@ jobs:
 
   xcode_spm:
     name: Xcode ${{ matrix.xcode }} (Swift Package)
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         xcode: ["13.3.1", "14.0.1"]

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: ["12.5", "13.0"]
+        xcode: ["13.3.1", "14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: ["12.5", "13.0"]
+        xcode: ["13.3.1", "14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -19,7 +19,7 @@ jobs:
         xcode: ["13.3.1", "14.0.1"]
       fail-fast: false
     env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
     steps:
       - uses: actions/checkout@v3
       - run: ./test macos
@@ -35,7 +35,7 @@ jobs:
         xcode: ["13.3.1", "14.0.1"]
       fail-fast: false
     env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
     steps:
       - uses: actions/checkout@v3
       - run: ./test macos_xcodespm

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cocoapods:
     name: CocoaPods Lint
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -8,10 +8,10 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/Quick/Nimble"
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }
   s.author       = "Quick Contributors"
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
-  s.tvos.deployment_target = "9.0"
-  s.watchos.deployment_target = "5.0"
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "10.15"
+  s.tvos.deployment_target = "13.0"
+  s.watchos.deployment_target = "6.0"
   s.source       = { :git => "https://github.com/Quick/Nimble.git",
                      :tag => "v#{s.version}" }
 

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -2213,7 +2213,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -2225,9 +2226,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -2278,7 +2280,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2291,10 +2294,11 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -2316,7 +2320,6 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Sources/Nimble/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2355,7 +2358,6 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Sources/Nimble/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2387,7 +2389,6 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/NimbleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2407,7 +2408,6 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = Tests/NimbleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2459,7 +2459,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -2501,7 +2500,6 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -2522,7 +2520,6 @@
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -2546,7 +2543,6 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -2573,7 +2569,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2612,7 +2607,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2645,7 +2639,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;
@@ -2666,7 +2659,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = NimbleTests;

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
     name: "Nimble",
     platforms: [
-      .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v5)
+      .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         .library(name: "Nimble", targets: ["Nimble"]),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,8 +1,0 @@
-import XCTest
-
-import NimbleTests
-
-var tests = [XCTestCaseEntry]()
-tests += NimbleTests.__allTests()
-
-XCTMain(tests)

--- a/Tests/NimbleTests/objc/ObjCHaveCountTest.m
+++ b/Tests/NimbleTests/objc/ObjCHaveCountTest.m
@@ -73,31 +73,37 @@
     expect(table).to(haveCount(3));
     expect(table).notTo(haveCount(1));
 
+    NSString *tableDescription = [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+
     NSString *msg = [NSString stringWithFormat:
-                     @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
-                     [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+                     @"expected to have %@with count 1, got 3\nActual Value: %@",
+                     tableDescription,
+                     tableDescription];
     expectFailureMessage(msg, ^{
         expect(table).to(haveCount(@1));
     });
 
     msg = [NSString stringWithFormat:
-           @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
-           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+           @"expected to not have %@with count 3, got 3\nActual Value: %@",
+           tableDescription,
+           tableDescription];
     expectFailureMessage(msg, ^{
         expect(table).notTo(haveCount(@3));
     });
 
 
     msg = [NSString stringWithFormat:
-           @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
-           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+           @"expected to have %@with count 1, got 3\nActual Value: %@",
+           tableDescription,
+           tableDescription];
     expectFailureMessage(msg, ^{
         expect(table).to(haveCount(1));
     });
 
     msg = [NSString stringWithFormat:
-           @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
-           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+           @"expected to not have %@with count 3, got 3\nActual Value: %@",
+           tableDescription,
+           tableDescription];
     expectFailureMessage(msg, ^{
         expect(table).notTo(haveCount(3));
     });

--- a/test
+++ b/test
@@ -82,7 +82,7 @@ function test_watchos {
     run set -o pipefail && xcodebuild -project Nimble.xcodeproj -scheme "Nimble-watchOS" -configuration "Debug" -destination "generic/platform=watchOS" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build | xcpretty
 
     run osascript -e 'tell app "Simulator" to quit'
-    run set -o pipefail && xcodebuild -project Nimble.xcodeproj -scheme "Nimble-watchOS" -configuration "Debug" -sdk "watchsimulator$BUILD_WATCHOS_SDK_VERSION" -destination "name=Apple Watch Series 6 - 40mm,OS=$RUNTIME_WATCHOS_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
+    run set -o pipefail && xcodebuild -project Nimble.xcodeproj -scheme "Nimble-watchOS" -configuration "Debug" -sdk "watchsimulator$BUILD_WATCHOS_SDK_VERSION" -destination "name=Apple Watch Series 6 (40mm),OS=$RUNTIME_WATCHOS_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
 }
 
 function test_macos {
@@ -113,7 +113,7 @@ function test_xcode_spm_watchos {
     run osascript -e 'tell app "Simulator" to quit'
     mv Nimble.xcodeproj Nimble.xcodeproj.bak
     trap 'mv Nimble.xcodeproj.bak Nimble.xcodeproj' EXIT
-    run set -o pipefail && xcodebuild -scheme "Nimble" -configuration "Debug" -sdk "watchsimulator$BUILD_WATCHOS_SDK_VERSION" -destination "name=Apple Watch Series 6 - 40mm,OS=$RUNTIME_WATCHOS_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
+    run set -o pipefail && xcodebuild -scheme "Nimble" -configuration "Debug" -sdk "watchsimulator$BUILD_WATCHOS_SDK_VERSION" -destination "name=Apple Watch Series 6 (40mm),OS=$RUNTIME_WATCHOS_VERSION" OTHER_SWIFT_FLAGS='$(inherited) -suppress-warnings' build-for-testing test-without-building | xcpretty
 }
 
 function test_podspec {


### PR DESCRIPTION
Resolves https://github.com/Quick/Nimble/issues/984

With this PR:

- Swift is now 5.6 and later
- Xcode is now 13.3.1 and later
- iOS is now 13 and later
- tvOS is now 13 and later
- watchOS is now 6 and later
- macOS is now 10.15 and later

This also gets rid of the now-deprecated LinuxMain.swift, for running linux tests. It's no longer necessary if you're running Linux Tests using only XCTest.
