### PR TITLE
Drop swift 5.6

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1", "14.0.1"]
+        xcode: ["14.0.1"]
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
     steps:
@@ -29,7 +29,6 @@ jobs:
     strategy:
       matrix:
         container:
-          - swift:5.6
           - swift:5.7
           # - swiftlang/swift:nightly
       fail-fast: false

--- a/.github/workflows/ci-xcode.yml
+++ b/.github/workflows/ci-xcode.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1", "14.0.1"]
+        xcode: ["14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: ["13.3.1", "14.0.1"]
+        xcode: ["14.0.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,20 @@ some "ground rules":
   issues or pull requests submitted to the project. Please provide kind,
   constructive feedback. Please don't be sarcastic or snarky.
 
+### Updating Minimum Swift & OS Versions
+
+When updating the minimum Swift (or Xcode) version, you only need to update:
+
+- Package.swift
+- The Github actions workflows.
+
+When updating the minimum OS versions, you need to update the above 2 options as well as:
+
+- Nimble.podspec
+- Nimble.xcodeproj (update the OS versions in the Nimble project, not for each individual target)
+
+In addition, be sure to check if there's any relevant documentation to update, and update it.
+
 ### Creating a Release
 
 The process is relatively straight forward, but here's is a useful checklist for tagging:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
The developer experience, especially with `toEventually` is pretty bad. 5.6 is fine for Quick, but Nimble should require 5.7.

In the PR marking sync versions of toEventually as noasync, I'll give a better explanation. This is just setting up for that.

This PR also adds documentation for what to update for the next time someone updates swift and/or OS versions.