### PR TITLE
Ensure that stringify'ing an expression as part of the async/await polling infrastructure always happens on the main thread

### DIFF
--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -1,5 +1,6 @@
 import Dispatch
 
+@MainActor
 private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to: String, description: String?, predicateExecutor: () async throws -> PredicateResult) async -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.userDescription = description


### PR DESCRIPTION
Whenever you trip the main thread checker in test, it outputs a backtrace of what called what to lead to the main thread checker being tripped. A bunch of test result parsers treat any backtrace information as a test crash, even though the test isn't actually crashing.

This prevents Nimble from accidentally tripping the main thread checking when stringifying the expression being checked in the async/await version of toEventually, by forcing that particular function to run on the main actor.

In a smoke test, I found that this does work, and I didn't notice any issues with doing this.