### PR TITLE
Use uncached expression in the async versions of toEventually

### DIFF
--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -60,7 +60,7 @@ extension SyncExpectation {
                     timeout: timeout,
                     poll: pollInterval,
                     fnName: "toEventually") {
-                        try predicate.satisfies(expression)
+                        try predicate.satisfies(expression.withoutCaching())
                     }
             }
         return verify(pass, msg)
@@ -84,7 +84,7 @@ extension SyncExpectation {
                     timeout: timeout,
                     poll: pollInterval,
                     fnName: "toEventuallyNot") {
-                        try predicate.satisfies(expression)
+                        try predicate.satisfies(expression.withoutCaching())
                     }
             }
         return verify(pass, msg)
@@ -117,7 +117,7 @@ extension SyncExpectation {
                     timeout: until,
                     poll: pollInterval,
                     fnName: "toNever") {
-                        try predicate.satisfies(expression)
+                        try predicate.satisfies(expression.withoutCaching())
                     }
             }
         return verify(pass, msg)
@@ -150,7 +150,7 @@ extension SyncExpectation {
                     timeout: until,
                     poll: pollInterval,
                     fnName: "toAlways") {
-                        try predicate.satisfies(expression)
+                        try predicate.satisfies(expression.withoutCaching())
                     }
             }
         return verify(pass, msg)

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -140,7 +140,7 @@ final class AsyncAwaitTest: XCTestCase {
         await failsWithErrorMessage("Waited more than 0.01 seconds") {
             await waitUntil(timeout: .milliseconds(10)) { done in
                 Task {
-                    Thread.sleep(forTimeInterval: 0.1)
+                    _ = try? await Task.sleep(nanoseconds: 100_000_000)
                     done()
                     await waitState.stopWaiting()
                 }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -49,6 +49,21 @@ final class AsyncAwaitTest: XCTestCase {
         await expect(1).toEventually(equal(1), timeout: .seconds(300))
     }
 
+    func testToEventuallyWaitingOnMainTask() async {
+        class EncapsulatedValue {
+            static var executed = false
+
+            static func execute() {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    Self.executed = true
+                }
+            }
+        }
+
+        EncapsulatedValue.execute()
+        await expect(EncapsulatedValue.executed).toEventually(beTrue())
+    }
+
     @MainActor
     func testToEventuallyOnMain() async {
         await expect(1).toEventually(equal(1), timeout: .seconds(300))


### PR DESCRIPTION
Fixes https://github.com/Quick/Nimble/issues/1015

Forgot to use `uncachedExpression()` when sending the expression to be verified by the matcher. D'oh!