### PR TITLE
Allow using async/await in expect

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -56,9 +56,9 @@
 		1F1871E01CA89EF600A34BF2 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1871BC1CA89EDB00A34BF2 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F1871E11CA89EF600A34BF2 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1871BE1CA89EDB00A34BF2 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F1871E21CA89EF600A34BF2 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1871C01CA89EDB00A34BF2 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1F1871E41CA89FB600A34BF2 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Async.swift */; };
-		1F1871E71CA8A18400A34BF2 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Async.swift */; };
-		1F1871E81CA8A18400A34BF2 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Async.swift */; };
+		1F1871E41CA89FB600A34BF2 /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Polling.swift */; };
+		1F1871E71CA8A18400A34BF2 /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Polling.swift */; };
+		1F1871E81CA8A18400A34BF2 /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Polling.swift */; };
 		1F1A742F1940169200FFFC47 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F1A74351940169200FFFC47 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F1A74291940169200FFFC47 /* Nimble.framework */; };
 		1F1B5AD41963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B5AD31963E13900CA8BF9 /* BeAKindOfTest.swift */; };
@@ -329,6 +329,14 @@
 		898F28B025D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
 		898F28B125D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
 		898F28B225D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
+		899441EF2902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */; };
+		899441F02902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */; };
+		899441F12902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */; };
+		899441F22902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */; };
+		899441F82902EF2500C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
+		899441F92902EF2600C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
+		899441FA2902EF2700C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
+		899441FB2902EF2800C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
 		964CFEFD1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFF1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
@@ -497,7 +505,7 @@
 		D95F8969267EA20A004B1B4D /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20058C020E92C7500C1264D /* ElementsEqual.swift */; };
 		D95F896A267EA20A004B1B4D /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		D95F896B267EA20A004B1B4D /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD101968AB07008ED995 /* BeEmpty.swift */; };
-		D95F896C267EA20A004B1B4D /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Async.swift */; };
+		D95F896C267EA20A004B1B4D /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871E31CA89FB600A34BF2 /* Polling.swift */; };
 		D95F896D267EA20A004B1B4D /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD0F1968AB07008ED995 /* BeCloseTo.swift */; };
 		D95F896E267EA20A004B1B4D /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F91DD301C74BF61002C309F /* BeVoid.swift */; };
 		D95F896F267EA20A004B1B4D /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1B1968AB07008ED995 /* EndWith.swift */; };
@@ -636,7 +644,7 @@
 		1F1871C11CA89EDB00A34BF2 /* NMBStringify.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NMBStringify.m; sourceTree = "<group>"; };
 		1F1871C21CA89EDB00A34BF2 /* NMBExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NMBExpectation.swift; sourceTree = "<group>"; };
 		1F1871CD1CA89EE000A34BF2 /* ExceptionCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExceptionCapture.swift; sourceTree = "<group>"; };
-		1F1871E31CA89FB600A34BF2 /* Async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
+		1F1871E31CA89FB600A34BF2 /* Polling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Polling.swift; sourceTree = "<group>"; };
 		1F1A74291940169200FFFC47 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F1A742D1940169200FFFC47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F1A742E1940169200FFFC47 /* Nimble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Nimble.h; sourceTree = "<group>"; };
@@ -742,6 +750,8 @@
 		857D1848253610A900D8693A /* BeWithin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeWithin.swift; sourceTree = "<group>"; };
 		857D184D2536123F00D8693A /* BeWithinTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeWithinTest.swift; sourceTree = "<group>"; };
 		898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysFailMatcher.swift; sourceTree = "<group>"; };
+		899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTest.swift; sourceTree = "<group>"; };
+		899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSL+AsyncAwait.swift"; sourceTree = "<group>"; };
 		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
 		964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAssertion.swift; sourceTree = "<group>"; };
 		965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCUserDescriptionTest.m; sourceTree = "<group>"; };
@@ -912,11 +922,13 @@
 			children = (
 				1FD8CD041968AB07008ED995 /* Adapters */,
 				1FD8CD081968AB07008ED995 /* DSL.swift */,
+				899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */,
 				DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */,
 				1FD8CD091968AB07008ED995 /* Expectation.swift */,
 				1FD8CD0A1968AB07008ED995 /* Expression.swift */,
 				1FE661561E6574E20035F243 /* ExpectationMessage.swift */,
 				1FD8CD0B1968AB07008ED995 /* FailureMessage.swift */,
+				1F1871E31CA89FB600A34BF2 /* Polling.swift */,
 				1F1A742D1940169200FFFC47 /* Info.plist */,
 				1FD8CD0C1968AB07008ED995 /* Matchers */,
 				1F1A742E1940169200FFFC47 /* Nimble.h */,
@@ -933,6 +945,7 @@
 				CDBC39B82462EA7D00069677 /* PredicateTest.swift */,
 				1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */,
 				1F925EE5195C121200ED456B /* AsynchronousTest.swift */,
+				899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */,
 				965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */,
 				6CAEDD091CAEA86F003F1584 /* LinuxSupport.swift */,
 				1FFD729A1963FC8200CD29A2 /* objc */,
@@ -1010,7 +1023,6 @@
 			isa = PBXGroup;
 			children = (
 				DDB1BC781A92235600F743C3 /* AllPass.swift */,
-				1F1871E31CA89FB600A34BF2 /* Async.swift */,
 				1FD8CD0E1968AB07008ED995 /* BeAKindOf.swift */,
 				1FD8CD0D1968AB07008ED995 /* BeAnInstanceOf.swift */,
 				1FD8CD0F1968AB07008ED995 /* BeCloseTo.swift */,
@@ -1591,13 +1603,14 @@
 				1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */,
 				1FD8CD561968AB07008ED995 /* Contain.swift in Sources */,
 				CDFB6A481F7E082500AD8CC7 /* CwlMachBadInstructionHandler.m in Sources */,
+				899441F92902EF2600C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				CDFB6A3C1F7E082500AD8CC7 /* CwlCatchBadInstruction.swift in Sources */,
 				1FD8CD481968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
 				1FD8CD441968AB07008ED995 /* BeginWith.swift in Sources */,
 				1FD8CD4A1968AB07008ED995 /* BeIdenticalTo.swift in Sources */,
 				1FE661581E6574E30035F243 /* ExpectationMessage.swift in Sources */,
 				1FD8CD421968AB07008ED995 /* BeEmpty.swift in Sources */,
-				1F1871E41CA89FB600A34BF2 /* Async.swift in Sources */,
+				1F1871E41CA89FB600A34BF2 /* Polling.swift in Sources */,
 				1F1871CA1CA89EDB00A34BF2 /* NMBStringify.m in Sources */,
 				A8A3B6EB2071487E00E25A08 /* SatisfyAllOf.swift in Sources */,
 				1FD8CD521968AB07008ED995 /* BeNil.swift in Sources */,
@@ -1624,6 +1637,7 @@
 				1F4A569A1A3B3539009E1637 /* ObjCEqualTest.m in Sources */,
 				898F28B125D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */,
 				1F925EEC195C12C800ED456B /* RaisesExceptionTest.swift in Sources */,
+				899441F02902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
 				62FB326A23B78D500047BED9 /* BeginWithPrefixTest.swift in Sources */,
 				1F925EFF195C187600ED456B /* EndWithTest.swift in Sources */,
 				1F1B5AD41963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */,
@@ -1710,7 +1724,7 @@
 				A8A3B6EC2071487F00E25A08 /* SatisfyAllOf.swift in Sources */,
 				CD3D9A79232647BC00802581 /* CwlCatchBadInstructionPosix.swift in Sources */,
 				1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */,
-				1F1871E81CA8A18400A34BF2 /* Async.swift in Sources */,
+				1F1871E81CA8A18400A34BF2 /* Polling.swift in Sources */,
 				1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */,
 				1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */,
 				1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */,
@@ -1720,6 +1734,7 @@
 				1F1871DB1CA89EF100A34BF2 /* NMBExpectation.swift in Sources */,
 				CDFB6A4F1F7E084600AD8CC7 /* CwlMachBadInstructionHandler.m in Sources */,
 				1F5DF1741BDCA0F500C3A531 /* Expression.swift in Sources */,
+				899441FA2902EF2700C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				1F5DF1781BDCA0F500C3A531 /* BeAnInstanceOf.swift in Sources */,
 				1F5DF1771BDCA0F500C3A531 /* BeAKindOf.swift in Sources */,
 				1F5DF17F1BDCA0F500C3A531 /* BeLessThan.swift in Sources */,
@@ -1768,6 +1783,7 @@
 				CD79C9AD1D2CC848004B6F9A /* ObjCBeTrueTest.m in Sources */,
 				898F28B225D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */,
 				CD79C9B41D2CC848004B6F9A /* ObjCRaiseExceptionTest.m in Sources */,
+				899441F12902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
 				62FB326923B78D4F0047BED9 /* BeginWithPrefixTest.swift in Sources */,
 				1F5DF1A31BDCA10200C3A531 /* BeLogicalTest.swift in Sources */,
 				1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */,
@@ -1852,7 +1868,7 @@
 				1F43728E1A1B343F00EB80F8 /* Stringers.swift in Sources */,
 				1F43728C1A1B343C00EB80F8 /* SourceLocation.swift in Sources */,
 				1FD8CD4F1968AB07008ED995 /* BeLessThanOrEqual.swift in Sources */,
-				1F1871E71CA8A18400A34BF2 /* Async.swift in Sources */,
+				1F1871E71CA8A18400A34BF2 /* Polling.swift in Sources */,
 				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				AE4BA9AE1C88DDB500B73906 /* Errors.swift in Sources */,
 				0477153523B740AD00402D4E /* DispatchTimeInterval.swift in Sources */,
@@ -1884,6 +1900,7 @@
 				CDD80B831F2030790002CD65 /* MatcherProtocols.swift in Sources */,
 				1FD8CD571968AB07008ED995 /* Contain.swift in Sources */,
 				7A0A26231E7F52360092A34E /* ToSucceed.swift in Sources */,
+				899441F82902EF2500C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				CDFB6A471F7E082500AD8CC7 /* CwlMachBadInstructionHandler.m in Sources */,
 				CDFB6A3B1F7E082500AD8CC7 /* CwlCatchBadInstruction.swift in Sources */,
 				1FD8CD491968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
@@ -1917,6 +1934,7 @@
 				1F4A569B1A3B3539009E1637 /* ObjCEqualTest.m in Sources */,
 				898F28B025D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */,
 				1F925EED195C12C800ED456B /* RaisesExceptionTest.swift in Sources */,
+				899441EF2902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
 				62FB326B23B78D510047BED9 /* BeginWithPrefixTest.swift in Sources */,
 				1F925F00195C187600ED456B /* EndWithTest.swift in Sources */,
 				1F1B5AD51963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */,
@@ -2013,6 +2031,7 @@
 				D95F895D267EA205004B1B4D /* Expectation.swift in Sources */,
 				D95F8959267EA205004B1B4D /* NMBExpectation.swift in Sources */,
 				D95F8979267EA20A004B1B4D /* BeLessThan.swift in Sources */,
+				899441FB2902EF2800C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				D95F8968267EA20A004B1B4D /* BeGreaterThan.swift in Sources */,
 				D95F8972267EA20A004B1B4D /* Match.swift in Sources */,
 				D95F8986267EA20E004B1B4D /* Stringers.swift in Sources */,
@@ -2028,7 +2047,7 @@
 				D95F898B267EA315004B1B4D /* CwlCatchBadInstructionPosix.swift in Sources */,
 				D95F8974267EA20A004B1B4D /* RaisesException.swift in Sources */,
 				D95F8961267EA20A004B1B4D /* BeResult.swift in Sources */,
-				D95F896C267EA20A004B1B4D /* Async.swift in Sources */,
+				D95F896C267EA20A004B1B4D /* Polling.swift in Sources */,
 				D95F8964267EA20A004B1B4D /* Contain.swift in Sources */,
 				D95F8962267EA20A004B1B4D /* Equal.swift in Sources */,
 				D95F8956267EA1F7004B1B4D /* AssertionDispatcher.swift in Sources */,
@@ -2065,6 +2084,7 @@
 				D95F893B267EA1E8004B1B4D /* BeLogicalTest.swift in Sources */,
 				D95F894D267EA1E8004B1B4D /* ElementsEqualTest.swift in Sources */,
 				D95F8939267EA1E8004B1B4D /* BeIdenticalToObjectTest.swift in Sources */,
+				899441F22902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
 				D95F8937267EA1E8004B1B4D /* BeginWithTest.swift in Sources */,
 				D95F8948267EA1E8004B1B4D /* MatchErrorTest.swift in Sources */,
 				D95F893C267EA1E8004B1B4D /* ContainTest.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ expect(ocean.isClean).toEventually(beTruthy())
   - [Operator Overloads](#operator-overloads)
   - [Lazily Computed Values](#lazily-computed-values)
   - [C Primitives](#c-primitives)
-  - [Asynchronous Expectations](#asynchronous-expectations)
+  - [Async/Await in Expectations](#asyncawait-support)
+  - [Polling Expectations](#polling-expectations)
   - [Objective-C Support](#objective-c-support)
   - [Disabling Objective-C Shorthand](#disabling-objective-c-shorthand)
 - [Built-in Matcher Functions](#built-in-matcher-functions)
@@ -297,7 +298,30 @@ expect(1 as CInt).to(equal(1))
 expect(@(1 + 1)).to(equal(@2));
 ```
 
-## Asynchronous Expectations
+## Async/Await Support
+
+Nimble makes it easy to await for an async function to complete. Simply pass
+the async function in to `expect`:
+
+```swift
+// Swift
+await expect(await aFunctionReturning1()).to(equal(1))
+```
+
+The async function is awaited on first, before passing it to the matcher. This
+enables the matcher to run synchronous code like before, without caring about
+whether the value it's processing was abtained async or not.
+
+Async support is Swift-only, and it requires that you execute the test in an
+async context. For XCTest, this is as simple as marking your test function with
+`async`. If you use Quick, then you don't need to do anything because as of
+Quick 6, all tests are executed in an async context.
+
+Note: Async/Await support is different than the `toEventually`/`toEventuallyNot`
+feature described below. In fact, async/await is not supported in expectations
+that make use of `toEventually` or `toEventuallyNot`.
+
+## Polling Expectations
 
 In Nimble, it's easy to make expectations on values that are updated
 asynchronously. Just use `toEventually` or `toEventuallyNot`:

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -28,7 +28,7 @@ public class NMBExpectation: NSObject {
         self._line = line
     }
 
-    private var expectValue: Expectation<NSObject> {
+    private var expectValue: SyncExpectation<NSObject> {
         return expect(file: _file, line: _line, self._actualBlock() as NSObject?)
     }
 

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -1,0 +1,45 @@
+private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) async -> (() throws -> T) {
+    let result: Result<T, Error>
+    do {
+        result = .success(try await asyncExpression())
+    } catch {
+        result = .failure(error)
+    }
+    return { try result.get() }
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () async throws -> T?) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: Expression(
+            expression: await convertAsyncExpression(expression),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T)) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: Expression(
+            expression: await convertAsyncExpression(expression()),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: Expression(
+            expression: await convertAsyncExpression(expression()),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+public func expect(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
+    return AsyncExpectation(
+        expression: Expression(
+            expression: await convertAsyncExpression(expression()),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,33 +1,33 @@
-/// Make an expectation on a given actual value. The value given is lazily evaluated.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () throws -> T?) -> Expectation<T> {
-    return Expectation(
+/// Make an ``Expectation`` on a given actual value. The value given is lazily evaluated.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () throws -> T?) -> SyncExpectation<T> {
+    return SyncExpectation(
         expression: Expression(
             expression: expression,
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
 
-/// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T)) -> Expectation<T> {
-    return Expectation(
+/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T)) -> SyncExpectation<T> {
+    return SyncExpectation(
         expression: Expression(
             expression: expression(),
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
 
-/// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T?)) -> Expectation<T> {
-    return Expectation(
+/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T?)) -> SyncExpectation<T> {
+    return SyncExpectation(
         expression: Expression(
             expression: expression(),
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
 
-/// Make an expectation on a given actual value. The closure is lazily invoked.
-public func expect(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> Void)) -> Expectation<Void> {
-    return Expectation(
+/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+public func expect(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> Void)) -> SyncExpectation<Void> {
+    return SyncExpectation(
         expression: Expression(
             expression: expression(),
             location: SourceLocation(file: file, line: line),

--- a/Sources/Nimble/Expression.swift
+++ b/Sources/Nimble/Expression.swift
@@ -1,6 +1,6 @@
 // Memoizes the given closure, only calling the passed
 // closure once; even if repeat calls to the returned closure
-internal func memoizedClosure<T>(_ closure: @escaping () throws -> T) -> (Bool) throws -> T {
+private func memoizedClosure<T>(_ closure: @escaping () throws -> T) -> (Bool) throws -> T {
     var cache: T?
     return { withoutCaching in
         if withoutCaching || cache == nil {
@@ -15,14 +15,14 @@ internal func memoizedClosure<T>(_ closure: @escaping () throws -> T) -> (Bool) 
 /// evaluate() multiple times without causing a re-evaluation of the underlying
 /// closure.
 ///
-/// @warning Since the closure can be any code, Objective-C code may choose
-///          to raise an exception. Currently, Expression does not memoize
+/// - Warning: Since the closure can be any code, Objective-C code may choose
+///          to raise an exception. Currently, SyncExpression does not memoize
 ///          exception raising.
 ///
 /// This provides a common consumable API for matchers to utilize to allow
 /// Nimble to change internals to how the captured closure is managed.
-public struct Expression<T> {
-    internal let _expression: (Bool) throws -> T?
+public struct Expression<Value> {
+    internal let _expression: (Bool) throws -> Value?
     internal let _withoutCaching: Bool
     public let location: SourceLocation
     public let isClosure: Bool
@@ -30,15 +30,15 @@ public struct Expression<T> {
     /// Creates a new expression struct. Normally, expect(...) will manage this
     /// creation process. The expression is memoized.
     ///
-    /// @param expression The closure that produces a given value.
-    /// @param location The source location that this closure originates from.
-    /// @param isClosure A bool indicating if the captured expression is a
+    /// - Parameter expression: The closure that produces a given value.
+    /// - Parameter location: The source location that this closure originates from.
+    /// - Parameter isClosure: A bool indicating if the captured expression is a
     ///                  closure or internally produced closure. Some matchers
     ///                  may require closures. For example, toEventually()
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(expression: @escaping () throws -> T?, location: SourceLocation, isClosure: Bool = true) {
+    public init(expression: @escaping () throws -> Value?, location: SourceLocation, isClosure: Bool = true) {
         self._expression = memoizedClosure(expression)
         self.location = location
         self._withoutCaching = false
@@ -48,18 +48,18 @@ public struct Expression<T> {
     /// Creates a new expression struct. Normally, expect(...) will manage this
     /// creation process.
     ///
-    /// @param expression The closure that produces a given value.
-    /// @param location The source location that this closure originates from.
-    /// @param withoutCaching Indicates if the struct should memoize the given
+    /// - Parameter expression: The closure that produces a given value.
+    /// - Parameter location: The source location that this closure originates from.
+    /// - Parameter withoutCaching: Indicates if the struct should memoize the given
     ///                       closure's result. Subsequent evaluate() calls will
     ///                       not call the given closure if this is true.
-    /// @param isClosure A bool indicating if the captured expression is a
+    /// - Parameter isClosure: A bool indicating if the captured expression is a
     ///                  closure or internally produced closure. Some matchers
     ///                  may require closures. For example, toEventually()
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(memoizedExpression: @escaping (Bool) throws -> T?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
+    public init(memoizedExpression: @escaping (Bool) throws -> Value?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
         self._expression = memoizedExpression
         self.location = location
         self._withoutCaching = withoutCaching
@@ -72,9 +72,9 @@ public struct Expression<T> {
     ///
     /// The returned expression will preserve location and isClosure.
     ///
-    /// @param block The block that can cast the current Expression value to a
+    /// - Parameter block: The block that can cast the current Expression value to a
     ///              new type.
-    public func cast<U>(_ block: @escaping (T?) throws -> U?) -> Expression<U> {
+    public func cast<U>(_ block: @escaping (Value?) throws -> U?) -> Expression<U> {
         return Expression<U>(
             expression: ({ try block(self.evaluate()) }),
             location: self.location,
@@ -82,11 +82,11 @@ public struct Expression<T> {
         )
     }
 
-    public func evaluate() throws -> T? {
+    public func evaluate() throws -> Value? {
         return try self._expression(_withoutCaching)
     }
 
-    public func withoutCaching() -> Expression<T> {
+    public func withoutCaching() -> Expression<Value> {
         return Expression(
             memoizedExpression: self._expression,
             location: location,

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -123,43 +123,37 @@ public func beCloseTo<Value: FloatingPoint, Values: Collection>(
 
 infix operator ≈ : ComparisonPrecedence
 
-extension Expectation where T: Collection, T.Element: FloatingPoint {
-    // swiftlint:disable:next identifier_name
-    public static func ≈(lhs: Expectation, rhs: T) {
-        lhs.to(beCloseTo(rhs))
-    }
+// swiftlint:disable:next identifier_name
+public func ≈<Exp: Expectation, Value>(lhs: Exp, rhs: Value) where Value: Collection, Value.Element: FloatingPoint, Exp.Value == Value {
+    lhs.to(beCloseTo(rhs))
 }
 
-extension Expectation where T: FloatingPoint {
-    // swiftlint:disable:next identifier_name
-    public static func ≈(lhs: Expectation, rhs: T) {
-        lhs.to(beCloseTo(rhs))
-    }
-
-    // swiftlint:disable:next identifier_name
-    public static func ≈(lhs: Expectation, rhs: (expected: T, delta: T)) {
-        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
-    }
-
-    public static func == (lhs: Expectation, rhs: (expected: T, delta: T)) {
-        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
-    }
+// swiftlint:disable:next identifier_name
+public func ≈<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: Value) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs))
 }
 
-extension Expectation where T: NMBDoubleConvertible {
-    // swiftlint:disable:next identifier_name
-    public static func ≈(lhs: Expectation, rhs: T) {
-        lhs.to(beCloseTo(rhs))
-    }
+// swiftlint:disable:next identifier_name
+public func ≈<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: (expected: Value, delta: Value)) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
 
-    // swiftlint:disable:next identifier_name
-    public static func ≈(lhs: Expectation, rhs: (expected: T, delta: Double)) {
-        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
-    }
+public func ==<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: (expected: Value, delta: Value)) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
 
-    public static func == (lhs: Expectation, rhs: (expected: T, delta: Double)) {
-        lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
-    }
+// swiftlint:disable:next identifier_name
+public func ≈<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: Value) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs))
+}
+
+// swiftlint:disable:next identifier_name
+public func ≈<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: (expected: Value, delta: Double)) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
+
+public func ==<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: (expected: Value, delta: Double)) where Exp.Value == Value {
+    lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
 // make this higher precedence than exponents so the Doubles either end aren't pulled in

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -8,7 +8,7 @@ public func beGreaterThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) {
+public func ><Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
     lhs.to(beGreaterThan(rhs))
 }
 
@@ -16,7 +16,7 @@ public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) {
 import enum Foundation.ComparisonResult
 
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
-public func beGreaterThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
+public func beGreaterThan<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
     let errorMessage = "be greater than <\(stringify(expectedValue))>"
     return Predicate.simple(errorMessage) { actualExpression in
         let actualValue = try actualExpression.evaluate()
@@ -26,7 +26,7 @@ public func beGreaterThan(_ expectedValue: NMBComparable?) -> Predicate<NMBCompa
     }
 }
 
-public func > (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
+public func ><Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T?) where Exp.Value == T {
     lhs.to(beGreaterThan(rhs))
 }
 

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -9,7 +9,7 @@ public func beGreaterThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predic
     }
 }
 
-public func >=<T: Comparable>(lhs: Expectation<T>, rhs: T) {
+public func >=<Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
@@ -27,7 +27,7 @@ public func beGreaterThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Pre
     }
 }
 
-public func >=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
+public func >=<Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T) where Exp.Value == T {
     lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -15,14 +15,12 @@ public func beIdenticalTo(_ expected: AnyObject?) -> Predicate<AnyObject> {
     }
 }
 
-extension Expectation where T == AnyObject {
-    public static func === (lhs: Expectation, rhs: AnyObject?) {
-        lhs.to(beIdenticalTo(rhs))
-    }
+public func ===<Exp: Expectation>(lhs: Exp, rhs: AnyObject?) where Exp.Value == AnyObject {
+    lhs.to(beIdenticalTo(rhs))
+}
 
-    public static func !== (lhs: Expectation, rhs: AnyObject?) {
-        lhs.toNot(beIdenticalTo(rhs))
-    }
+public func !==<Exp: Expectation>(lhs: Exp, rhs: AnyObject?) where Exp.Value == AnyObject {
+    lhs.toNot(beIdenticalTo(rhs))
 }
 
 /// A Nimble matcher that succeeds when the actual value is the same instance

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -8,7 +8,7 @@ public func beLessThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-public func <<T: Comparable>(lhs: Expectation<T>, rhs: T) {
+public func <<Exp: Expectation, V: Comparable>(lhs: Exp, rhs: V) where Exp.Value == V {
     lhs.to(beLessThan(rhs))
 }
 
@@ -16,7 +16,7 @@ public func <<T: Comparable>(lhs: Expectation<T>, rhs: T) {
 import enum Foundation.ComparisonResult
 
 /// A Nimble matcher that succeeds when the actual value is less than the expected value.
-public func beLessThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparable> {
+public func beLessThan<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
     let message = "be less than <\(stringify(expectedValue))>"
     return Predicate.simple(message) { actualExpression in
         let actualValue = try actualExpression.evaluate()
@@ -25,7 +25,7 @@ public func beLessThan(_ expectedValue: NMBComparable?) -> Predicate<NMBComparab
     }
 }
 
-public func < (lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
+public func <<Exp: Expectation, V: NMBComparable>(lhs: Exp, rhs: V?) where Exp.Value == V {
     lhs.to(beLessThan(rhs))
 }
 

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -8,7 +8,7 @@ public func beLessThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predicate
     }
 }
 
-public func <=<T: Comparable>(lhs: Expectation<T>, rhs: T) {
+public func <=<Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 
@@ -25,7 +25,7 @@ public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predic
     }
 }
 
-public func <=<T: NMBComparable>(lhs: Expectation<T>, rhs: T) {
+public func <=<Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T) where Exp.Value == T {
     lhs.to(beLessThanOrEqualTo(rhs))
 }
 

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -18,17 +18,27 @@ public func beNil<T>() -> Predicate<T> {
     }
 }
 
-extension Expectation {
-    /// Represents `nil` value to be used with the operator overloads for `beNil`.
-    public struct Nil: ExpressibleByNilLiteral {
-        public init(nilLiteral: ()) {}
-    }
+/// Represents `nil` value to be used with the operator overloads for `beNil`.
+public struct ExpectationNil: ExpressibleByNilLiteral {
+    public init(nilLiteral: ()) {}
+}
 
-    public static func == (lhs: Expectation, rhs: Expectation.Nil) {
+extension SyncExpectation {
+    public static func == (lhs: SyncExpectation, rhs: ExpectationNil) {
         lhs.to(beNil())
     }
 
-    public static func != (lhs: Expectation, rhs: Expectation.Nil) {
+    public static func != (lhs: SyncExpectation, rhs: ExpectationNil) {
+        lhs.toNot(beNil())
+    }
+}
+
+extension AsyncExpectation {
+    public static func == (lhs: AsyncExpectation, rhs: ExpectationNil) {
+        lhs.to(beNil())
+    }
+
+    public static func != (lhs: AsyncExpectation, rhs: ExpectationNil) {
         lhs.toNot(beNil())
     }
 }

--- a/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Sources/Nimble/Matchers/BeVoid.swift
@@ -6,12 +6,10 @@ public func beVoid() -> Predicate<()> {
     }
 }
 
-extension Expectation where T == () {
-    public static func == (lhs: Expectation<()>, rhs: ()) {
-        lhs.to(beVoid())
-    }
+public func ==<Exp: Expectation>(lhs: Exp, rhs: ()) where Exp.Value == () {
+    lhs.to(beVoid())
+}
 
-    public static func != (lhs: Expectation<()>, rhs: ()) {
-        lhs.toNot(beVoid())
-    }
+public func !=<Exp: Expectation>(lhs: Exp, rhs: ()) where Exp.Value == () {
+    lhs.toNot(beVoid())
 }

--- a/Sources/Nimble/Matchers/Equal+Tuple.swift
+++ b/Sources/Nimble/Matchers/Equal+Tuple.swift
@@ -10,17 +10,17 @@ public func equal<T1: Equatable, T2: Equatable>(
     equal(expectedValue, by: ==)
 }
 
-public func ==<T1: Equatable, T2: Equatable>(
-    lhs: Expectation<(T1, T2)>,
+public func ==<Exp: Expectation, T1: Equatable, T2: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2)?
-) {
+) where Exp.Value == (T1, T2) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T1: Equatable, T2: Equatable>(
-    lhs: Expectation<(T1, T2)>,
+public func !=<Exp: Expectation, T1: Equatable, T2: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2)?
-) {
+) where Exp.Value == (T1, T2) {
     lhs.toNot(equal(rhs))
 }
 
@@ -35,17 +35,17 @@ public func equal<T1: Equatable, T2: Equatable, T3: Equatable>(
     equal(expectedValue, by: ==)
 }
 
-public func ==<T1: Equatable, T2: Equatable, T3: Equatable>(
-    lhs: Expectation<(T1, T2, T3)>,
+public func ==<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3)?
-) {
+) where Exp.Value == (T1, T2, T3) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T1: Equatable, T2: Equatable, T3: Equatable>(
-    lhs: Expectation<(T1, T2, T3)>,
+public func !=<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3)?
-) {
+) where Exp.Value == (T1, T2, T3) {
     lhs.toNot(equal(rhs))
 }
 
@@ -60,17 +60,17 @@ public func equal<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
     equal(expectedValue, by: ==)
 }
 
-public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4)>,
+public func ==<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4)?
-) {
+) where Exp.Value == (T1, T2, T3, T4) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4)>,
+public func !=<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4)?
-) {
+) where Exp.Value == (T1, T2, T3, T4) {
     lhs.toNot(equal(rhs))
 }
 
@@ -85,17 +85,17 @@ public func equal<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5
     equal(expectedValue, by: ==)
 }
 
-public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4, T5)>,
+public func ==<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4, T5)?
-) {
+) where Exp.Value == (T1, T2, T3, T4, T5) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4, T5)>,
+public func !=<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4, T5)?
-) {
+) where Exp.Value == (T1, T2, T3, T4, T5) {
     lhs.toNot(equal(rhs))
 }
 
@@ -110,17 +110,17 @@ public func equal<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5
     equal(expectedValue, by: ==)
 }
 
-public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4, T5, T6)>,
+public func ==<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4, T5, T6)?
-) {
+) where Exp.Value == (T1, T2, T3, T4, T5, T6) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
-    lhs: Expectation<(T1, T2, T3, T4, T5, T6)>,
+public func !=<Exp: Expectation, T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
+    lhs: Exp,
     rhs: (T1, T2, T3, T4, T5, T6)?
-) {
+) where Exp.Value == (T1, T2, T3, T4, T5, T6) {
     lhs.toNot(equal(rhs))
 }
 

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -131,67 +131,131 @@ public func equal<K: Hashable, V: Equatable>(_ expectedValue: [K: V?]) -> Predic
     }
 }
 
-public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+public func ==<T: Equatable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
+public func ==<T: Equatable>(lhs: SyncExpectation<T>, rhs: T?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T) {
+public func !=<T: Equatable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.toNot(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: Expectation<T>, rhs: T?) {
+public func !=<T: Equatable>(lhs: SyncExpectation<T>, rhs: T?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
+public func ==<T: Equatable>(lhs: SyncExpectation<[T]>, rhs: [T]?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: Expectation<[T]>, rhs: [T]?) {
+public func !=<T: Equatable>(lhs: SyncExpectation<[T]>, rhs: [T]?) {
     lhs.toNot(equal(rhs))
 }
 
-public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+public func == <T>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>) {
     lhs.to(equal(rhs))
 }
 
-public func == <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func == <T>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
 }
 
-public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+public func != <T>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>) {
     lhs.toNot(equal(rhs))
 }
 
-public func != <T>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func != <T>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+public func ==<T: Comparable>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>) {
     lhs.to(equal(rhs))
 }
 
-public func ==<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func ==<T: Comparable>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>) {
+public func !=<T: Comparable>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>) {
     lhs.toNot(equal(rhs))
 }
 
-public func !=<T: Comparable>(lhs: Expectation<Set<T>>, rhs: Set<T>?) {
+public func !=<T: Comparable>(lhs: SyncExpectation<Set<T>>, rhs: Set<T>?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func ==<T, C: Equatable>(lhs: SyncExpectation<[T: C]>, rhs: [T: C]?) {
     lhs.to(equal(rhs))
 }
 
-public func !=<T, C: Equatable>(lhs: Expectation<[T: C]>, rhs: [T: C]?) {
+public func !=<T, C: Equatable>(lhs: SyncExpectation<[T: C]>, rhs: [T: C]?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) {
+    lhs.to(equal(rhs))
+}
+
+public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) {
+    lhs.toNot(equal(rhs))
+}
+
+public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func ==<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
+public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
+    lhs.to(equal(rhs))
+}
+
+public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
+}
+
+public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
+    lhs.to(equal(rhs))
+}
+
+public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
+    lhs.toNot(equal(rhs))
+}
+
+public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
+    lhs.toNot(equal(rhs))
+}
+
+public func ==<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) {
+    lhs.to(equal(rhs))
+}
+
+public func !=<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
 }
 

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -83,7 +83,7 @@ private let toEventuallyRequiresClosureError = FailureMessage(
         """
 )
 
-extension Expectation {
+extension SyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     ///
@@ -91,7 +91,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func toEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -119,7 +119,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func toEventuallyNot(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -149,7 +149,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func toNotEventually(_ predicate: Predicate<T>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
@@ -160,7 +160,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func toNever(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -190,7 +190,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func neverTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
@@ -201,7 +201,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func toAlways(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -231,7 +231,7 @@ extension Expectation {
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     @discardableResult
-    public func alwaysTo(_ predicate: Predicate<T>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -1,0 +1,17 @@
+#if !os(WASI)
+
+import XCTest
+import Nimble
+
+final class AsyncAwaitTest: XCTestCase {
+    func testToPositiveMatches() async {
+        func someAsyncFunction() async throws -> Int {
+            try await Task.sleep(nanoseconds: 1_000_000) // 1 millisecond
+            return 1
+        }
+
+        await expect { try await someAsyncFunction() }.to(equal(1))
+    }
+}
+
+#endif

--- a/Tests/NimbleTests/DSLTest.swift
+++ b/Tests/NimbleTests/DSLTest.swift
@@ -9,31 +9,65 @@ private func throwingInt() throws -> Int {
     return 1
 }
 
+private func nonThrowingAsyncInt() async -> Int {
+    return 1
+}
+
+private func throwingAsyncInt() async throws -> Int {
+    return 1
+}
+
 final class DSLTest: XCTestCase {
     func testExpectAutoclosureNonThrowing() throws {
-        let _: Expectation<Int> = expect(1)
-        let _: Expectation<Int> = expect(nonThrowingInt())
+        let _: SyncExpectation<Int> = expect(1)
+        let _: SyncExpectation<Int> = expect(nonThrowingInt())
     }
 
     func testExpectAutoclosureThrowing() throws {
-        let _: Expectation<Int> = expect(try throwingInt())
+        let _: SyncExpectation<Int> = expect(try throwingInt())
     }
 
     func testExpectClosure() throws {
-        let _: Expectation<Int> = expect { 1 }
-        let _: Expectation<Int> = expect { nonThrowingInt() }
-        let _: Expectation<Int> = expect { try throwingInt() }
-        let _: Expectation<Int> = expect { () -> Int in 1 }
-        let _: Expectation<Int> = expect { () -> Int? in 1 }
-        let _: Expectation<Int> = expect { () -> Int? in nil }
+        let _: SyncExpectation<Int> = expect { 1 }
+        let _: SyncExpectation<Int> = expect { nonThrowingInt() }
+        let _: SyncExpectation<Int> = expect { try throwingInt() }
+        let _: SyncExpectation<Int> = expect { () -> Int in 1 }
+        let _: SyncExpectation<Int> = expect { () -> Int? in 1 }
+        let _: SyncExpectation<Int> = expect { () -> Int? in nil }
 
-        let _: Expectation<Void> = expect { }
-        let _: Expectation<Void> = expect { () -> Void in }
+        let _: SyncExpectation<Void> = expect { }
+        let _: SyncExpectation<Void> = expect { () -> Void in }
 
-        let _: Expectation<Void> = expect { return }
-        let _: Expectation<Void> = expect { () -> Void in return }
+        let _: SyncExpectation<Void> = expect { return }
+        let _: SyncExpectation<Void> = expect { () -> Void in return }
 
-        let _: Expectation<Void> = expect { return () }
-        let _: Expectation<Void> = expect { () -> Void in return () }
+        let _: SyncExpectation<Void> = expect { return () }
+        let _: SyncExpectation<Void> = expect { () -> Void in return () }
+    }
+
+    func testExpectAsyncAutoclosureNonThrowing() async throws {
+        let _: AsyncExpectation<Int> = await expect(await nonThrowingAsyncInt())
+    }
+
+    func testExpectAsyncAutoclosureThrowing() async throws {
+        let _: AsyncExpectation<Int> = await expect(try await throwingAsyncInt())
+    }
+
+    func testExpectAsyncClosure() async throws {
+        let _: AsyncExpectation<Int> = await expect { 1 }
+        let _: AsyncExpectation<Int> = await expect { await nonThrowingAsyncInt() }
+        let _: AsyncExpectation<Int> = await expect { try await throwingAsyncInt() }
+        let _: AsyncExpectation<Int> = await expect { () -> Int in 1 }
+        let _: AsyncExpectation<Int> = await expect { () -> Int? in 1 }
+        let _: AsyncExpectation<Int> = await expect { () -> Int? in nil }
+
+        let _: AsyncExpectation<Void> = await expect { }
+        let _: AsyncExpectation<Void> = await expect { () -> Void in }
+
+        let _: AsyncExpectation<Void> = await expect { return }
+        let _: AsyncExpectation<Void> = await expect { () -> Void in return }
+
+        let _: AsyncExpectation<Void> = await expect { return () }
+        let _: AsyncExpectation<Void> = await expect { () -> Void in return () }
     }
 }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -76,7 +76,7 @@ func suppressErrors<T>(closure: () -> T) -> T {
     return output!
 }
 
-func producesStatus<T>(_ status: Expectation<T>.Status, file: FileString = #file, line: UInt = #line, closure: () -> Expectation<T>) {
+func producesStatus<Exp: Expectation, T>(_ status: ExpectationStatus, file: FileString = #file, line: UInt = #line, closure: () -> Exp) where Exp.Value == T {
     let expectation = suppressErrors(closure: closure)
     
     expect(file: file, line: line, expectation.status).to(equal(status))


### PR DESCRIPTION
Resolves https://github.com/Quick/Nimble/issues/1003

This changes Expectation into a protocol, and converts the old Expectation struct into SyncExpectation and AsyncExpectation. Expression is still synchronous, and toEventually is dropped for AsyncExpectations. Additionally, renamed the older Async methods to Polling to try to reduce confusion as to what toEventually actually does.

Updated documentation, both to explain what toEventually actually does, and to elaborate that Nimble supports async/await.