### PR TITLE
Fixes the build on Xcode 14.3b2

### DIFF
--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -68,27 +68,27 @@ NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBPredicate *NMB_beLessThanOrEqualTo(NSNumber
     return [NMBPredicate beLessThanOrEqualToMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beTruthy() {
+NIMBLE_EXPORT NMBPredicate *NMB_beTruthy(void) {
     return [NMBPredicate beTruthyMatcher];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beFalsy() {
+NIMBLE_EXPORT NMBPredicate *NMB_beFalsy(void) {
     return [NMBPredicate beFalsyMatcher];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beTrue() {
+NIMBLE_EXPORT NMBPredicate *NMB_beTrue(void) {
     return [NMBPredicate beTrueMatcher];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beFalse() {
+NIMBLE_EXPORT NMBPredicate *NMB_beFalse(void) {
     return [NMBPredicate beFalseMatcher];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beNil() {
+NIMBLE_EXPORT NMBPredicate *NMB_beNil(void) {
     return [NMBPredicate beNilMatcher];
 }
 
-NIMBLE_EXPORT NMBPredicate *NMB_beEmpty() {
+NIMBLE_EXPORT NMBPredicate *NMB_beEmpty(void) {
     return [NMBPredicate beEmptyMatcher];
 }
 
@@ -142,7 +142,7 @@ NIMBLE_EXPORT NMBPredicate *NMB_satisfyAllOfWithMatchers(id matchers) {
     return [NMBPredicate satisfyAllOfMatcher:matchers];
 }
 
-NIMBLE_EXPORT NMBObjCRaiseExceptionPredicate *NMB_raiseException() {
+NIMBLE_EXPORT NMBObjCRaiseExceptionPredicate *NMB_raiseException(void) {
     return [NMBPredicate raiseExceptionMatcher];
 }
 


### PR DESCRIPTION
### What behavior was changed?
None. 

### What code was refactored / updated to support this change?
Updates made to ObjC func implementations. More info: https://developer.apple.com/forums/thread/725753

### What issues are related to this PR? Or why was this change introduced?
Building Nimble in Xcode 14.3b2 (14E5207e) is failing due to 

```
.../nimble/Sources/NimbleObjectiveC/DSL.m:71:41: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
NIMBLE_EXPORT NMBPredicate *NMB_beTruthy() {
                                        ^
                                         void
```
---
- [x] Does this have tests? — NO
- [x] Does this have documentation? — NO
- [x] Does this break the public API (Requires major version bump)? — NO
- [x] Is this a new feature (Requires minor version bump)? — NO
