### PR TITLE
Remove autoclosure tag with async expectations

### DIFF
--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -11,7 +11,7 @@ private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) 
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () async throws -> T?) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping () async throws -> T?) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: Expression(
             expression: await convertAsyncExpression(expression),
@@ -20,7 +20,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T)) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: Expression(
             expression: await convertAsyncExpression(expression()),
@@ -29,7 +29,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: Expression(
             expression: await convertAsyncExpression(expression()),
@@ -38,7 +38,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
+public func expect(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: Expression(
             expression: await convertAsyncExpression(expression()),

--- a/Tests/NimbleTests/DSLTest.swift
+++ b/Tests/NimbleTests/DSLTest.swift
@@ -45,14 +45,6 @@ final class DSLTest: XCTestCase {
         let _: SyncExpectation<Void> = expect { () -> Void in return () }
     }
 
-    func testExpectAsyncAutoclosureNonThrowing() async throws {
-        let _: AsyncExpectation<Int> = await expect(await nonThrowingAsyncInt())
-    }
-
-    func testExpectAsyncAutoclosureThrowing() async throws {
-        let _: AsyncExpectation<Int> = await expect(try await throwingAsyncInt())
-    }
-
     func testExpectAsyncClosure() async throws {
         let _: AsyncExpectation<Int> = await expect { 1 }
         let _: AsyncExpectation<Int> = await expect { await nonThrowingAsyncInt() }
@@ -69,5 +61,12 @@ final class DSLTest: XCTestCase {
 
         let _: AsyncExpectation<Void> = await expect { return () }
         let _: AsyncExpectation<Void> = await expect { () -> Void in return () }
+    }
+
+    func testExpectCombinedSyncAndAsyncExpects() async throws {
+        await expect { await nonThrowingAsyncInt() }.to(equal(1))
+        expect(1).to(equal(1))
+
+        expect { nonThrowingInt() }.to(equal(1))
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Quick/Nimble/issues/1019

The autoclosure with async expect was causing the swift compiler to assume all expect calls where async expects if you used any kind of async functionality in your test

Breaking change, but I'm going to release it as a minor update version update (11.2.0)
