### PR TITLE
Rename AsyncDefaults to PollingDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,17 +491,17 @@ the default timeout and poll interval values. This can be done as follows:
 // Swift
 
 // Increase the global timeout to 5 seconds:
-Nimble.AsyncDefaults.timeout = .seconds(5)
+Nimble.PollingDefaults.timeout = .seconds(5)
 
 // Slow the polling interval to 0.1 seconds:
-Nimble.AsyncDefaults.pollInterval = .milliseconds(100)
+Nimble.PollingDefaults.pollInterval = .milliseconds(100)
 ```
 
 You can set these globally at test startup in two ways:
 
 #### Quick
 
-If you use [Quick](https://github.com/Quick/Quick), add a [`QuickConfiguration` subclass](https://github.com/Quick/Quick/blob/main/Documentation/en-us/ConfiguringQuick.md) which sets your desired `AsyncDefaults`.
+If you use [Quick](https://github.com/Quick/Quick), add a [`QuickConfiguration` subclass](https://github.com/Quick/Quick/blob/main/Documentation/en-us/ConfiguringQuick.md) which sets your desired `PollingDefaults`.
 
 ```swift
 import Quick
@@ -509,8 +509,8 @@ import Nimble
 
 class AsyncConfiguration: QuickConfiguration {
     override class func configure(_ configuration: QCKConfiguration) {
-        Nimble.AsyncDefaults.timeout = .seconds(5)
-        Nimble.AsyncDefaults.pollInterval = .milliseconds(100)
+        Nimble.PollingDefaults.timeout = .seconds(5)
+        Nimble.PollingDefaults.pollInterval = .milliseconds(100)
     }
 }
 ```
@@ -550,13 +550,13 @@ class TestSetup: NSObject {
 
 class AsyncConfigurationTestObserver: NSObject, XCTestObserver {
     func testBundleWillStart(_ testBundle: Bundle) {
-        Nimble.AsyncDefaults.timeout = .seconds(5)
-        Nimble.AsyncDefaults.pollInterval = .milliseconds(100)
+        Nimble.PollingDefaults.timeout = .seconds(5)
+        Nimble.PollingDefaults.pollInterval = .milliseconds(100)
     }
 }
 ```
 
-In Linux, you can implement `LinuxMain` to set the AsyncDefaults before calling `XCTMain`.
+In Linux, you can implement `LinuxMain` to set the PollingDefaults before calling `XCTMain`.
 
 ## Objective-C Support
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ If you use [Quick](https://github.com/Quick/Quick), add a [`QuickConfiguration` 
 import Quick
 import Nimble
 
-class AsyncConfiguration: QuickConfiguration {
+class PollingConfiguration: QuickConfiguration {
     override class func configure(_ configuration: QCKConfiguration) {
         Nimble.PollingDefaults.timeout = .seconds(5)
         Nimble.PollingDefaults.pollInterval = .milliseconds(100)
@@ -544,11 +544,11 @@ import Nimble
 @objc
 class TestSetup: NSObject {
 	override init() {
-		XCTestObservationCenter.shared.register(AsyncConfigurationTestObserver())
+		XCTestObservationCenter.shared.register(PollingConfigurationTestObserver())
 	}
 }
 
-class AsyncConfigurationTestObserver: NSObject, XCTestObserver {
+class PollingConfigurationTestObserver: NSObject, XCTestObserver {
     func testBundleWillStart(_ testBundle: Bundle) {
         Nimble.PollingDefaults.timeout = .seconds(5)
         Nimble.PollingDefaults.pollInterval = .milliseconds(100)

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -87,7 +87,7 @@ public func expecta(file: FileString = #file, line: UInt = #line, _ expression: 
 ///
 /// @warning
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
-public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) async -> Void) async {
+public func waitUntil(timeout: NimbleTimeInterval = PollingDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) async -> Void) async {
     await throwableUntil(timeout: timeout) { done in
         await action(done)
     }
@@ -100,7 +100,7 @@ public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file:
 ///
 /// @warning
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
-public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) async {
+public func waitUntil(timeout: NimbleTimeInterval = PollingDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) async {
     await throwableUntil(timeout: timeout, file: file, line: line) { done in
         action(done)
     }

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -117,7 +117,7 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: NimbleTime
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
 @available(*, noasync, message: "the sync version of `waitUntil` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
+public func waitUntil(timeout: NimbleTimeInterval = PollingDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -59,7 +59,7 @@ extension SyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let asyncExpression = expression.toAsyncExpression()
@@ -85,7 +85,7 @@ extension SyncExpectation {
     /// Tests the actual value using a matcher to not match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let asyncExpression = expression.toAsyncExpression()
@@ -113,14 +113,14 @@ extension SyncExpectation {
     ///
     /// Alias of toEventuallyNot()
     @discardableResult
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to never match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
         let asyncExpression = expression.toAsyncExpression()
 
@@ -147,14 +147,14 @@ extension SyncExpectation {
     ///
     /// Alias of toNever()
     @discardableResult
-    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to always match by checking
     /// continusouly at each pollInterval until the timeout is reached
     @discardableResult
-    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
         let asyncExpression = expression.toAsyncExpression()
 
@@ -181,7 +181,7 @@ extension SyncExpectation {
     ///
     /// Alias of toAlways()
     @discardableResult
-    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }
@@ -190,7 +190,7 @@ extension AsyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -214,7 +214,7 @@ extension AsyncExpectation {
     /// Tests the actual value using a matcher to not match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -240,14 +240,14 @@ extension AsyncExpectation {
     ///
     /// Alias of toEventuallyNot()
     @discardableResult
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to never match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -273,14 +273,14 @@ extension AsyncExpectation {
     ///
     /// Alias of toNever()
     @discardableResult
-    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to always match by checking
     /// continusouly at each pollInterval until the timeout is reached
     @discardableResult
-    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -306,7 +306,7 @@ extension AsyncExpectation {
     ///
     /// Alias of toAlways()
     @discardableResult
-    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -5,7 +5,36 @@ import Dispatch
 
 /// If you are running on a slower machine, it could be useful to increase the default timeout value
 /// or slow down poll interval. Default timeout interval is 1, and poll interval is 0.01.
+///
+/// - Warning: This has been renamed to ``PollingDefaults``. Starting in Nimble 13, the deprecation warning will change to a compiler error (removed). In Nimble 14, `AsyncDefaults` will be removed entirely.
+///
+/// For the time being, `AsyncDefaults` will function the same.
+/// However, `AsyncDefaults` will be removed in a future release.
+@available(*, deprecated, renamed: "PollingDefaults")
 public struct AsyncDefaults {
+    public static var timeout: NimbleTimeInterval {
+        get {
+            PollingDefaults.timeout
+        }
+        set {
+            PollingDefaults.timeout = newValue
+        }
+    }
+    public static var pollInterval: NimbleTimeInterval {
+        get {
+            PollingDefaults.pollInterval
+        }
+        set {
+            PollingDefaults.pollInterval = newValue
+        }
+    }
+}
+
+/// If you are running on a slower machine, it could be useful to increase the default timeout value
+/// or slow down poll interval. Default timeout interval is 1, and poll interval is 0.01.
+///
+/// Note: This used to be known as ``AsyncDefaults``.
+public struct PollingDefaults {
     public static var timeout: NimbleTimeInterval = .seconds(1)
     public static var pollInterval: NimbleTimeInterval = .milliseconds(10)
 }
@@ -100,7 +129,7 @@ extension SyncExpectation {
     /// This form of `toEventually` does not work in any kind of async context. Use the async form of `toEventually` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -133,7 +162,7 @@ extension SyncExpectation {
     /// Use the async form of `toEventuallyNot` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toEventuallyNot` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -168,7 +197,7 @@ extension SyncExpectation {
     /// Use the async form of `toNotEventually` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toNotEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
@@ -184,7 +213,7 @@ extension SyncExpectation {
     /// Use the async form of `toNever` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toNever` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -219,7 +248,7 @@ extension SyncExpectation {
     /// Use the async form of `neverTo` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `neverTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
@@ -235,7 +264,7 @@ extension SyncExpectation {
     /// Use the async form of `toAlways` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toAlways` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -270,7 +299,7 @@ extension SyncExpectation {
     /// Use the async form of `alwaysTo` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `alwaysTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -137,9 +137,9 @@ final class AsyncAwaitTest: XCTestCase {
     }
 
     func testToEventuallyWithCustomDefaultTimeout() async {
-        AsyncDefaults.timeout = .seconds(2)
+        PollingDefaults.timeout = .seconds(2)
         defer {
-            AsyncDefaults.timeout = .seconds(1)
+            PollingDefaults.timeout = .seconds(1)
         }
 
         var value = 0
@@ -165,9 +165,9 @@ final class AsyncAwaitTest: XCTestCase {
     }
 
     func testWaitUntilWithCustomDefaultsTimeout() async {
-        AsyncDefaults.timeout = .seconds(3)
+        PollingDefaults.timeout = .seconds(3)
         defer {
-            AsyncDefaults.timeout = .seconds(1)
+            PollingDefaults.timeout = .seconds(1)
         }
         await waitUntil { done in
             Thread.sleep(forTimeInterval: 2.8)

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -45,9 +45,9 @@ final class PollingTest: XCTestCase {
     }
 
     func testToEventuallyWithCustomDefaultTimeout() {
-        AsyncDefaults.timeout = .seconds(2)
+        PollingDefaults.timeout = .seconds(2)
         defer {
-            AsyncDefaults.timeout = .seconds(1)
+            PollingDefaults.timeout = .seconds(1)
         }
 
         var value = 0
@@ -69,9 +69,9 @@ final class PollingTest: XCTestCase {
     }
 
     func testWaitUntilWithCustomDefaultsTimeout() {
-        AsyncDefaults.timeout = .seconds(3)
+        PollingDefaults.timeout = .seconds(3)
         defer {
-            AsyncDefaults.timeout = .seconds(1)
+            PollingDefaults.timeout = .seconds(1)
         }
         waitUntil { done in
             Thread.sleep(forTimeInterval: 2.8)


### PR DESCRIPTION
Forgot about this until I was writing the documentation about configuring AsyncDefaults.

Given the overall rename of the toEventually and waitUntil version of async to the more accurate "polling", it makes logical sense to rename the AsyncDefaults closure to PollingDefaults.

This is implemented to be just a deprecation warning with a replaced. The functionality is still the same.
My idea is to keep the AsyncDefaults struct around for a bit longer.
After Nimble 12 is released, I'll submit a PR changing the deprecation warning to a removed. After Nimble 13, I'll fully remove AsyncDefaults.

This feels like a more-than-fair enough offramp.