### PR TITLE
Get toEventually et al working in async contexts.

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -146,7 +146,6 @@
 		1F5DF18C1BDCA0F500C3A531 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Await.swift */; };
 		1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
 		1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
-		1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
 		1F5DF1931BDCA10200C3A531 /* SynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */; };
 		1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
 		1F5DF1951BDCA10200C3A531 /* utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14FB63194180C5009F2A08 /* utils.swift */; };
@@ -183,8 +182,6 @@
 		1F925EB8195C0D6300ED456B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F925EAD195C0D6300ED456B /* Nimble.framework */; };
 		1F925EC7195C0DD100ED456B /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F925EE2195C0DFD00ED456B /* utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14FB63194180C5009F2A08 /* utils.swift */; };
-		1F925EE6195C121200ED456B /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
-		1F925EE7195C121200ED456B /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
 		1F925EE9195C124400ED456B /* BeAnInstanceOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */; };
 		1F925EEA195C124400ED456B /* BeAnInstanceOfTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */; };
 		1F925EEC195C12C800ED456B /* RaisesExceptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */; };
@@ -337,6 +334,18 @@
 		899441F92902EF2600C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
 		899441FA2902EF2700C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
 		899441FB2902EF2800C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
+		89F5E06D290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
+		89F5E06E290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
+		89F5E06F290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
+		89F5E070290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
+		89F5E073290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E074290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E075290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E076290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E077290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
+		89F5E078290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
+		89F5E079290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
+		89F5E07A290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
 		964CFEFD1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFF1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
@@ -441,7 +450,6 @@
 		D95F8929267EA1CA004B1B4D /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1871BD1CA89EDB00A34BF2 /* DSL.m */; };
 		D95F892A267EA1D9004B1B4D /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
 		D95F892B267EA1D9004B1B4D /* PredicateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBC39B82462EA7D00069677 /* PredicateTest.swift */; };
-		D95F892C267EA1D9004B1B4D /* AsynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EE5195C121200ED456B /* AsynchronousTest.swift */; };
 		D95F892D267EA1D9004B1B4D /* LinuxSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAEDD091CAEA86F003F1584 /* LinuxSupport.swift */; };
 		D95F892E267EA1D9004B1B4D /* DSLTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC157902511957100EAA480 /* DSLTest.swift */; };
 		D95F892F267EA1D9004B1B4D /* SynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */; };
@@ -682,7 +690,6 @@
 		1F91DD301C74BF61002C309F /* BeVoid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeVoid.swift; sourceTree = "<group>"; };
 		1F925EAD195C0D6300ED456B /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F925EB7195C0D6300ED456B /* NimbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		1F925EE5195C121200ED456B /* AsynchronousTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsynchronousTest.swift; sourceTree = "<group>"; };
 		1F925EE8195C124400ED456B /* BeAnInstanceOfTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeAnInstanceOfTest.swift; sourceTree = "<group>"; };
 		1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaisesExceptionTest.swift; sourceTree = "<group>"; };
 		1F925EEE195C136500ED456B /* BeLogicalTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeLogicalTest.swift; sourceTree = "<group>"; };
@@ -753,6 +760,7 @@
 		899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTest.swift; sourceTree = "<group>"; };
 		899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSL+AsyncAwait.swift"; sourceTree = "<group>"; };
 		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
+		89F5E06C290765BB001F9377 /* PollingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PollingTest.swift; sourceTree = "<group>"; };
 		964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAssertion.swift; sourceTree = "<group>"; };
 		965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCUserDescriptionTest.m; sourceTree = "<group>"; };
 		965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDescriptionTest.swift; sourceTree = "<group>"; };
@@ -942,9 +950,11 @@
 			isa = PBXGroup;
 			children = (
 				CDC157902511957100EAA480 /* DSLTest.swift */,
+				89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */,
+				89F5E06C290765BB001F9377 /* PollingTest.swift */,
 				CDBC39B82462EA7D00069677 /* PredicateTest.swift */,
+				89F5E072290765C5001F9377 /* StatusTest.swift */,
 				1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */,
-				1F925EE5195C121200ED456B /* AsynchronousTest.swift */,
 				899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */,
 				965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */,
 				6CAEDD091CAEA86F003F1584 /* LinuxSupport.swift */,
@@ -1645,6 +1655,7 @@
 				CDBC39BA2462EA7D00069677 /* PredicateTest.swift in Sources */,
 				1F4A56661A3B305F009E1637 /* ObjCAsyncTest.m in Sources */,
 				1F925EFC195C186800ED456B /* BeginWithTest.swift in Sources */,
+				89F5E06E290765BB001F9377 /* PollingTest.swift in Sources */,
 				1F14FB64194180C5009F2A08 /* utils.swift in Sources */,
 				DDB4D5F019FE442800E9D9FE /* MatchTest.swift in Sources */,
 				1F4A56731A3B3210009E1637 /* ObjCBeginWithTest.m in Sources */,
@@ -1688,7 +1699,6 @@
 				DDEFAEB41A93CBE6005CA37A /* ObjCAllPassTest.m in Sources */,
 				1F4A567F1A3B333F009E1637 /* ObjCBeLessThanTest.m in Sources */,
 				857D18502536124400D8693A /* BeWithinTest.swift in Sources */,
-				1F925EE6195C121200ED456B /* AsynchronousTest.swift in Sources */,
 				1F0648CC19639F5A001F9C46 /* ObjectWithLazyProperty.swift in Sources */,
 				1F4A56851A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
 				DD9A9A8F19CF439B00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
@@ -1794,6 +1804,7 @@
 				1F5DF1981BDCA10200C3A531 /* BeAKindOfTest.swift in Sources */,
 				1F5DF19B1BDCA10200C3A531 /* BeEmptyTest.swift in Sources */,
 				7B5358BC1C3846C900A23FAA /* SatisfyAnyOfTest.swift in Sources */,
+				89F5E06F290765BB001F9377 /* PollingTest.swift in Sources */,
 				1F5DF1A11BDCA10200C3A531 /* BeLessThanOrEqualToTest.swift in Sources */,
 				1F5DF1961BDCA10200C3A531 /* ObjectWithLazyProperty.swift in Sources */,
 				1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */,
@@ -1806,10 +1817,6 @@
 				CD79C9B31D2CC848004B6F9A /* ObjCMatchTest.m in Sources */,
 				1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */,
 				1F5DF1A21BDCA10200C3A531 /* BeLessThanTest.swift in Sources */,
-				CD79C9AB1D2CC848004B6F9A /* ObjCBeLessThanTest.m in Sources */,
-				CD79C9A81D2CC848004B6F9A /* ObjCBeIdenticalToTest.m in Sources */,
-				CD79C9AE1D2CC848004B6F9A /* ObjCBeTruthyTest.m in Sources */,
-				1F5DF1921BDCA10200C3A531 /* AsynchronousTest.swift in Sources */,
 				CDC157932511957100EAA480 /* DSLTest.swift in Sources */,
 				1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */,
 				A8A3B708207368F100E25A08 /* ObjCSatisfyAllOfTest.m in Sources */,
@@ -1942,6 +1949,7 @@
 				CDBC39B92462EA7D00069677 /* PredicateTest.swift in Sources */,
 				1F4A56671A3B305F009E1637 /* ObjCAsyncTest.m in Sources */,
 				1F925EFD195C186800ED456B /* BeginWithTest.swift in Sources */,
+				89F5E06D290765BB001F9377 /* PollingTest.swift in Sources */,
 				1F925EE2195C0DFD00ED456B /* utils.swift in Sources */,
 				DDB4D5F119FE442800E9D9FE /* MatchTest.swift in Sources */,
 				1F4A56741A3B3210009E1637 /* ObjCBeginWithTest.m in Sources */,
@@ -1970,10 +1978,6 @@
 				1F4A567D1A3B3311009E1637 /* ObjCBeIdenticalToTest.m in Sources */,
 				965B0D0D1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */,
 				1FCF91501C61C85A00B15DCB /* PostNotificationTest.swift in Sources */,
-				965B0D0A1B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */,
-				1F4A56921A3B344A009E1637 /* ObjCBeNilTest.m in Sources */,
-				1F8A37B11B7C5042001C8357 /* ObjCSyncTest.m in Sources */,
-				1F4A56951A3B346F009E1637 /* ObjCContainTest.m in Sources */,
 				1F299EAC19627B2D002641AF /* BeEmptyTest.swift in Sources */,
 				7B13BA101DD361EA00C9098C /* ObjCContainElementSatisfyingTest.m in Sources */,
 				1F925EF7195C147800ED456B /* BeCloseToTest.swift in Sources */,
@@ -1984,7 +1988,6 @@
 				DDEFAEB51A93CBE6005CA37A /* ObjCAllPassTest.m in Sources */,
 				1F4A56801A3B333F009E1637 /* ObjCBeLessThanTest.m in Sources */,
 				857D184F2536124400D8693A /* BeWithinTest.swift in Sources */,
-				1F925EE7195C121200ED456B /* AsynchronousTest.swift in Sources */,
 				1F0648CD19639F5A001F9C46 /* ObjectWithLazyProperty.swift in Sources */,
 				106112C52251E13B000A5848 /* BeResultTest.swift in Sources */,
 				1F4A56861A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
@@ -2086,6 +2089,7 @@
 				D95F8939267EA1E8004B1B4D /* BeIdenticalToObjectTest.swift in Sources */,
 				899441F22902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
 				D95F8937267EA1E8004B1B4D /* BeginWithTest.swift in Sources */,
+				89F5E070290765BB001F9377 /* PollingTest.swift in Sources */,
 				D95F8948267EA1E8004B1B4D /* MatchErrorTest.swift in Sources */,
 				D95F893C267EA1E8004B1B4D /* ContainTest.swift in Sources */,
 				D95F8933267EA1E8004B1B4D /* BeWithinTest.swift in Sources */,
@@ -2104,7 +2108,6 @@
 				D95F8944267EA1E8004B1B4D /* SatisfyAllOfTest.swift in Sources */,
 				D95F893D267EA1E8004B1B4D /* HaveCountTest.swift in Sources */,
 				D95F893E267EA1E8004B1B4D /* RaisesExceptionTest.swift in Sources */,
-				D95F892C267EA1D9004B1B4D /* AsynchronousTest.swift in Sources */,
 				D95F892D267EA1D9004B1B4D /* LinuxSupport.swift in Sources */,
 				D95F892F267EA1D9004B1B4D /* SynchronousTest.swift in Sources */,
 				D95F8953267EA1EE004B1B4D /* AlwaysFailMatcher.swift in Sources */,

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -99,9 +99,7 @@
 		1F4A568E1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A568D1A3B342B009E1637 /* ObjCBeFalseTest.m */; };
 		1F4A568F1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A568D1A3B342B009E1637 /* ObjCBeFalseTest.m */; };
 		1F4A56911A3B344A009E1637 /* ObjCBeNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56901A3B344A009E1637 /* ObjCBeNilTest.m */; };
-		1F4A56921A3B344A009E1637 /* ObjCBeNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56901A3B344A009E1637 /* ObjCBeNilTest.m */; };
 		1F4A56941A3B346F009E1637 /* ObjCContainTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56931A3B346F009E1637 /* ObjCContainTest.m */; };
-		1F4A56951A3B346F009E1637 /* ObjCContainTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56931A3B346F009E1637 /* ObjCContainTest.m */; };
 		1F4A56971A3B34AA009E1637 /* ObjCEndWithTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56961A3B34AA009E1637 /* ObjCEndWithTest.m */; };
 		1F4A56981A3B34AA009E1637 /* ObjCEndWithTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56961A3B34AA009E1637 /* ObjCEndWithTest.m */; };
 		1F4A569A1A3B3539009E1637 /* ObjCEqualTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56991A3B3539009E1637 /* ObjCEqualTest.m */; };
@@ -143,7 +141,7 @@
 		1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB4D5EC19FE43C200E9D9FE /* Match.swift */; };
 		1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59651B551EE6002D767E /* ThrowError.swift */; };
-		1F5DF18C1BDCA0F500C3A531 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Await.swift */; };
+		1F5DF18C1BDCA0F500C3A531 /* PollAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* PollAwait.swift */; };
 		1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
 		1F5DF18E1BDCA0F500C3A531 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
 		1F5DF1931BDCA10200C3A531 /* SynchronousTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */; };
@@ -172,7 +170,6 @@
 		1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F925EEB195C12C800ED456B /* RaisesExceptionTest.swift */; };
 		1F5DF1AB1BDCA10200C3A531 /* ThrowErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EA59621B551ED2002D767E /* ThrowErrorTest.swift */; };
 		1F8A37B01B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
-		1F8A37B11B7C5042001C8357 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
 		1F91DD2D1C74BF36002C309F /* BeVoidTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F91DD2C1C74BF36002C309F /* BeVoidTest.swift */; };
 		1F91DD2E1C74BF36002C309F /* BeVoidTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F91DD2C1C74BF36002C309F /* BeVoidTest.swift */; };
 		1F91DD2F1C74BF36002C309F /* BeVoidTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F91DD2C1C74BF36002C309F /* BeVoidTest.swift */; };
@@ -270,8 +267,8 @@
 		1FD8CD5B1968AB07008ED995 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1C1968AB07008ED995 /* Equal.swift */; };
 		1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
 		1FD8CD5F1968AB07008ED995 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD1E1968AB07008ED995 /* RaisesException.swift */; };
-		1FD8CD6A1968AB07008ED995 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Await.swift */; };
-		1FD8CD6B1968AB07008ED995 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Await.swift */; };
+		1FD8CD6A1968AB07008ED995 /* PollAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* PollAwait.swift */; };
+		1FD8CD6B1968AB07008ED995 /* PollAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* PollAwait.swift */; };
 		1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
 		1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */; };
 		1FE661571E6574E30035F243 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE661561E6574E20035F243 /* ExpectationMessage.swift */; };
@@ -338,19 +335,37 @@
 		89F5E06E290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
 		89F5E06F290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
 		89F5E070290765BB001F9377 /* PollingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E06C290765BB001F9377 /* PollingTest.swift */; };
-		89F5E073290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
-		89F5E074290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
-		89F5E075290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
-		89F5E076290765C5001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */; };
-		89F5E077290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
-		89F5E078290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
-		89F5E079290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
-		89F5E07A290765C5001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E072290765C5001F9377 /* StatusTest.swift */; };
+		89F5E0862908E655001F9377 /* Polling+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */; };
+		89F5E0872908E655001F9377 /* Polling+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */; };
+		89F5E0882908E655001F9377 /* Polling+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */; };
+		89F5E0892908E655001F9377 /* Polling+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */; };
+		89F5E08C290B8D22001F9377 /* AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E08B290B8D22001F9377 /* AsyncAwait.swift */; };
+		89F5E08D290B8D22001F9377 /* AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E08B290B8D22001F9377 /* AsyncAwait.swift */; };
+		89F5E08E290B8D22001F9377 /* AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E08B290B8D22001F9377 /* AsyncAwait.swift */; };
+		89F5E08F290B8D22001F9377 /* AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E08B290B8D22001F9377 /* AsyncAwait.swift */; };
+		89F5E091290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */; };
+		89F5E092290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */; };
+		89F5E093290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */; };
+		89F5E094290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */; };
+		89F5E097290C37B8001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E095290C37B8001F9377 /* StatusTest.swift */; };
+		89F5E098290C37B8001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E095290C37B8001F9377 /* StatusTest.swift */; };
+		89F5E099290C37B8001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E095290C37B8001F9377 /* StatusTest.swift */; };
+		89F5E09A290C37B8001F9377 /* StatusTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E095290C37B8001F9377 /* StatusTest.swift */; };
+		89F5E09B290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E09C290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E09D290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E09E290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */; };
+		89F5E09F290C37DD001F9377 /* ObjCSyncTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A37AF1B7C5042001C8357 /* ObjCSyncTest.m */; };
+		89F5E0A0290C37F0001F9377 /* ObjCBeIdenticalToTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A567B1A3B3311009E1637 /* ObjCBeIdenticalToTest.m */; };
+		89F5E0A1290C37F7001F9377 /* ObjCBeLessThanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A567E1A3B333F009E1637 /* ObjCBeLessThanTest.m */; };
+		89F5E0A2290C37FB001F9377 /* ObjCBeNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56901A3B344A009E1637 /* ObjCBeNilTest.m */; };
+		89F5E0A3290C37FF001F9377 /* ObjCBeTruthyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56841A3B33A0009E1637 /* ObjCBeTruthyTest.m */; };
+		89F5E0A4290C3803001F9377 /* ObjCContainTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56931A3B346F009E1637 /* ObjCContainTest.m */; };
+		89F5E0A5290C380B001F9377 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		964CFEFD1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFF1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		965B0D091B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
-		965B0D0A1B62B8ED0005AE66 /* ObjCUserDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */; };
 		965B0D0C1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
 		965B0D0D1B62C06D0005AE66 /* UserDescriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */; };
 		A8A3B6EB2071487E00E25A08 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F6B5BC2070186D00FCB5ED /* SatisfyAllOf.swift */; };
@@ -393,13 +408,10 @@
 		CD79C9A51D2CC848004B6F9A /* ObjCBeginWithTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56721A3B3210009E1637 /* ObjCBeginWithTest.m */; };
 		CD79C9A61D2CC848004B6F9A /* ObjCBeGreaterThanOrEqualToTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56781A3B32E3009E1637 /* ObjCBeGreaterThanOrEqualToTest.m */; };
 		CD79C9A71D2CC848004B6F9A /* ObjCBeGreaterThanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56751A3B3253009E1637 /* ObjCBeGreaterThanTest.m */; };
-		CD79C9A81D2CC848004B6F9A /* ObjCBeIdenticalToTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A567B1A3B3311009E1637 /* ObjCBeIdenticalToTest.m */; };
 		CD79C9A91D2CC848004B6F9A /* ObjCBeKindOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A566C1A3B3159009E1637 /* ObjCBeKindOfTest.m */; };
 		CD79C9AA1D2CC848004B6F9A /* ObjCBeLessThanOrEqualToTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56811A3B336F009E1637 /* ObjCBeLessThanOrEqualToTest.m */; };
-		CD79C9AB1D2CC848004B6F9A /* ObjCBeLessThanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A567E1A3B333F009E1637 /* ObjCBeLessThanTest.m */; };
 		CD79C9AC1D2CC848004B6F9A /* ObjCBeNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56901A3B344A009E1637 /* ObjCBeNilTest.m */; };
 		CD79C9AD1D2CC848004B6F9A /* ObjCBeTrueTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A568A1A3B3407009E1637 /* ObjCBeTrueTest.m */; };
-		CD79C9AE1D2CC848004B6F9A /* ObjCBeTruthyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56841A3B33A0009E1637 /* ObjCBeTruthyTest.m */; };
 		CD79C9AF1D2CC848004B6F9A /* ObjCContainTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56931A3B346F009E1637 /* ObjCContainTest.m */; };
 		CD79C9B01D2CC848004B6F9A /* ObjCEndWithTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56961A3B34AA009E1637 /* ObjCEndWithTest.m */; };
 		CD79C9B11D2CC848004B6F9A /* ObjCEqualTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A56991A3B3539009E1637 /* ObjCEqualTest.m */; };
@@ -540,7 +552,7 @@
 		D95F8984267EA20E004B1B4D /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
 		D95F8985267EA20E004B1B4D /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* DispatchTimeInterval.swift */; };
 		D95F8986267EA20E004B1B4D /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
-		D95F8987267EA20E004B1B4D /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* Await.swift */; };
+		D95F8987267EA20E004B1B4D /* PollAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* PollAwait.swift */; };
 		D95F8988267EA20E004B1B4D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4BA9AC1C88DDB500B73906 /* Errors.swift */; };
 		D95F8989267EA216004B1B4D /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F1A742E1940169200FFFC47 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D95F898A267EA2FC004B1B4D /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CDFB6A341F7E082400AD8CC7 /* CwlMachBadInstructionHandler.m */; };
@@ -733,7 +745,7 @@
 		1FD8CD1C1968AB07008ED995 /* Equal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Equal.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1FD8CD1D1968AB07008ED995 /* MatcherProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatcherProtocols.swift; sourceTree = "<group>"; };
 		1FD8CD1E1968AB07008ED995 /* RaisesException.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RaisesException.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		1FD8CD261968AB07008ED995 /* Await.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Await.swift; sourceTree = "<group>"; };
+		1FD8CD261968AB07008ED995 /* PollAwait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PollAwait.swift; sourceTree = "<group>"; };
 		1FD8CD271968AB07008ED995 /* SourceLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceLocation.swift; sourceTree = "<group>"; };
 		1FD8CD281968AB07008ED995 /* Stringers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stringers.swift; sourceTree = "<group>"; };
 		1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionDispatcher.swift; sourceTree = "<group>"; };
@@ -759,8 +771,13 @@
 		898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysFailMatcher.swift; sourceTree = "<group>"; };
 		899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTest.swift; sourceTree = "<group>"; };
 		899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSL+AsyncAwait.swift"; sourceTree = "<group>"; };
-		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
 		89F5E06C290765BB001F9377 /* PollingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PollingTest.swift; sourceTree = "<group>"; };
+		89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Polling+AsyncAwait.swift"; sourceTree = "<group>"; };
+		89F5E08B290B8D22001F9377 /* AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwait.swift; sourceTree = "<group>"; };
+		89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertionRecorder+Async.swift"; sourceTree = "<group>"; };
+		89F5E095290C37B8001F9377 /* StatusTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusTest.swift; sourceTree = "<group>"; };
+		89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnFailureThrowsTest.swift; sourceTree = "<group>"; };
+		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
 		964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAssertion.swift; sourceTree = "<group>"; };
 		965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCUserDescriptionTest.m; sourceTree = "<group>"; };
 		965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDescriptionTest.swift; sourceTree = "<group>"; };
@@ -937,6 +954,7 @@
 				1FE661561E6574E20035F243 /* ExpectationMessage.swift */,
 				1FD8CD0B1968AB07008ED995 /* FailureMessage.swift */,
 				1F1871E31CA89FB600A34BF2 /* Polling.swift */,
+				89F5E0852908E655001F9377 /* Polling+AsyncAwait.swift */,
 				1F1A742D1940169200FFFC47 /* Info.plist */,
 				1FD8CD0C1968AB07008ED995 /* Matchers */,
 				1F1A742E1940169200FFFC47 /* Nimble.h */,
@@ -950,10 +968,10 @@
 			isa = PBXGroup;
 			children = (
 				CDC157902511957100EAA480 /* DSLTest.swift */,
-				89F5E071290765C5001F9377 /* OnFailureThrowsTest.swift */,
+				89F5E096290C37B8001F9377 /* OnFailureThrowsTest.swift */,
 				89F5E06C290765BB001F9377 /* PollingTest.swift */,
 				CDBC39B82462EA7D00069677 /* PredicateTest.swift */,
-				89F5E072290765C5001F9377 /* StatusTest.swift */,
+				89F5E095290C37B8001F9377 /* StatusTest.swift */,
 				1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */,
 				899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */,
 				965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */,
@@ -1021,6 +1039,7 @@
 				1FD8CD061968AB07008ED995 /* AdapterProtocols.swift */,
 				1FDBD8661AF8A4FF0089F27B /* AssertionDispatcher.swift */,
 				1FD8CD051968AB07008ED995 /* AssertionRecorder.swift */,
+				89F5E090290B9D5C001F9377 /* AssertionRecorder+Async.swift */,
 				1FC494A91C29CBA40010975C /* NimbleEnvironment.swift */,
 				1FD8CD071968AB07008ED995 /* NimbleXCTestHandler.swift */,
 				1F1871BA1CA89E2500A34BF2 /* NonObjectiveC */,
@@ -1074,7 +1093,8 @@
 		1FD8CD241968AB07008ED995 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				1FD8CD261968AB07008ED995 /* Await.swift */,
+				1FD8CD261968AB07008ED995 /* PollAwait.swift */,
+				89F5E08B290B8D22001F9377 /* AsyncAwait.swift */,
 				1FD8CD271968AB07008ED995 /* SourceLocation.swift */,
 				1FD8CD281968AB07008ED995 /* Stringers.swift */,
 				AE4BA9AC1C88DDB500B73906 /* Errors.swift */,
@@ -1577,6 +1597,7 @@
 				1F1871C81CA89EDB00A34BF2 /* NMBExceptionCapture.m in Sources */,
 				106112C02251E0FA000A5848 /* BeResult.swift in Sources */,
 				1FD8CD361968AB07008ED995 /* Expectation.swift in Sources */,
+				89F5E08D290B8D22001F9377 /* AsyncAwait.swift in Sources */,
 				1FD8CD321968AB07008ED995 /* NimbleXCTestHandler.swift in Sources */,
 				1F43728F1A1B344000EB80F8 /* Stringers.swift in Sources */,
 				1F43728D1A1B343D00EB80F8 /* SourceLocation.swift in Sources */,
@@ -1606,6 +1627,7 @@
 				1FD8CD461968AB07008ED995 /* BeGreaterThan.swift in Sources */,
 				F8A1BE2F1CB3710900031679 /* XCTestObservationCenter+Register.m in Sources */,
 				1F1871C61CA89EDB00A34BF2 /* DSL.m in Sources */,
+				89F5E092290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */,
 				1FD8CD301968AB07008ED995 /* AdapterProtocols.swift in Sources */,
 				AE7ADE451C80BF8000B94CD3 /* MatchError.swift in Sources */,
 				1FC494AA1C29CBA40010975C /* NimbleEnvironment.swift in Sources */,
@@ -1613,6 +1635,7 @@
 				1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */,
 				1FD8CD561968AB07008ED995 /* Contain.swift in Sources */,
 				CDFB6A481F7E082500AD8CC7 /* CwlMachBadInstructionHandler.m in Sources */,
+				89F5E0872908E655001F9377 /* Polling+AsyncAwait.swift in Sources */,
 				899441F92902EF2600C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				CDFB6A3C1F7E082500AD8CC7 /* CwlCatchBadInstruction.swift in Sources */,
 				1FD8CD481968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
@@ -1624,7 +1647,7 @@
 				1F1871CA1CA89EDB00A34BF2 /* NMBStringify.m in Sources */,
 				A8A3B6EB2071487E00E25A08 /* SatisfyAllOf.swift in Sources */,
 				1FD8CD521968AB07008ED995 /* BeNil.swift in Sources */,
-				1FD8CD6A1968AB07008ED995 /* Await.swift in Sources */,
+				1FD8CD6A1968AB07008ED995 /* PollAwait.swift in Sources */,
 				CDFB6A241F7E07C700AD8CC7 /* CwlCatchException.swift in Sources */,
 				1FD8CD581968AB07008ED995 /* EndWith.swift in Sources */,
 				1FD8CD341968AB07008ED995 /* DSL.swift in Sources */,
@@ -1648,6 +1671,7 @@
 				898F28B125D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */,
 				1F925EEC195C12C800ED456B /* RaisesExceptionTest.swift in Sources */,
 				899441F02902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
+				89F5E098290C37B8001F9377 /* StatusTest.swift in Sources */,
 				62FB326A23B78D500047BED9 /* BeginWithPrefixTest.swift in Sources */,
 				1F925EFF195C187600ED456B /* EndWithTest.swift in Sources */,
 				1F1B5AD41963E13900CA8BF9 /* BeAKindOfTest.swift in Sources */,
@@ -1667,6 +1691,7 @@
 				1F4A568E1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */,
 				1F925F11195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift in Sources */,
 				1F925EEF195C136500ED456B /* BeLogicalTest.swift in Sources */,
+				89F5E09C290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */,
 				1F4A56A01A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */,
 				A8A3B6F92073643000E25A08 /* ObjCSatisfyAnyOfTest.m in Sources */,
 				1F925F0B195C18E100ED456B /* BeLessThanTest.swift in Sources */,
@@ -1736,6 +1761,7 @@
 				1F5DF1801BDCA0F500C3A531 /* BeLessThanOrEqual.swift in Sources */,
 				1F1871E81CA8A18400A34BF2 /* Polling.swift in Sources */,
 				1F5DF18A1BDCA0F500C3A531 /* ThrowError.swift in Sources */,
+				89F5E08E290B8D22001F9377 /* AsyncAwait.swift in Sources */,
 				1F5DF1891BDCA0F500C3A531 /* RaisesException.swift in Sources */,
 				1F5DF1761BDCA0F500C3A531 /* AllPass.swift in Sources */,
 				AE4BA9AF1C88DDB500B73906 /* Errors.swift in Sources */,
@@ -1767,15 +1793,17 @@
 				1F5DF17B1BDCA0F500C3A531 /* BeginWith.swift in Sources */,
 				1F5DF17E1BDCA0F500C3A531 /* BeIdenticalTo.swift in Sources */,
 				1F5DF17A1BDCA0F500C3A531 /* BeEmpty.swift in Sources */,
-				1F5DF18C1BDCA0F500C3A531 /* Await.swift in Sources */,
+				1F5DF18C1BDCA0F500C3A531 /* PollAwait.swift in Sources */,
 				1F1871D81CA89EEF00A34BF2 /* NMBStringify.m in Sources */,
 				106112C22251E0FD000A5848 /* BeResult.swift in Sources */,
 				1F5DF1821BDCA0F500C3A531 /* BeNil.swift in Sources */,
 				1F5DF16F1BDCA0F500C3A531 /* AssertionDispatcher.swift in Sources */,
+				89F5E0882908E655001F9377 /* Polling+AsyncAwait.swift in Sources */,
 				964CFEFF1C4FF48900513336 /* ThrowAssertion.swift in Sources */,
 				1F5DF1841BDCA0F500C3A531 /* EndWith.swift in Sources */,
 				B20058C320E92CA900C1264D /* ElementsEqual.swift in Sources */,
 				1F5DF18D1BDCA0F500C3A531 /* SourceLocation.swift in Sources */,
+				89F5E093290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */,
 				1F5DF1701BDCA0F500C3A531 /* DSL.swift in Sources */,
 				CDD80B851F20307B0002CD65 /* MatcherProtocols.swift in Sources */,
 				1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */,
@@ -1813,6 +1841,7 @@
 				1F5DF1A51BDCA10200C3A531 /* ContainTest.swift in Sources */,
 				7B13BA121DD361EB00C9098C /* ObjCContainElementSatisfyingTest.m in Sources */,
 				AE7ADE4B1C80C00D00B94CD3 /* MatchErrorTest.swift in Sources */,
+				89F5E0A0290C37F0001F9377 /* ObjCBeIdenticalToTest.m in Sources */,
 				7B13BA0F1DD361DF00C9098C /* ContainElementSatisfyingTest.swift in Sources */,
 				CD79C9B31D2CC848004B6F9A /* ObjCMatchTest.m in Sources */,
 				1F5DF19E1BDCA10200C3A531 /* BeGreaterThanTest.swift in Sources */,
@@ -1821,17 +1850,20 @@
 				1F5DF1A91BDCA10200C3A531 /* MatchTest.swift in Sources */,
 				A8A3B708207368F100E25A08 /* ObjCSatisfyAllOfTest.m in Sources */,
 				1F5DF1A81BDCA10200C3A531 /* HaveCountTest.swift in Sources */,
+				89F5E0A3290C37FF001F9377 /* ObjCBeTruthyTest.m in Sources */,
 				1F5DF1971BDCA10200C3A531 /* AllPassTest.swift in Sources */,
 				CD79C9A61D2CC848004B6F9A /* ObjCBeGreaterThanOrEqualToTest.m in Sources */,
 				CD79C99F1D2CC835004B6F9A /* ObjCSyncTest.m in Sources */,
 				1FCF91511C61C85A00B15DCB /* PostNotificationTest.swift in Sources */,
 				CD79C9B51D2CC848004B6F9A /* ObjCUserDescriptionTest.m in Sources */,
 				1F5DF19C1BDCA10200C3A531 /* BeginWithTest.swift in Sources */,
+				89F5E099290C37B8001F9377 /* StatusTest.swift in Sources */,
 				1F5DF1A01BDCA10200C3A531 /* BeIdenticalToTest.swift in Sources */,
 				1F5DF19A1BDCA10200C3A531 /* BeCloseToTest.swift in Sources */,
 				B20058C720E92CE400C1264D /* ElementsEqualTest.swift in Sources */,
 				1F5DF1A61BDCA10200C3A531 /* EndWithTest.swift in Sources */,
 				CD79C9A31D2CC841004B6F9A /* ObjCBeFalseTest.m in Sources */,
+				89F5E09D290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */,
 				1F5DF1A71BDCA10200C3A531 /* EqualTest.swift in Sources */,
 				106112C72251E13B000A5848 /* BeResultTest.swift in Sources */,
 				CD79C9AA1D2CC848004B6F9A /* ObjCBeLessThanOrEqualToTest.m in Sources */,
@@ -1845,6 +1877,7 @@
 				CD79C9A71D2CC848004B6F9A /* ObjCBeGreaterThanTest.m in Sources */,
 				CD79C9A51D2CC848004B6F9A /* ObjCBeginWithTest.m in Sources */,
 				1F5DF1AA1BDCA10200C3A531 /* RaisesExceptionTest.swift in Sources */,
+				89F5E0A1290C37F7001F9377 /* ObjCBeLessThanTest.m in Sources */,
 				1F5DF1941BDCA10200C3A531 /* UserDescriptionTest.swift in Sources */,
 				CD79C9AF1D2CC848004B6F9A /* ObjCContainTest.m in Sources */,
 				1F5DF19F1BDCA10200C3A531 /* BeIdenticalToObjectTest.swift in Sources */,
@@ -1871,6 +1904,7 @@
 				1F1871D31CA89EEE00A34BF2 /* NMBExceptionCapture.m in Sources */,
 				106112BD2251DFE7000A5848 /* BeResult.swift in Sources */,
 				1FD8CD371968AB07008ED995 /* Expectation.swift in Sources */,
+				89F5E08C290B8D22001F9377 /* AsyncAwait.swift in Sources */,
 				1FD8CD331968AB07008ED995 /* NimbleXCTestHandler.swift in Sources */,
 				1F43728E1A1B343F00EB80F8 /* Stringers.swift in Sources */,
 				1F43728C1A1B343C00EB80F8 /* SourceLocation.swift in Sources */,
@@ -1900,6 +1934,7 @@
 				1FD8CD471968AB07008ED995 /* BeGreaterThan.swift in Sources */,
 				F8A1BE301CB3710900031679 /* XCTestObservationCenter+Register.m in Sources */,
 				1FD8CD311968AB07008ED995 /* AdapterProtocols.swift in Sources */,
+				89F5E091290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */,
 				1F1871D21CA89EEE00A34BF2 /* DSL.m in Sources */,
 				AE7ADE461C80BF8000B94CD3 /* MatchError.swift in Sources */,
 				1FC494AB1C29CBA40010975C /* NimbleEnvironment.swift in Sources */,
@@ -1907,6 +1942,7 @@
 				CDD80B831F2030790002CD65 /* MatcherProtocols.swift in Sources */,
 				1FD8CD571968AB07008ED995 /* Contain.swift in Sources */,
 				7A0A26231E7F52360092A34E /* ToSucceed.swift in Sources */,
+				89F5E0862908E655001F9377 /* Polling+AsyncAwait.swift in Sources */,
 				899441F82902EF2500C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				CDFB6A471F7E082500AD8CC7 /* CwlMachBadInstructionHandler.m in Sources */,
 				CDFB6A3B1F7E082500AD8CC7 /* CwlCatchBadInstruction.swift in Sources */,
@@ -1918,7 +1954,7 @@
 				1F1871D41CA89EEE00A34BF2 /* NMBStringify.m in Sources */,
 				A8F6B5BD2070186D00FCB5ED /* SatisfyAllOf.swift in Sources */,
 				1FD8CD531968AB07008ED995 /* BeNil.swift in Sources */,
-				1FD8CD6B1968AB07008ED995 /* Await.swift in Sources */,
+				1FD8CD6B1968AB07008ED995 /* PollAwait.swift in Sources */,
 				CDFB6A231F7E07C700AD8CC7 /* CwlCatchException.swift in Sources */,
 				964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */,
 				1FD8CD591968AB07008ED995 /* EndWith.swift in Sources */,
@@ -1939,6 +1975,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F4A569B1A3B3539009E1637 /* ObjCEqualTest.m in Sources */,
+				89F5E09F290C37DD001F9377 /* ObjCSyncTest.m in Sources */,
 				898F28B025D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */,
 				1F925EED195C12C800ED456B /* RaisesExceptionTest.swift in Sources */,
 				899441EF2902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */,
@@ -1961,8 +1998,10 @@
 				B20058C520E92CE400C1264D /* ElementsEqualTest.swift in Sources */,
 				1F4A568F1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */,
 				1F925F12195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift in Sources */,
+				89F5E097290C37B8001F9377 /* StatusTest.swift in Sources */,
 				1F925EF0195C136500ED456B /* BeLogicalTest.swift in Sources */,
 				1F4A56A11A3B359E009E1637 /* ObjCRaiseExceptionTest.m in Sources */,
+				89F5E0A5290C380B001F9377 /* ObjCUserDescriptionTest.m in Sources */,
 				A8A3B6FA2073643100E25A08 /* ObjCSatisfyAnyOfTest.m in Sources */,
 				1F925F0C195C18E100ED456B /* BeLessThanTest.swift in Sources */,
 				1F9DB8FC1A74E793002E96AD /* ObjCBeEmptyTest.m in Sources */,
@@ -1989,10 +2028,13 @@
 				1F4A56801A3B333F009E1637 /* ObjCBeLessThanTest.m in Sources */,
 				857D184F2536124400D8693A /* BeWithinTest.swift in Sources */,
 				1F0648CD19639F5A001F9C46 /* ObjectWithLazyProperty.swift in Sources */,
+				89F5E0A4290C3803001F9377 /* ObjCContainTest.m in Sources */,
 				106112C52251E13B000A5848 /* BeResultTest.swift in Sources */,
 				1F4A56861A3B33A0009E1637 /* ObjCBeTruthyTest.m in Sources */,
+				89F5E09B290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */,
 				DD9A9A9019CF43AD00706F49 /* BeIdenticalToObjectTest.swift in Sources */,
 				1F4BB8B61DACA0E30048464B /* ThrowAssertionTest.swift in Sources */,
+				89F5E0A2290C37FB001F9377 /* ObjCBeNilTest.m in Sources */,
 				1F0648D51963AAB2001F9C46 /* SynchronousTest.swift in Sources */,
 				4793854E1BA0BB2500296F85 /* ObjCHaveCountTest.m in Sources */,
 				1F925F09195C18CF00ED456B /* BeGreaterThanTest.swift in Sources */,
@@ -2026,6 +2068,7 @@
 				D95F8967267EA20A004B1B4D /* SatisfyAnyOf.swift in Sources */,
 				D95F8973267EA20A004B1B4D /* Predicate.swift in Sources */,
 				D95F8976267EA20A004B1B4D /* BeGreaterThanOrEqualTo.swift in Sources */,
+				89F5E08F290B8D22001F9377 /* AsyncAwait.swift in Sources */,
 				D95F8958267EA1F7004B1B4D /* AssertionRecorder.swift in Sources */,
 				D95F897E267EA20A004B1B4D /* BeWithin.swift in Sources */,
 				D95F8928267EA1CA004B1B4D /* NMBExceptionCapture.m in Sources */,
@@ -2044,7 +2087,7 @@
 				D95F895E267EA205004B1B4D /* DSL.swift in Sources */,
 				D95F897D267EA20A004B1B4D /* BeAKindOf.swift in Sources */,
 				D95F8977267EA20A004B1B4D /* MatchError.swift in Sources */,
-				D95F8987267EA20E004B1B4D /* Await.swift in Sources */,
+				D95F8987267EA20E004B1B4D /* PollAwait.swift in Sources */,
 				D95F897C267EA20A004B1B4D /* BeginWithPrefix.swift in Sources */,
 				D95F8927267EA1CA004B1B4D /* NMBStringify.m in Sources */,
 				D95F898B267EA315004B1B4D /* CwlCatchBadInstructionPosix.swift in Sources */,
@@ -2062,10 +2105,12 @@
 				D95F8978267EA20A004B1B4D /* BeAnInstanceOf.swift in Sources */,
 				D95F896D267EA20A004B1B4D /* BeCloseTo.swift in Sources */,
 				D95F8963267EA20A004B1B4D /* ThrowError.swift in Sources */,
+				89F5E0892908E655001F9377 /* Polling+AsyncAwait.swift in Sources */,
 				D95F8970267EA20A004B1B4D /* MatcherProtocols.swift in Sources */,
 				D95F897F267EA20A004B1B4D /* AllPass.swift in Sources */,
 				D95F896A267EA20A004B1B4D /* ThrowAssertion.swift in Sources */,
 				D95F8980267EA20A004B1B4D /* Equal+Tuple.swift in Sources */,
+				89F5E094290B9D5C001F9377 /* AssertionRecorder+Async.swift in Sources */,
 				D95F896F267EA20A004B1B4D /* EndWith.swift in Sources */,
 				D95F8975267EA20A004B1B4D /* BeIdenticalTo.swift in Sources */,
 				D95F8984267EA20E004B1B4D /* SourceLocation.swift in Sources */,
@@ -2084,6 +2129,7 @@
 				D95F8949267EA1E8004B1B4D /* MatchTest.swift in Sources */,
 				D95F8951267EA1EE004B1B4D /* utils.swift in Sources */,
 				D95F8941267EA1E8004B1B4D /* BeginWithPrefixTest.swift in Sources */,
+				89F5E09E290C37B8001F9377 /* OnFailureThrowsTest.swift in Sources */,
 				D95F893B267EA1E8004B1B4D /* BeLogicalTest.swift in Sources */,
 				D95F894D267EA1E8004B1B4D /* ElementsEqualTest.swift in Sources */,
 				D95F8939267EA1E8004B1B4D /* BeIdenticalToObjectTest.swift in Sources */,
@@ -2111,6 +2157,7 @@
 				D95F892D267EA1D9004B1B4D /* LinuxSupport.swift in Sources */,
 				D95F892F267EA1D9004B1B4D /* SynchronousTest.swift in Sources */,
 				D95F8953267EA1EE004B1B4D /* AlwaysFailMatcher.swift in Sources */,
+				89F5E09A290C37B8001F9377 /* StatusTest.swift in Sources */,
 				D95F892A267EA1D9004B1B4D /* UserDescriptionTest.swift in Sources */,
 				D95F893F267EA1E8004B1B4D /* BeLessThanOrEqualToTest.swift in Sources */,
 				D95F894C267EA1E8004B1B4D /* PostNotificationTest.swift in Sources */,

--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -54,10 +54,14 @@ extension NMBExceptionCapture {
 /// Allows you to temporarily replace the current Nimble assertion handler with
 /// the one provided for the scope of the closure.
 ///
+/// @warning
+/// This form of `withAssertionHandler` does not work in any kind of
+/// async context. Use the async form of `withAssertionHandler`
+/// if you are running tests in an async context.
+///
 /// Once the closure finishes, then the original Nimble assertion handler is restored.
 ///
 /// @see AssertionHandler
-@available(*, noasync)
 public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
                                  file: FileString = #file,
                                  line: UInt = #line,
@@ -87,11 +91,15 @@ public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
 /// This can be useful if you want to gather information about expectations
 /// that occur within a closure.
 ///
+/// @warning
+/// This form of `gatherExpectations` does not work in any kind of
+/// async context. Use the async form of `gatherExpectations`
+/// if you are running tests in an async context.
+///
 /// @param silently expectations are no longer send to the default Nimble 
 ///                 assertion handler when this is true. Defaults to false.
 ///
 /// @see gatherFailingExpectations
-@available(*, noasync)
 public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let previousRecorder = NimbleEnvironment.activeInstance.assertionHandler
     let recorder = AssertionRecorder()
@@ -114,12 +122,16 @@ public func gatherExpectations(silently: Bool = false, closure: () -> Void) -> [
 /// This can be useful if you want to gather information about failed
 /// expectations that occur within a closure.
 ///
+/// @warning
+/// This form of `gatherFailingExpectations` does not work in any kind of
+/// async context. Use the async form of `gatherFailingExpectations`
+/// if you are running tests in an async context.
+///
 /// @param silently expectations are no longer send to the default Nimble
 ///                 assertion handler when this is true. Defaults to false.
 ///
 /// @see gatherExpectations
 /// @see raiseException source for an example use case.
-@available(*, noasync)
 public func gatherFailingExpectations(silently: Bool = false, closure: () -> Void) -> [AssertionRecord] {
     let assertions = gatherExpectations(silently: silently, closure: closure)
     return assertions.filter { assertion in

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) async -> (() throws -> T) {
     let result: Result<T, Error>
     do {
@@ -43,3 +45,72 @@ public func expect(file: FileString = #file, line: UInt = #line, _ expression: @
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
+
+/// Wait asynchronously until the done closure is called or the timeout has been reached.
+///
+/// @discussion
+/// Call the done() closure to indicate the waiting has completed.
+///
+/// @warning
+/// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
+public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) async -> Void) async {
+    await throwableUntil(timeout: timeout) { done in
+        await action(done)
+    }
+}
+
+/// Wait asynchronously until the done closure is called or the timeout has been reached.
+///
+/// @discussion
+/// Call the done() closure to indicate the waiting has completed.
+///
+/// @warning
+/// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
+public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) async {
+    await throwableUntil(timeout: timeout, file: file, line: line) { done in
+        action(done)
+    }
+}
+
+private enum ErrorResult {
+    case error(Error)
+    case none
+}
+
+private func throwableUntil(
+    timeout: DispatchTimeInterval,
+    file: FileString = #file,
+    line: UInt = #line,
+    action: @escaping (@escaping () -> Void) async throws -> Void) async {
+        let awaiter = NimbleEnvironment.activeInstance.awaiter
+        let leeway = timeout.divided
+        let result = await awaiter.performBlock(file: file, line: line) { @MainActor (done: @escaping (ErrorResult) -> Void) async throws -> Void in
+            do {
+                try await action {
+                    done(.none)
+                }
+            } catch let e {
+                done(.error(e))
+            }
+        }
+            .timeout(timeout, forcefullyAbortTimeout: leeway)
+            .wait("waitUntil(...)", file: file, line: line)
+
+        switch result {
+        case .incomplete: internalError("Reached .incomplete state for waitUntil(...).")
+        case .blockedRunLoop:
+            fail(blockedRunLoopErrorMessageFor("-waitUntil()", leeway: leeway),
+                 file: file, line: line)
+        case .timedOut:
+            fail("Waited more than \(timeout.description)", file: file, line: line)
+        case let .raisedException(exception):
+            fail("Unexpected exception raised: \(exception)")
+        case let .errorThrown(error):
+            fail("Unexpected error thrown: \(error)")
+        case .completed(.error(let error)):
+            fail("Unexpected error thrown: \(error)")
+        case .completed(.none): // success
+            break
+        }
+}
+

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -113,4 +113,3 @@ private func throwableUntil(
             break
         }
 }
-

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -116,7 +116,6 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: DispatchTi
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
-@available(*, noasync)
 public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -116,6 +116,7 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: DispatchTi
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+@available(*, noasync)
 public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -110,10 +110,8 @@ public func beCloseTo<Value: FloatingPoint, Values: Collection>(
             return .doesNotMatch
         }
 
-        for index in actualValues.indices {
-            if abs(actualValues[index] - expectedValues[index]) > delta {
-                return .doesNotMatch
-            }
+        for index in actualValues.indices where abs(actualValues[index] - expectedValues[index]) > delta {
+            return .doesNotMatch
         }
         return .matches
     }

--- a/Sources/Nimble/Matchers/ContainElementSatisfying.swift
+++ b/Sources/Nimble/Matchers/ContainElementSatisfying.swift
@@ -10,10 +10,8 @@ public func containElementSatisfying<S: Sequence>(
         }
 
         if let sequence = try actualExpression.evaluate() {
-            for object in sequence {
-                if predicate(object) {
-                    return PredicateResult(bool: true, message: message)
-                }
+            for object in sequence where predicate(object) {
+                return PredicateResult(bool: true, message: message)
             }
 
             return PredicateResult(bool: false, message: message)

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -1,9 +1,9 @@
+// swiftlint:disable all
 #if canImport(CwlPreconditionTesting) && (os(macOS) || os(iOS))
 import CwlPreconditionTesting
 #elseif canImport(CwlPosixPreconditionTesting)
 import CwlPosixPreconditionTesting
 #elseif canImport(Glibc)
-// swiftlint:disable all
 import Glibc
 
 // This function is called from the signal handler to shut down the thread and return 1 (indicating a SIGILL was received).
@@ -79,7 +79,6 @@ public func catchBadInstruction(block: @escaping () -> Void) -> BadInstructionEx
 
     return caught ? BadInstructionException() : nil
 }
-// swiftlint:enable all
 #endif
 
 public func throwAssertion<Out>() -> Predicate<Out> {
@@ -144,3 +143,4 @@ public func throwAssertion<Out>() -> Predicate<Out> {
     #endif
     }
 }
+// swiftlint:enable all

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -17,6 +17,7 @@ private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to
     }
 }
 
+// swiftlint:disable:next function_parameter_count
 private func poll<T>(
     expression: Expression<T>,
     style: ExpectationStyle,

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -1,0 +1,202 @@
+import Dispatch
+
+private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to: String, description: String?, predicateExecutor: () async throws -> PredicateResult) async -> (Bool, FailureMessage) {
+    let msg = FailureMessage()
+    msg.userDescription = description
+    msg.to = to
+    do {
+        let result = try await predicateExecutor()
+        result.message.update(failureMessage: msg)
+        if msg.actualValue == "" {
+            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
+        }
+        return (result.toBoolean(expectation: style), msg)
+    } catch let error {
+        msg.stringValue = "unexpected error thrown: <\(error)>"
+        return (false, msg)
+    }
+}
+
+private func poll<T>(
+    expression: Expression<T>,
+    style: ExpectationStyle,
+    matchStyle: AsyncMatchStyle,
+    timeout: DispatchTimeInterval,
+    poll: DispatchTimeInterval,
+    fnName: String,
+    predicateRunner: @escaping () throws -> PredicateResult
+) async -> PredicateResult {
+    let fnName = "expect(...).\(fnName)(...)"
+    var lastPredicateResult: PredicateResult?
+    let result = await pollBlock(
+        pollInterval: poll,
+        timeoutInterval: timeout,
+        file: expression.location.file,
+        line: expression.location.line,
+        fnName: fnName) {
+            lastPredicateResult = try predicateRunner()
+            return lastPredicateResult!.toBoolean(expectation: style)
+        }
+    switch result {
+    case .completed:
+        switch matchStyle {
+        case .eventually:
+            return lastPredicateResult!
+        case .never:
+            return PredicateResult(
+                status: .fail,
+                message: lastPredicateResult?.message ?? .fail("matched the predicate when it shouldn't have")
+            )
+        case .always:
+            return PredicateResult(
+                status: .fail,
+                message: lastPredicateResult?.message ?? .fail("didn't match the predicate when it should have")
+            )
+        }
+    case .timedOut:
+        switch matchStyle {
+        case .eventually:
+            let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
+            return PredicateResult(status: .fail, message: message)
+        case .never:
+            return PredicateResult(status: .doesNotMatch, message: .expectedTo("never match the predicate"))
+        case .always:
+            return PredicateResult(status: .matches, message: .expectedTo("always match the predicate"))
+        }
+    case let .errorThrown(error):
+        return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
+    case let .raisedException(exception):
+        return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
+    case .blockedRunLoop:
+        let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
+            .fail("main run loop was unresponsive")
+        return PredicateResult(status: .fail, message: message)
+    case .incomplete:
+        internalError("Reached .incomplete state for \(fnName)(...).")
+    }
+}
+
+extension SyncExpectation {
+    /// Tests the actual value using a matcher to match by checking continuously
+    /// at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let (pass, msg) = await execute(
+            expression,
+            style: .toMatch,
+            to: "to eventually",
+            description: description) {
+                await poll(
+                    expression: expression,
+                    style: .toMatch,
+                    matchStyle: .eventually,
+                    timeout: timeout,
+                    poll: pollInterval,
+                    fnName: "toEventually") {
+                        try predicate.satisfies(expression)
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let (pass, msg) = await execute(
+            expression,
+            style: .toNotMatch,
+            to: "to eventually not",
+            description: description) {
+                await poll(
+                    expression: expression,
+                    style: .toNotMatch,
+                    matchStyle: .eventually,
+                    timeout: timeout,
+                    poll: pollInterval,
+                    fnName: "toEventuallyNot") {
+                        try predicate.satisfies(expression)
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toEventuallyNot()
+    @discardableResult
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
+    }
+
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let (pass, msg) = await execute(
+            expression,
+            style: .toNotMatch,
+            to: "to never",
+            description: description) {
+                await poll(
+                    expression: expression,
+                    style: .toMatch,
+                    matchStyle: .never,
+                    timeout: until,
+                    poll: pollInterval,
+                    fnName: "toNever") {
+                        try predicate.satisfies(expression)
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toNever()
+    @discardableResult
+    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
+    }
+
+    /// Tests the actual value using a matcher to always match by checking
+    /// continusouly at each pollInterval until the timeout is reached
+    @discardableResult
+    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let (pass, msg) = await execute(
+            expression,
+            style: .toMatch,
+            to: "to always",
+            description: description) {
+                await poll(
+                    expression: expression,
+                    style: .toNotMatch,
+                    matchStyle: .always,
+                    timeout: until,
+                    poll: pollInterval,
+                    fnName: "toAlways") {
+                        try predicate.satisfies(expression)
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to always match by checking
+    /// continusouly at each pollInterval until the timeout is reached
+    ///
+    /// Alias of toAlways()
+    @discardableResult
+    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
+    }
+}

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -37,43 +37,7 @@ private func poll<T>(
             lastPredicateResult = try predicateRunner()
             return lastPredicateResult!.toBoolean(expectation: style)
         }
-    switch result {
-    case .completed:
-        switch matchStyle {
-        case .eventually:
-            return lastPredicateResult!
-        case .never:
-            return PredicateResult(
-                status: .fail,
-                message: lastPredicateResult?.message ?? .fail("matched the predicate when it shouldn't have")
-            )
-        case .always:
-            return PredicateResult(
-                status: .fail,
-                message: lastPredicateResult?.message ?? .fail("didn't match the predicate when it should have")
-            )
-        }
-    case .timedOut:
-        switch matchStyle {
-        case .eventually:
-            let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
-            return PredicateResult(status: .fail, message: message)
-        case .never:
-            return PredicateResult(status: .doesNotMatch, message: .expectedTo("never match the predicate"))
-        case .always:
-            return PredicateResult(status: .matches, message: .expectedTo("always match the predicate"))
-        }
-    case let .errorThrown(error):
-        return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
-    case let .raisedException(exception):
-        return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
-    case .blockedRunLoop:
-        let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
-            .fail("main run loop was unresponsive")
-        return PredicateResult(status: .fail, message: message)
-    case .incomplete:
-        internalError("Reached .incomplete state for \(fnName)(...).")
-    }
+    return processPollResult(result, matchStyle: matchStyle, lastPredicateResult: lastPredicateResult, fnName: fnName)
 }
 
 extension SyncExpectation {

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -10,12 +10,12 @@ public struct AsyncDefaults {
     public static var pollInterval: DispatchTimeInterval = .milliseconds(10)
 }
 
-private enum AsyncMatchStyle {
+internal enum AsyncMatchStyle {
     case eventually, never, always
 }
 
 // swiftlint:disable:next function_parameter_count
-private func async<T>(
+private func poll<T>(
     style: ExpectationStyle,
     matchStyle: AsyncMatchStyle,
     predicate: Predicate<T>,
@@ -76,7 +76,7 @@ private func async<T>(
     }
 }
 
-private let toEventuallyRequiresClosureError = FailureMessage(
+internal let toEventuallyRequiresClosureError = FailureMessage(
     stringValue: """
         expect(...).toEventually(...) requires an explicit closure (eg - expect { ... }.toEventually(...) )
         Swift 1.2 @autoclosure behavior has changed in an incompatible way for Nimble to function
@@ -90,14 +90,18 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `toEventually` does not work in any kind of async context that uses the main actor. Use the async form of `toEventually` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
             expression,
             .toMatch,
-            async(
+            poll(
                 style: .toMatch,
                 matchStyle: .eventually,
                 predicate: predicate,
@@ -118,14 +122,18 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `toEventuallyNot` does not work in any kind of async context that uses the main actor. Use the async form of `toEventuallyNot` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
             expression,
             .toNotMatch,
-            async(
+            poll(
                 style: .toNotMatch,
                 matchStyle: .eventually,
                 predicate: predicate,
@@ -148,7 +156,11 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `toNotEventually` does not work in any kind of async context that uses the main actor. Use the async form of `toNotEventually` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
@@ -159,14 +171,18 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `toNever` does not work in any kind of async context that uses the main actor. Use the async form of `toNever` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
             expression,
             .toNotMatch,
-            async(
+            poll(
                 style: .toMatch,
                 matchStyle: .never,
                 predicate: predicate,
@@ -189,7 +205,11 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `neverTo` does not work in any kind of async context that uses the main actor. Use the async form of `neverTo` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
@@ -200,14 +220,18 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `toAlways` does not work in any kind of async context that uses the main actor. Use the async form of `toAlways` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
             expression,
             .toMatch,
-            async(
+            poll(
                 style: .toNotMatch,
                 matchStyle: .always,
                 predicate: predicate,
@@ -230,7 +254,11 @@ extension SyncExpectation {
     /// @discussion
     /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+    ///
+    /// @warning
+    /// This form of `alwaysTo` does not work in any kind of async context that uses the main actor. Use the async form of `alwaysTo` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync)
     public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -96,9 +96,8 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `toEventually` does not work in any kind of async context that uses the main actor. Use the async form of `toEventually` if you are running tests in an async context.
+    /// This form of `toEventually` does not work in any kind of async context. Use the async form of `toEventually` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -128,9 +127,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `toEventuallyNot` does not work in any kind of async context that uses the main actor. Use the async form of `toEventuallyNot` if you are running tests in an async context.
+    /// This form of `toEventuallyNot` does not work in any kind of async context.
+    /// Use the async form of `toEventuallyNot` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -162,9 +161,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `toNotEventually` does not work in any kind of async context that uses the main actor. Use the async form of `toNotEventually` if you are running tests in an async context.
+    /// This form of `toNotEventually` does not work in any kind of async context.
+    /// Use the async form of `toNotEventually` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
@@ -177,9 +176,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `toNever` does not work in any kind of async context that uses the main actor. Use the async form of `toNever` if you are running tests in an async context.
+    /// This form of `toNever` does not work in any kind of async context.
+    /// Use the async form of `toNever` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -211,9 +210,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `neverTo` does not work in any kind of async context that uses the main actor. Use the async form of `neverTo` if you are running tests in an async context.
+    /// This form of `neverTo` does not work in any kind of async context.
+    /// Use the async form of `neverTo` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
@@ -226,9 +225,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `toAlways` does not work in any kind of async context that uses the main actor. Use the async form of `toAlways` if you are running tests in an async context.
+    /// This form of `toAlways` does not work in any kind of async context.
+    /// Use the async form of `toAlways` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -260,9 +259,9 @@ extension SyncExpectation {
     /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
     ///
     /// @warning
-    /// This form of `alwaysTo` does not work in any kind of async context that uses the main actor. Use the async form of `alwaysTo` if you are running tests in an async context.
+    /// This form of `alwaysTo` does not work in any kind of async context.
+    /// Use the async form of `alwaysTo` if you are running tests in an async context.
     @discardableResult
-    @available(*, noasync)
     public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -40,6 +40,7 @@ private func poll<T>(
     }
 }
 
+// swiftlint:disable:next cyclomatic_complexity
 internal func processPollResult(_ result: PollResult<Bool>, matchStyle: AsyncMatchStyle, lastPredicateResult: PredicateResult?, fnName: String) -> PredicateResult {
     switch result {
     case .completed:

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -36,43 +36,47 @@ private func poll<T>(
                 lastPredicateResult = try predicate.satisfies(uncachedExpression)
                 return lastPredicateResult!.toBoolean(expectation: style)
         }
-        switch result {
-        case .completed:
-            switch matchStyle {
-            case .eventually:
-                return lastPredicateResult!
-            case .never:
-                return PredicateResult(
-                    status: .fail,
-                    message: lastPredicateResult?.message ?? .fail("matched the predicate when it shouldn't have")
-                )
-            case .always:
-                return PredicateResult(
-                    status: .fail,
-                    message: lastPredicateResult?.message ?? .fail("didn't match the predicate when it should have")
-                )
-            }
-        case .timedOut:
-            switch matchStyle {
-            case .eventually:
-                let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
-                return PredicateResult(status: .fail, message: message)
-            case .never:
-                return PredicateResult(status: .doesNotMatch, message: .expectedTo("never match the predicate"))
-            case .always:
-                return PredicateResult(status: .matches, message: .expectedTo("always match the predicate"))
-            }
-        case let .errorThrown(error):
-            return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
-        case let .raisedException(exception):
-            return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
-        case .blockedRunLoop:
-            let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
-                .fail("main run loop was unresponsive")
-            return PredicateResult(status: .fail, message: message)
-        case .incomplete:
-            internalError("Reached .incomplete state for \(fnName)(...).")
+        return processPollResult(result, matchStyle: matchStyle, lastPredicateResult: lastPredicateResult, fnName: fnName)
+    }
+}
+
+internal func processPollResult(_ result: PollResult<Bool>, matchStyle: AsyncMatchStyle, lastPredicateResult: PredicateResult?, fnName: String) -> PredicateResult {
+    switch result {
+    case .completed:
+        switch matchStyle {
+        case .eventually:
+            return lastPredicateResult!
+        case .never:
+            return PredicateResult(
+                status: .fail,
+                message: lastPredicateResult?.message ?? .fail("matched the predicate when it shouldn't have")
+            )
+        case .always:
+            return PredicateResult(
+                status: .fail,
+                message: lastPredicateResult?.message ?? .fail("didn't match the predicate when it should have")
+            )
         }
+    case .timedOut:
+        switch matchStyle {
+        case .eventually:
+            let message = lastPredicateResult?.message ?? .fail("timed out before returning a value")
+            return PredicateResult(status: .fail, message: message)
+        case .never:
+            return PredicateResult(status: .doesNotMatch, message: .expectedTo("never match the predicate"))
+        case .always:
+            return PredicateResult(status: .matches, message: .expectedTo("always match the predicate"))
+        }
+    case let .errorThrown(error):
+        return PredicateResult(status: .fail, message: .fail("unexpected error thrown: <\(error)>"))
+    case let .raisedException(exception):
+        return PredicateResult(status: .fail, message: .fail("unexpected exception raised: \(exception)"))
+    case .blockedRunLoop:
+        let message = lastPredicateResult?.message.appended(message: " (timed out, but main run loop was unresponsive).") ??
+            .fail("main run loop was unresponsive")
+        return PredicateResult(status: .fail, message: message)
+    case .incomplete:
+        internalError("Reached .incomplete state for \(fnName)(...).")
     }
 }
 

--- a/Sources/Nimble/Utils/AsyncAwait.swift
+++ b/Sources/Nimble/Utils/AsyncAwait.swift
@@ -1,0 +1,216 @@
+#if !os(WASI)
+
+import CoreFoundation
+import Dispatch
+import Foundation
+
+private let timeoutLeeway = DispatchTimeInterval.milliseconds(1)
+private let pollLeeway = DispatchTimeInterval.milliseconds(1)
+
+internal struct AsyncAwaitTrigger {
+    let timeoutSource: DispatchSourceTimer
+    let actionSource: DispatchSourceTimer?
+    let start: () async throws -> Void
+}
+
+/// Factory for building fully configured AwaitPromises and waiting for their results.
+///
+/// This factory stores all the state for an async expectation so that Await doesn't
+/// doesn't have to manage it.
+internal class AsyncAwaitPromiseBuilder<T> {
+    let awaiter: Awaiter
+    let waitLock: WaitLock
+    let trigger: AsyncAwaitTrigger
+    let promise: AwaitPromise<T>
+
+    internal init(
+        awaiter: Awaiter,
+        waitLock: WaitLock,
+        promise: AwaitPromise<T>,
+        trigger: AsyncAwaitTrigger) {
+            self.awaiter = awaiter
+            self.waitLock = waitLock
+            self.promise = promise
+            self.trigger = trigger
+    }
+
+    func timeout(_ timeoutInterval: DispatchTimeInterval, forcefullyAbortTimeout: DispatchTimeInterval) -> Self {
+        /// = Discussion =
+        ///
+        /// There's a lot of technical decisions here that is useful to elaborate on. This is
+        /// definitely more lower-level than the previous NSRunLoop based implementation.
+        ///
+        ///
+        /// Why Dispatch Source?
+        ///
+        ///
+        /// We're using a dispatch source to have better control of the run loop behavior.
+        /// A timer source gives us deferred-timing control without having to rely as much on
+        /// a run loop's traditional dispatching machinery (eg - NSTimers, DefaultRunLoopMode, etc.)
+        /// which is ripe for getting corrupted by application code.
+        ///
+        /// And unlike `dispatch_async()`, we can control how likely our code gets prioritized to
+        /// executed (see leeway parameter) + DISPATCH_TIMER_STRICT.
+        ///
+        /// This timer is assumed to run on the HIGH priority queue to ensure it maintains the
+        /// highest priority over normal application / test code when possible.
+        ///
+        ///
+        /// Run Loop Management
+        ///
+        /// In order to properly interrupt the waiting behavior performed by this factory class,
+        /// this timer stops the main run loop to tell the waiter code that the result should be
+        /// checked.
+        ///
+        /// In addition, stopping the run loop is used to halt code executed on the main run loop.
+        trigger.timeoutSource.schedule(
+            deadline: DispatchTime.now() + timeoutInterval,
+            repeating: .never,
+            leeway: timeoutLeeway
+        )
+        trigger.timeoutSource.setEventHandler {
+            guard self.promise.asyncResult.isIncomplete() else { return }
+            let timedOutSem = DispatchSemaphore(value: 0)
+            let semTimedOutOrBlocked = DispatchSemaphore(value: 0)
+            semTimedOutOrBlocked.signal()
+            DispatchQueue.main.async {
+                if semTimedOutOrBlocked.wait(timeout: .now()) == .success {
+                    timedOutSem.signal()
+                    semTimedOutOrBlocked.signal()
+                    self.promise.resolveResult(.timedOut)
+                }
+            }
+            // potentially interrupt blocking code on run loop to let timeout code run
+            let now = DispatchTime.now() + forcefullyAbortTimeout
+            let didNotTimeOut = timedOutSem.wait(timeout: now) != .success
+            let timeoutWasNotTriggered = semTimedOutOrBlocked.wait(timeout: .now()) == .success
+            if didNotTimeOut && timeoutWasNotTriggered {
+                self.promise.resolveResult(.blockedRunLoop)
+            }
+        }
+        return self
+    }
+
+    /// Blocks for an asynchronous result.
+    ///
+    /// @discussion
+    /// This function cannot be nested. This is because this function (and it's related methods)
+    /// coordinate through the main run loop. Tampering with the run loop can cause undesirable behavior.
+    ///
+    /// This method will return an AwaitResult in the following cases:
+    ///
+    /// - The main run loop is blocked by other operations and the async expectation cannot be
+    ///   be stopped.
+    /// - The async expectation timed out
+    /// - The async expectation succeeded
+    /// - The async expectation raised an unexpected exception (objc)
+    /// - The async expectation raised an unexpected error (swift)
+    ///
+    /// The returned AwaitResult will NEVER be .incomplete.
+    @MainActor
+    func wait(_ fnName: String = #function, file: FileString = #file, line: UInt = #line) async -> PollResult<T> {
+        waitLock.acquireWaitingLock(
+            fnName,
+            file: file,
+            line: line)
+
+        defer {
+            self.waitLock.releaseWaitingLock()
+        }
+        do {
+            try await self.trigger.start()
+        } catch let error {
+            self.promise.resolveResult(.errorThrown(error))
+        }
+        self.trigger.timeoutSource.resume()
+        while self.promise.asyncResult.isIncomplete() {
+            // Stopping the run loop does not work unless we run only 1 mode
+            await Task.yield()
+        }
+
+        self.trigger.timeoutSource.cancel()
+        if let asyncSource = self.trigger.actionSource {
+            asyncSource.cancel()
+        }
+
+        return promise.asyncResult
+    }
+}
+
+extension Awaiter {
+    func performBlock<T>(
+        file: FileString,
+        line: UInt,
+        _ closure: @escaping (@escaping (T) -> Void) async throws -> Void
+        ) async -> AsyncAwaitPromiseBuilder<T> {
+            let promise = AwaitPromise<T>()
+            let timeoutSource = createTimerSource(timeoutQueue)
+            var completionCount = 0
+            let trigger = AsyncAwaitTrigger(timeoutSource: timeoutSource, actionSource: nil) {
+                try await closure { result in
+                    completionCount += 1
+                    if completionCount < 2 {
+                        promise.resolveResult(.completed(result))
+                    } else {
+                        fail("waitUntil(..) expects its completion closure to be only called once",
+                             file: file, line: line)
+                    }
+                }
+            }
+
+            return AsyncAwaitPromiseBuilder(
+                awaiter: self,
+                waitLock: waitLock,
+                promise: promise,
+                trigger: trigger)
+    }
+
+    func poll<T>(_ pollInterval: DispatchTimeInterval, closure: @escaping () throws -> T?) async -> AsyncAwaitPromiseBuilder<T> {
+        let promise = AwaitPromise<T>()
+        let timeoutSource = createTimerSource(timeoutQueue)
+        let asyncSource = createTimerSource(asyncQueue)
+        let trigger = AsyncAwaitTrigger(timeoutSource: timeoutSource, actionSource: asyncSource) {
+            let interval = pollInterval
+            asyncSource.schedule(deadline: .now(), repeating: interval, leeway: pollLeeway)
+            asyncSource.setEventHandler {
+                do {
+                    if let result = try closure() {
+                        promise.resolveResult(.completed(result))
+                    }
+                } catch let error {
+                    promise.resolveResult(.errorThrown(error))
+                }
+            }
+            asyncSource.resume()
+        }
+
+        return AsyncAwaitPromiseBuilder(
+            awaiter: self,
+            waitLock: waitLock,
+            promise: promise,
+            trigger: trigger)
+    }
+}
+
+internal func pollBlock(
+    pollInterval: DispatchTimeInterval,
+    timeoutInterval: DispatchTimeInterval,
+    file: FileString,
+    line: UInt,
+    fnName: String = #function,
+    expression: @escaping () throws -> Bool) async -> PollResult<Bool> {
+        let awaiter = NimbleEnvironment.activeInstance.awaiter
+        let result = await awaiter.poll(pollInterval) { () throws -> Bool? in
+            if try expression() {
+                return true
+            }
+            return nil
+        }
+            .timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided)
+            .wait(fnName, file: file, line: line)
+
+        return result
+}
+
+#endif // #if !os(WASI)
+

--- a/Sources/Nimble/Utils/AsyncAwait.swift
+++ b/Sources/Nimble/Utils/AsyncAwait.swift
@@ -124,7 +124,6 @@ internal class AsyncAwaitPromiseBuilder<T> {
         }
         self.trigger.timeoutSource.resume()
         while self.promise.asyncResult.isIncomplete() {
-            // Stopping the run loop does not work unless we run only 1 mode
             await Task.yield()
         }
 
@@ -213,4 +212,3 @@ internal func pollBlock(
 }
 
 #endif // #if !os(WASI)
-

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -295,7 +295,6 @@ internal class Awaiter {
         return DispatchSource.makeTimerSource(flags: .strict, queue: queue)
     }
 
-    @available(*, noasync)
     func performBlock<T>(
         file: FileString,
         line: UInt,
@@ -333,7 +332,6 @@ internal class Awaiter {
                 trigger: trigger)
     }
 
-    @available(*, noasync)
     func poll<T>(_ pollInterval: DispatchTimeInterval, closure: @escaping () throws -> T?) -> AwaitPromiseBuilder<T> {
         let promise = AwaitPromise<T>()
         let timeoutSource = createTimerSource(timeoutQueue)
@@ -365,7 +363,6 @@ internal class Awaiter {
     }
 }
 
-@available(*, noasync)
 internal func pollBlock(
     pollInterval: DispatchTimeInterval,
     timeoutInterval: DispatchTimeInterval,

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -70,7 +70,7 @@ internal class AssertionWaitLock: WaitLock {
     }
 }
 
-internal enum AwaitResult<T> {
+internal enum PollResult<T> {
     /// Incomplete indicates None (aka - this value hasn't been fulfilled yet)
     case incomplete
     /// TimedOut indicates the result reached its defined timeout limit before returning
@@ -106,7 +106,7 @@ internal enum AwaitResult<T> {
 /// Holds the resulting value from an asynchronous expectation.
 /// This class is thread-safe at receiving an "response" to this promise.
 internal final class AwaitPromise<T> {
-    private(set) internal var asyncResult: AwaitResult<T> = .incomplete
+    private(set) internal var asyncResult: PollResult<T> = .incomplete
     private var signal: DispatchSemaphore
 
     init() {
@@ -122,7 +122,8 @@ internal final class AwaitPromise<T> {
     ///
     /// @returns a Bool that indicates if the async result was accepted or rejected because another
     ///          value was received first.
-    func resolveResult(_ result: AwaitResult<T>) -> Bool {
+    @discardableResult
+    func resolveResult(_ result: PollResult<T>) -> Bool {
         if signal.wait(timeout: .now()) == .success {
             self.asyncResult = result
             return true
@@ -132,7 +133,7 @@ internal final class AwaitPromise<T> {
     }
 }
 
-internal struct AwaitTrigger {
+internal struct PollAwaitTrigger {
     let timeoutSource: DispatchSourceTimer
     let actionSource: DispatchSourceTimer?
     let start: () throws -> Void
@@ -145,14 +146,14 @@ internal struct AwaitTrigger {
 internal class AwaitPromiseBuilder<T> {
     let awaiter: Awaiter
     let waitLock: WaitLock
-    let trigger: AwaitTrigger
+    let trigger: PollAwaitTrigger
     let promise: AwaitPromise<T>
 
     internal init(
         awaiter: Awaiter,
         waitLock: WaitLock,
         promise: AwaitPromise<T>,
-        trigger: AwaitTrigger) {
+        trigger: PollAwaitTrigger) {
             self.awaiter = awaiter
             self.waitLock = waitLock
             self.promise = promise
@@ -243,7 +244,7 @@ internal class AwaitPromiseBuilder<T> {
     /// - The async expectation raised an unexpected error (swift)
     ///
     /// The returned AwaitResult will NEVER be .incomplete.
-    func wait(_ fnName: String = #function, file: FileString = #file, line: UInt = #line) -> AwaitResult<T> {
+    func wait(_ fnName: String = #function, file: FileString = #file, line: UInt = #line) -> PollResult<T> {
         waitLock.acquireWaitingLock(
             fnName,
             file: file,
@@ -290,10 +291,11 @@ internal class Awaiter {
             self.timeoutQueue = timeoutQueue
     }
 
-    private func createTimerSource(_ queue: DispatchQueue) -> DispatchSourceTimer {
+    internal func createTimerSource(_ queue: DispatchQueue) -> DispatchSourceTimer {
         return DispatchSource.makeTimerSource(flags: .strict, queue: queue)
     }
 
+    @available(*, noasync)
     func performBlock<T>(
         file: FileString,
         line: UInt,
@@ -302,7 +304,7 @@ internal class Awaiter {
             let promise = AwaitPromise<T>()
             let timeoutSource = createTimerSource(timeoutQueue)
             var completionCount = 0
-            let trigger = AwaitTrigger(timeoutSource: timeoutSource, actionSource: nil) {
+            let trigger = PollAwaitTrigger(timeoutSource: timeoutSource, actionSource: nil) {
                 try closure { result in
                     completionCount += 1
                     if completionCount < 2 {
@@ -331,11 +333,12 @@ internal class Awaiter {
                 trigger: trigger)
     }
 
+    @available(*, noasync)
     func poll<T>(_ pollInterval: DispatchTimeInterval, closure: @escaping () throws -> T?) -> AwaitPromiseBuilder<T> {
         let promise = AwaitPromise<T>()
         let timeoutSource = createTimerSource(timeoutQueue)
         let asyncSource = createTimerSource(asyncQueue)
-        let trigger = AwaitTrigger(timeoutSource: timeoutSource, actionSource: asyncSource) {
+        let trigger = PollAwaitTrigger(timeoutSource: timeoutSource, actionSource: asyncSource) {
             let interval = pollInterval
             asyncSource.schedule(deadline: .now(), repeating: interval, leeway: pollLeeway)
             asyncSource.setEventHandler {
@@ -362,20 +365,23 @@ internal class Awaiter {
     }
 }
 
+@available(*, noasync)
 internal func pollBlock(
     pollInterval: DispatchTimeInterval,
     timeoutInterval: DispatchTimeInterval,
     file: FileString,
     line: UInt,
     fnName: String = #function,
-    expression: @escaping () throws -> Bool) -> AwaitResult<Bool> {
+    expression: @escaping () throws -> Bool) -> PollResult<Bool> {
         let awaiter = NimbleEnvironment.activeInstance.awaiter
         let result = awaiter.poll(pollInterval) { () throws -> Bool? in
             if try expression() {
                 return true
             }
             return nil
-        }.timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided).wait(fnName, file: file, line: line)
+        }
+            .timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided)
+            .wait(fnName, file: file, line: line)
 
         return result
 }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -12,6 +12,284 @@ final class AsyncAwaitTest: XCTestCase {
 
         await expect { try await someAsyncFunction() }.to(equal(1))
     }
+
+    class Error: Swift.Error {}
+    let errorToThrow = Error()
+
+    private func doThrowError() throws -> Int {
+        throw errorToThrow
+    }
+
+    func testToEventuallyPositiveMatches() async {
+        var value = 0
+        deferToMainQueue { value = 1 }
+        await expect { value }.toEventually(equal(1))
+
+        deferToMainQueue { value = 0 }
+        await expect { value }.toEventuallyNot(equal(1))
+    }
+
+    func testToEventuallyNegativeMatches() async {
+        let value = 0
+        await failsWithErrorMessage("expected to eventually not equal <0>, got <0>") {
+            await expect { value }.toEventuallyNot(equal(0))
+        }
+        await failsWithErrorMessage("expected to eventually equal <1>, got <0>") {
+            await expect { value }.toEventually(equal(1))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.toEventually(equal(1))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.toEventuallyNot(equal(0))
+        }
+    }
+
+    func testToEventuallySyncCase() async {
+        await expect(1).toEventually(equal(1), timeout: .seconds(300))
+    }
+
+    @MainActor
+    func testToEventuallyOnMain() async {
+        await expect(1).toEventually(equal(1), timeout: .seconds(300))
+        await expect { usleep(10); return 1 }.toEventually(equal(1))
+    }
+
+    func testToEventuallyWithCustomDefaultTimeout() async {
+        AsyncDefaults.timeout = .seconds(2)
+        defer {
+            AsyncDefaults.timeout = .seconds(1)
+        }
+
+        var value = 0
+
+        let sleepThenSetValueTo: (Int) -> Void = { newValue in
+            Thread.sleep(forTimeInterval: 1.1)
+            value = newValue
+        }
+
+        let task = Task {
+            sleepThenSetValueTo(1)
+        }
+        await expect { value }.toEventually(equal(1))
+
+        let secondTask = Task {
+            sleepThenSetValueTo(0)
+        }
+
+        await expect { value }.toEventuallyNot(equal(1))
+
+        _ = await task.value
+        _ = await secondTask.result
+    }
+
+    func testWaitUntilWithCustomDefaultsTimeout() async {
+        AsyncDefaults.timeout = .seconds(3)
+        defer {
+            AsyncDefaults.timeout = .seconds(1)
+        }
+        await waitUntil { done in
+            Thread.sleep(forTimeInterval: 2.8)
+            done()
+        }
+    }
+
+    func testWaitUntilPositiveMatches() async {
+        await waitUntil { done in
+            done()
+        }
+        await waitUntil { done in
+            deferToMainQueue {
+                done()
+            }
+        }
+    }
+
+    func testWaitUntilTimesOutIfNotCalled() async {
+        await failsWithErrorMessage("Waited more than 1.0 second") {
+            await waitUntil(timeout: .seconds(1)) { _ in return }
+        }
+    }
+
+    func testWaitUntilTimesOutWhenExceedingItsTime() async throws {
+        actor WaitState {
+            var waiting: Bool = true
+
+            func stopWaiting() {
+                waiting = false
+            }
+        }
+
+        let waitState = WaitState()
+
+        await failsWithErrorMessage("Waited more than 0.01 seconds") {
+            await waitUntil(timeout: .milliseconds(10)) { done in
+                Task {
+                    Thread.sleep(forTimeInterval: 0.1)
+                    done()
+                    await waitState.stopWaiting()
+                }
+            }
+        }
+
+        // "clear" runloop to ensure this test doesn't poison other tests
+        repeat {
+            try await Task.sleep(nanoseconds: 200_000_000)
+        } while(await waitState.waiting)
+    }
+
+    func testWaitUntilNegativeMatches() async {
+        await failsWithErrorMessage("expected to equal <2>, got <1>") {
+            await waitUntil { done in
+                Thread.sleep(forTimeInterval: 0.1)
+                expect(1).to(equal(2))
+                done()
+            }
+        }
+    }
+
+    func testWaitUntilDetectsStalledMainThreadActivity() async {
+        let msg = "-waitUntil() timed out but was unable to run the timeout handler because the main thread is unresponsive (0.5 seconds is allow after the wait times out). Conditions that may cause this include processing blocking IO on the main thread, calls to sleep(), deadlocks, and synchronous IPC. Nimble forcefully stopped run loop which may cause future failures in test run."
+        await failsWithErrorMessage(msg) {
+            await waitUntil(timeout: .seconds(1)) { done in
+                Thread.sleep(forTimeInterval: 3.0)
+                done()
+            }
+        }
+    }
+
+    func testWaitUntilErrorsIfDoneIsCalledMultipleTimes() async {
+        await failsWithErrorMessage("waitUntil(..) expects its completion closure to be only called once") {
+            await waitUntil { done in
+                deferToMainQueue {
+                    done()
+                    done()
+                }
+            }
+        }
+    }
+
+    func testWaitUntilDoesNotCompleteBeforeRunLoopIsWaiting() async {
+        // This verifies the fix for a race condition in which `done()` is
+        // called asynchronously on a background thread after the main thread checks
+        // for completion, but prior to `RunLoop.current.run(mode:before:)` being called.
+        // This race condition resulted in the RunLoop locking up.
+        var failed = false
+
+        let timeoutQueue = DispatchQueue(label: "Nimble.waitUntilTest.timeout", qos: .background)
+        let timer = DispatchSource.makeTimerSource(flags: .strict, queue: timeoutQueue)
+        timer.schedule(
+            deadline: DispatchTime.now() + 5,
+            repeating: .never,
+            leeway: .milliseconds(1)
+        )
+        timer.setEventHandler {
+            failed = true
+            fail("Timed out: Main RunLoop stalled.")
+            CFRunLoopStop(CFRunLoopGetMain())
+        }
+        timer.resume()
+
+        for index in 0..<100 {
+            if failed { break }
+            await waitUntil(line: UInt(index)) { done in
+                DispatchQueue(label: "Nimble.waitUntilTest.\(index)").async {
+                    done()
+                }
+            }
+        }
+
+        timer.cancel()
+    }
+
+    final class ClassUnderTest {
+        var deinitCalled: (() -> Void)?
+        var count = 0
+        deinit { deinitCalled?() }
+    }
+
+    func testSubjectUnderTestIsReleasedFromMemory() async {
+        var subject: ClassUnderTest? = ClassUnderTest()
+
+        if let sub = subject {
+            await expect(sub.count).toEventually(equal(0), timeout: .milliseconds(100))
+            await expect(sub.count).toEventuallyNot(equal(1), timeout: .milliseconds(100))
+        }
+
+        await waitUntil(timeout: .milliseconds(500)) { done in
+            subject?.deinitCalled = {
+                done()
+            }
+
+            deferToMainQueue { subject = nil }
+        }
+    }
+
+    func testToNeverPositiveMatches() async {
+        var value = 0
+        deferToMainQueue { value = 1 }
+        await expect { value }.toNever(beGreaterThan(1))
+
+        deferToMainQueue { value = 0 }
+        await expect { value }.neverTo(beGreaterThan(1))
+    }
+
+    func testToNeverNegativeMatches() async {
+        var value = 0
+        await failsWithErrorMessage("expected to never equal <0>, got <0>") {
+            await expect { value }.toNever(equal(0))
+        }
+        await failsWithErrorMessage("expected to never equal <0>, got <0>") {
+            await expect { value }.neverTo(equal(0))
+        }
+        await failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            deferToMainQueue { value = 1 }
+            await expect { value }.toNever(equal(1))
+        }
+        await failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            deferToMainQueue { value = 1 }
+            await expect { value }.neverTo(equal(1))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.toNever(equal(0))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.neverTo(equal(0))
+        }
+    }
+
+    func testToAlwaysPositiveMatches() async {
+        var value = 1
+        deferToMainQueue { value = 2 }
+        await expect { value }.toAlways(beGreaterThan(0))
+
+        deferToMainQueue { value = 2 }
+        await expect { value }.alwaysTo(beGreaterThan(1))
+    }
+
+    func testToAlwaysNegativeMatches() async {
+        var value = 1
+        await failsWithErrorMessage("expected to always equal <0>, got <1>") {
+            await expect { value }.toAlways(equal(0))
+        }
+        await failsWithErrorMessage("expected to always equal <0>, got <1>") {
+            await expect { value }.alwaysTo(equal(0))
+        }
+        await failsWithErrorMessage("expected to always equal <1>, got <0>") {
+            deferToMainQueue { value = 0 }
+            await expect { value }.toAlways(equal(1))
+        }
+        await failsWithErrorMessage("expected to always equal <1>, got <0>") {
+            deferToMainQueue { value = 0 }
+            await expect { value }.alwaysTo(equal(1))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.toAlways(equal(0))
+        }
+        await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
+            await expect { try self.doThrowError() }.alwaysTo(equal(0))
+        }
+    }
 }
 
 #endif

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -186,7 +186,6 @@ final class AsyncAwaitTest: XCTestCase {
         timer.setEventHandler {
             failed = true
             fail("Timed out: Main RunLoop stalled.")
-            CFRunLoopStop(CFRunLoopGetMain())
         }
         timer.resume()
 

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -5,7 +5,6 @@ import Foundation
 @testable import Nimble
 import XCTest
 
-@available(*, noasync)
 func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
@@ -53,7 +52,6 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
     }
 }
 
-@available(*, noasync)
 func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     failsWithErrorMessage(
         [message],
@@ -64,7 +62,6 @@ func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UI
     )
 }
 
-@available(*, noasync)
 func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -139,7 +139,7 @@ func suppressErrors<T>(closure: () -> T) -> T {
 
 func producesStatus<Exp: Expectation, T>(_ status: ExpectationStatus, file: FileString = #file, line: UInt = #line, closure: () -> Exp) where Exp.Value == T {
     let expectation = suppressErrors(closure: closure)
-    
+
     expect(file: file, line: line, expectation.status).to(equal(status))
 }
 

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -5,6 +5,7 @@ import Foundation
 @testable import Nimble
 import XCTest
 
+@available(*, noasync)
 func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     var filePath = file
     var lineNumber = line
@@ -52,8 +53,9 @@ func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line:
     }
 }
 
+@available(*, noasync)
 func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
-    return failsWithErrorMessage(
+    failsWithErrorMessage(
         [message],
         file: file,
         line: line,
@@ -62,8 +64,70 @@ func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UI
     )
 }
 
+@available(*, noasync)
 func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
     failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
+}
+
+func failsWithErrorMessage(_ messages: [String], file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+    var filePath = file
+    var lineNumber = line
+
+    let recorder = AssertionRecorder()
+    await withAssertionHandler(recorder, file: file, line: line, closure: closure)
+
+    for msg in messages {
+        var lastFailure: AssertionRecord?
+        var foundFailureMessage = false
+
+        for assertion in recorder.assertions where assertion.message.stringValue == msg && !assertion.success {
+            lastFailure = assertion
+            foundFailureMessage = true
+            break
+        }
+
+        if foundFailureMessage {
+            continue
+        }
+
+        if preferOriginalSourceLocation {
+            if let failure = lastFailure {
+                filePath = failure.location.file
+                lineNumber = failure.location.line
+            }
+        }
+
+        let message: String
+        if let lastFailure = lastFailure {
+            message = "Got failure message: \"\(lastFailure.message.stringValue)\", but expected \"\(msg)\""
+        } else {
+            let knownFailures = recorder.assertions.filter { !$0.success }.map { $0.message.stringValue }
+            let knownFailuresJoined = knownFailures.joined(separator: ", ")
+            message = """
+                Expected error message (\(msg)), got (\(knownFailuresJoined))
+
+                Assertions Received:
+                \(recorder.assertions)
+                """
+        }
+        NimbleAssertionHandler.assert(false,
+                                      message: FailureMessage(stringValue: message),
+                                      location: SourceLocation(file: filePath, line: lineNumber))
+    }
+}
+
+func failsWithErrorMessage(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+    await failsWithErrorMessage(
+        [message],
+        file: file,
+        line: line,
+        preferOriginalSourceLocation: preferOriginalSourceLocation,
+        closure: closure
+    )
+}
+
+func failsWithErrorMessageForNil(_ message: String, file: FileString = #file, line: UInt = #line, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+    await failsWithErrorMessage("\(message) (use beNil() to match nils)", file: file, line: line, preferOriginalSourceLocation: preferOriginalSourceLocation, closure: closure)
 }
 
 @discardableResult

--- a/Tests/NimbleTests/OnFailureThrowsTest.swift
+++ b/Tests/NimbleTests/OnFailureThrowsTest.swift
@@ -2,22 +2,20 @@ import XCTest
 import Nimble
 
 final class OnFailureThrowsTest: XCTestCase {
-    
+
     enum MyError: Error, Equatable {
         case error1
     }
-    
+
     func testUnexecutedLogsAnError() {
-        
         failsWithErrorMessage("Attempted to call `Expectation.onFailure(throw:) before a predicate has been applied.\nTry using `expect(...).to(...).onFailure(throw: ...`) instead.") {
             try expect(true).onFailure(throw: MyError.error1)
         }
     }
-    
+
     func testPassedDoesNotThrow() {
-        
         let expectation = expect(true).to(beTrue())
-        
+
         expect(try expectation.onFailure(throw: MyError.error1)).notTo(throwError())
     }
 
@@ -28,7 +26,7 @@ final class OnFailureThrowsTest: XCTestCase {
 
         expect(try expectation.onFailure(throw: MyError.error1)).to(throwError(MyError.error1))
     }
-    
+
     func testMixedThrowsAnError() {
         let expectation = suppressErrors {
             expect(true).to(beTrue()).to(beFalse())

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -39,15 +39,19 @@ final class PollingTest: XCTestCase {
         }
     }
 
+    func testToEventuallySyncCase() {
+        expect(1).toEventually(equal(1), timeout: .seconds(300))
+    }
+
     @MainActor
     func testToEventuallyInAsyncContextOnMain() async {
-        expect(1).toEventually(equal(1)) // Fails with 'testToEventuallyInAsyncContextOnMain(): timed out before returning a value'
-        expect { usleep(10); return 1 }.toEventually(equal(1))
+        await expect(1).toEventually(equal(1), timeout: .seconds(300)) // Fails with 'testToEventuallyInAsyncContextOnMain(): timed out before returning a value'
+        await expect { usleep(10); return 1 }.toEventually(equal(1))
     }
 
     func testToEventuallyInAsyncContextOffMain() async {
-        expect(1).toEventually(equal(1))
-        expect { usleep(10); return 1 }.toEventually(equal(1))
+        await expect(1).toEventually(equal(1))
+        await expect { usleep(10); return 1 }.toEventually(equal(1))
     }
 
     func testToEventuallyWithCustomDefaultTimeout() {

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -6,6 +6,7 @@ import Foundation
 import XCTest
 import Nimble
 
+// swiftlint:disable:next type_body_length
 final class PollingTest: XCTestCase {
     class Error: Swift.Error {}
     let errorToThrow = Error()
@@ -41,17 +42,6 @@ final class PollingTest: XCTestCase {
 
     func testToEventuallySyncCase() {
         expect(1).toEventually(equal(1), timeout: .seconds(300))
-    }
-
-    @MainActor
-    func testToEventuallyInAsyncContextOnMain() async {
-        await expect(1).toEventually(equal(1), timeout: .seconds(300)) // Fails with 'testToEventuallyInAsyncContextOnMain(): timed out before returning a value'
-        await expect { usleep(10); return 1 }.toEventually(equal(1))
-    }
-
-    func testToEventuallyInAsyncContextOffMain() async {
-        await expect(1).toEventually(equal(1))
-        await expect { usleep(10); return 1 }.toEventually(equal(1))
     }
 
     func testToEventuallyWithCustomDefaultTimeout() {

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -6,7 +6,7 @@ import Foundation
 import XCTest
 import Nimble
 
-final class AsyncTest: XCTestCase {
+final class PollingTest: XCTestCase {
     class Error: Swift.Error {}
     let errorToThrow = Error()
 
@@ -37,6 +37,17 @@ final class AsyncTest: XCTestCase {
         failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.toEventuallyNot(equal(0))
         }
+    }
+
+    @MainActor
+    func testToEventuallyInAsyncContextOnMain() async {
+        expect(1).toEventually(equal(1)) // Fails with 'testToEventuallyInAsyncContextOnMain(): timed out before returning a value'
+        expect { usleep(10); return 1 }.toEventually(equal(1))
+    }
+
+    func testToEventuallyInAsyncContextOffMain() async {
+        expect(1).toEventually(equal(1))
+        expect { usleep(10); return 1 }.toEventually(equal(1))
     }
 
     func testToEventuallyWithCustomDefaultTimeout() {

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -184,6 +184,7 @@ final class PollingTest: XCTestCase {
     }
 
     func testWaitUntilDoesNotCompleteBeforeRunLoopIsWaiting() {
+#if canImport(Darwin)
         // This verifies the fix for a race condition in which `done()` is
         // called asynchronously on a background thread after the main thread checks
         // for completion, but prior to `RunLoop.current.run(mode:before:)` being called.
@@ -214,6 +215,7 @@ final class PollingTest: XCTestCase {
         }
 
         timer.cancel()
+#endif // canImport(Darwin)
     }
 
     func testWaitUntilAllowsInBackgroundThread() {

--- a/Tests/NimbleTests/StatusTest.swift
+++ b/Tests/NimbleTests/StatusTest.swift
@@ -2,18 +2,18 @@ import XCTest
 import Nimble
 
 final class StatusTest: XCTestCase {
-    
+
     func testUnexecuted() {
         producesStatus(.pending) {
             expect(true)
         }
     }
-    
+
     func testSingleExecution() {
         producesStatus(.passed) {
             expect(true).to(beTrue())
         }
-        
+
         producesStatus(.failed) {
             expect(true).to(beFalse())
         }
@@ -23,25 +23,25 @@ final class StatusTest: XCTestCase {
         producesStatus(.passed) {
             expect(true).to(beTrue()).to(beTrue())
         }
-        
+
         producesStatus(.failed) {
             expect(true).to(beFalse()).to(beFalse())
         }
-        
+
         producesStatus(.mixed) {
             expect(true).to(beTrue()).to(beFalse())
         }
-        
+
         producesStatus(.mixed) {
             expect(true).to(beFalse()).to(beTrue())
         }
     }
-    
+
     func testAsync() {
         producesStatus(.passed) {
             expect(true).toEventually(beTrue())
         }
-        
+
         producesStatus(.failed) {
             expect(true).toEventually(beFalse())
         }


### PR DESCRIPTION
Resolves https://github.com/Quick/Nimble/issues/1006

## The Problem

#1006 is a result of `RunLoop` not being available on Swift Async contexts. I found that, effectively, these methods turn into no-ops if you run them in a swift async context (even if the function itself is not marked as async, if it's in a call hierarchy that has an async function, then that's still an async context). Which means that when the `wait` function continuously calls `RunLoop.run(mode:before:)` to spin the runloop while the matcher polling happens <sup>[Await.swift:264-267](https://github.com/Quick/Nimble/blob/4e2015ae9c4636ed54463a5000094af23fa92524/Sources/Nimble/Utils/Await.swift#L264-L267)</sup>, what's actually happening is that it's just continuously checking `self.promise.asyncResult.isIncomplete()` - almost as if the `run(mode:before:)` call isn't even in there. Which is a problem because using the `RunLoop.run` methods is how you can yield control of the current thread to other tasks.

Backing up a bit further, `toEventually` and `waitUntil` both work by combining 2 dispatch sources with control of the RunLoop. They set up one dispatch source as the timeout source and the other as the polling source (note that `waitUntil` does not use the polling source, but the `done` function argument is the equivalent of a polling source).

The timeout source uses a background queue, and runs once the timeout occurs. When the timeout happens, sets the result of the entire matcher to `.timedOut` and then stops the runloop (there's also logic for detecting a stalled runloop, which is unimportant to this discussion) <sup>[]()</sup>. It's important to note that, because the timeout source is attached to a background queue, its handler is called on a background thread. This is why #1006 is "always results in a timeout error" instead of "hangs the test".

The polling source uses the main queue, and runs every pollInterval. This is where the actual matcher checking happens. This reruns the matcher, checking if it's passed. If the matcher has passed (or thrown an error), then the poller sets the result of the entire matcher to `.completed` and stops the runloop <sup>[`Awaiter.poll`](https://github.com/Quick/Nimble/blob/4e2015ae9c4636ed54463a5000094af23fa92524/Sources/Nimble/Utils/Await.swift#L334-L362)</sup>.

As noted earlier, `waitUntil` doesn't use a polling source. What it does is, when you call the `done` function argument, it runs logic on the main thread which sets the await result to `.completed` and stops the runloop <sup>[`Awaiter.performBlock`](https://github.com/Quick/Nimble/blob/4e2015ae9c4636ed54463a5000094af23fa92524/Sources/Nimble/Utils/Await.swift#L297-L332)</sup>. Which, for this bug, is effectively the same as the "continuously poll the matcher on the main thread" logic that `toEventually` uses. It also shows that the root of the issue is not the dispatch sources.

The dispatch sources work great in either async or synchronous contexts. As I stated earlier, the issue is that, while waiting for the matcher to get polled (or for `done()` to be called), [`AwaitPromiseBuilder.wait`](https://github.com/Quick/Nimble/blob/4e2015ae9c4636ed54463a5000094af23fa92524/Sources/Nimble/Utils/Await.swift#L246-L276) is refusing to yield control of the main thread.

For those curious why `toEventually` works when called in an async context that's not the main actor? Because in that case, `wait` is not running on the main thread. It's still pegging the CPU and refusing to yield control, but since it's not running on the main thread, the only consequence is unnecessarily using resources. So, it's spinning and continuously checking if the m matcher has completed/`done()` has been called, but not blocking the main thread.

## The Solution

So, the solution? Stop using `RunLoop.run()` to yield control of the main thread.

Simpler said then done. The only other way I know of is to use `Task.yield`, but that would require me to make `Wait` async, and everything that calls it also `async`. Which is exactly what I did. I effectively duplicated the await methods, marked the old ones as noasync, and adjusted these new ones to work well in an async world.

The async version of `toEventually` uses a new async version of `execute`. The noasync version uses a Predicate under the hood so that it can re-use `execute`. Given that predicates aren't (yet?) Async-aware, I couldn't use that same approach. So, instead, this `async` version of execute is almost entirely the same as the synchronous version, but instead of taking in a predicate, it takes in a predicateExecutor (which is an async function), which returns the predicate result. This allows me to use an async version of [`Polling/async`](https://github.com/Quick/Nimble/blob/4e2015ae9c4636ed54463a5000094af23fa92524/Sources/Nimble/Polling.swift#L18) (this PR renames that function to `poll`) to call into the now async-aware versions of the old polling logic.

This was a wild bug.