### PR TITLE
Fix wasm build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: swiftwasm/swiftwasm-action@v5.4
+      - uses: swiftwasm/swiftwasm-action@v5.7

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -1,4 +1,6 @@
+#if !os(WASI)
 import Dispatch
+#endif
 
 private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) async -> (() throws -> T) {
     let result: Result<T, Error>
@@ -45,6 +47,8 @@ public func expect(file: FileString = #file, line: UInt = #line, _ expression: (
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
+
+#if !os(WASI)
 
 /// Wait asynchronously until the done closure is called or the timeout has been reached.
 ///
@@ -113,3 +117,5 @@ private func throwableUntil(
             break
         }
 }
+
+#endif // #if !os(WASI)

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -1,3 +1,5 @@
+#if !os(WASI)
+
 import Dispatch
 
 @MainActor
@@ -166,3 +168,5 @@ extension SyncExpectation {
         return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }
+
+#endif // #if !os(WASI)

--- a/Tests/NimbleTests/StatusTest.swift
+++ b/Tests/NimbleTests/StatusTest.swift
@@ -37,6 +37,7 @@ final class StatusTest: XCTestCase {
         }
     }
 
+    #if !os(WASI)
     func testAsync() {
         producesStatus(.passed) {
             expect(true).toEventually(beTrue())
@@ -46,4 +47,5 @@ final class StatusTest: XCTestCase {
             expect(true).toEventually(beFalse())
         }
     }
+    #endif
 }


### PR DESCRIPTION
refs:
- #889 
- https://book.swiftwasm.org/getting-started/porting.html#swift-foundation-and-dispatch

Dispatch isn't supported on SwiftWasm, so excludes Dispatch-related codes from wasm build.

Also updates swiftwasm-action to 5.7.