### PR TITLE
Mark the sync versions of toEventually as nonasync

### DIFF
--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -116,6 +116,7 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: DispatchTi
 /// 
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
+@available(*, noasync, message: "the sync version of `waitUntil` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
 public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -99,6 +99,7 @@ extension SyncExpectation {
     /// @warning
     /// This form of `toEventually` does not work in any kind of async context. Use the async form of `toEventually` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `toEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -131,6 +132,7 @@ extension SyncExpectation {
     /// This form of `toEventuallyNot` does not work in any kind of async context.
     /// Use the async form of `toEventuallyNot` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `toEventuallyNot` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -165,6 +167,7 @@ extension SyncExpectation {
     /// This form of `toNotEventually` does not work in any kind of async context.
     /// Use the async form of `toNotEventually` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `toNotEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
@@ -180,6 +183,7 @@ extension SyncExpectation {
     /// This form of `toNever` does not work in any kind of async context.
     /// Use the async form of `toNever` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `toNever` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -214,6 +218,7 @@ extension SyncExpectation {
     /// This form of `neverTo` does not work in any kind of async context.
     /// Use the async form of `neverTo` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `neverTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
@@ -229,6 +234,7 @@ extension SyncExpectation {
     /// This form of `toAlways` does not work in any kind of async context.
     /// Use the async form of `toAlways` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `toAlways` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
@@ -263,6 +269,7 @@ extension SyncExpectation {
     /// This form of `alwaysTo` does not work in any kind of async context.
     /// Use the async form of `alwaysTo` if you are running tests in an async context.
     @discardableResult
+    @available(*, noasync, message: "the sync version of `alwaysTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
     public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }


### PR DESCRIPTION
I wish we could actually make this an error, but a warning will have to suffice.

This fixes the developer experience bug where the following will compile perfectly fine, but the test will fail with a timeout error:

```swift
class MyXCTestCase: XCTestcase {
    @MainActor func test_myExample() async {
        expect(1).toEventually(equal(1))
    }
}
```

Which is the [exact same issue](https://github.com/Quick/Nimble/issues) I tried to avoid in https://github.com/Quick/Nimble/pull/1007.

Swift offers no other way to mark a function as unavailable in async contexts except through the `@available(*, noasync)` mechanism. Which, in Swift 5.7, emits a warning, not an error. But a warning is better than nothing, so we're doing this.

Note for historical purposes: We shipped Nimble 11 without this because I thought it was more important to have swift version parity with Quick.