### PR TITLE
Allow usage of toEventually with async expressions

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -320,6 +320,10 @@
 		857D184F2536124400D8693A /* BeWithinTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D184D2536123F00D8693A /* BeWithinTest.swift */; };
 		857D18502536124400D8693A /* BeWithinTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D184D2536123F00D8693A /* BeWithinTest.swift */; };
 		857D18512536124500D8693A /* BeWithinTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D184D2536123F00D8693A /* BeWithinTest.swift */; };
+		892FDF1329D3EA7700523A80 /* AsyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892FDF1229D3EA7700523A80 /* AsyncExpression.swift */; };
+		892FDF1429D3EA7700523A80 /* AsyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892FDF1229D3EA7700523A80 /* AsyncExpression.swift */; };
+		892FDF1529D3EA7700523A80 /* AsyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892FDF1229D3EA7700523A80 /* AsyncExpression.swift */; };
+		892FDF1629D3EA7700523A80 /* AsyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892FDF1229D3EA7700523A80 /* AsyncExpression.swift */; };
 		898F28B025D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
 		898F28B125D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
 		898F28B225D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
@@ -768,6 +772,7 @@
 		7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSatisfyAnyOfTest.m; sourceTree = "<group>"; };
 		857D1848253610A900D8693A /* BeWithin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeWithin.swift; sourceTree = "<group>"; };
 		857D184D2536123F00D8693A /* BeWithinTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeWithinTest.swift; sourceTree = "<group>"; };
+		892FDF1229D3EA7700523A80 /* AsyncExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpression.swift; sourceTree = "<group>"; };
 		898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysFailMatcher.swift; sourceTree = "<group>"; };
 		899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTest.swift; sourceTree = "<group>"; };
 		899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSL+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -946,6 +951,7 @@
 			isa = PBXGroup;
 			children = (
 				1FD8CD041968AB07008ED995 /* Adapters */,
+				892FDF1229D3EA7700523A80 /* AsyncExpression.swift */,
 				1FD8CD081968AB07008ED995 /* DSL.swift */,
 				899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */,
 				DA9E8C811A414BB9002633C2 /* DSL+Wait.swift */,
@@ -1605,6 +1611,7 @@
 				1FDBD8671AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				AE4BA9AD1C88DDB500B73906 /* Errors.swift in Sources */,
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
+				892FDF1429D3EA7700523A80 /* AsyncExpression.swift in Sources */,
 				0477153623B740B700402D4E /* DispatchTimeInterval.swift in Sources */,
 				7A6AB2C51E7F628900A2F694 /* ToSucceed.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -1778,6 +1785,7 @@
 				1F91DD331C74BF61002C309F /* BeVoid.swift in Sources */,
 				1FCF91551C61C8A400B15DCB /* PostNotification.swift in Sources */,
 				1F5DF1831BDCA0F500C3A531 /* Contain.swift in Sources */,
+				892FDF1529D3EA7700523A80 /* AsyncExpression.swift in Sources */,
 				1F5DF1851BDCA0F500C3A531 /* Equal.swift in Sources */,
 				F8A1BE311CB3710900031679 /* XCTestObservationCenter+Register.m in Sources */,
 				1FE661591E6574E30035F243 /* ExpectationMessage.swift in Sources */,
@@ -1912,6 +1920,7 @@
 				1F1871E71CA8A18400A34BF2 /* Polling.swift in Sources */,
 				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				AE4BA9AE1C88DDB500B73906 /* Errors.swift in Sources */,
+				892FDF1329D3EA7700523A80 /* AsyncExpression.swift in Sources */,
 				0477153523B740AD00402D4E /* DispatchTimeInterval.swift in Sources */,
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,
@@ -2085,6 +2094,7 @@
 				D95F895A267EA205004B1B4D /* Expression.swift in Sources */,
 				D95F897A267EA20A004B1B4D /* BeNil.swift in Sources */,
 				D95F895E267EA205004B1B4D /* DSL.swift in Sources */,
+				892FDF1629D3EA7700523A80 /* AsyncExpression.swift in Sources */,
 				D95F897D267EA20A004B1B4D /* BeAKindOf.swift in Sources */,
 				D95F8977267EA20A004B1B4D /* MatchError.swift in Sources */,
 				D95F8987267EA20E004B1B4D /* PollAwait.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -317,9 +317,28 @@ async context. For XCTest, this is as simple as marking your test function with
 `async`. If you use Quick, then you don't need to do anything because as of
 Quick 6, all tests are executed in an async context.
 
+To avoid a compiler errors when using synchronous `expect` in asynchronous contexts,
+`expect` with async expressions does not support autoclosures. However, the `expecta`
+(expect async) function is provided as an alternative, which does support autoclosures.
+
+```swift
+// Swift
+await expect(await aFunctionReturning1()).to(equal(1)))
+```
+
+Similarly, if you're ever in a situation where you want to force the compiler to
+produce a `SyncExpectation`, you can use the `expects` (expect sync) function to
+produce a `SyncExpectation`. Like so:
+
+```swift
+// Swift
+expects(someNonAsyncFunction()).to(equal(1)))
+
+expects(await someAsyncFunction()).to(equal(1)) // Compiler error: 'async' call in an autoclosure that does not support concurrency
+```
+
 Note: Async/Await support is different than the `toEventually`/`toEventuallyNot`
-feature described below. In fact, async/await is not supported in expectations
-that make use of `toEventually` or `toEventuallyNot`.
+feature described below.
 
 ## Polling Expectations
 
@@ -356,6 +375,22 @@ In the above example, `ocean` is constantly re-evaluated. If it ever
 contains dolphins and whales, the expectation passes. If `ocean` still
 doesn't contain them, even after being continuously re-evaluated for one
 whole second, the expectation fails.
+
+`toEventaully` et. al. now also supports async expectations. For example, the following test is now supported:
+
+```swift
+actor MyActor {
+    private var counter = 0
+
+    func access() -> Int {
+        counter += 1
+        return counter
+    }
+}
+
+let subject = MyActor()
+await expect { await subject.access() }.toEventually(equal(2))
+```
 
 You can also test that a value always or never matches throughout the length of the timeout. Use `toNever` and `toAlways` for this:
 

--- a/Sources/Nimble/AsyncExpression.swift
+++ b/Sources/Nimble/AsyncExpression.swift
@@ -1,0 +1,114 @@
+// Memoizes the given closure, only calling the passed
+// closure once; even if repeat calls to the returned closure
+private func memoizedClosure<T>(_ closure: @escaping () async throws -> T) -> (Bool) async throws -> T {
+    var cache: T?
+    return { withoutCaching in
+        if withoutCaching || cache == nil {
+            cache = try await closure()
+        }
+        return cache!
+    }
+}
+
+/// Expression represents the closure of the value inside expect(...).
+/// Expressions are memoized by default. This makes them safe to call
+/// evaluate() multiple times without causing a re-evaluation of the underlying
+/// closure.
+///
+/// - Warning: Since the closure can be any code, Objective-C code may choose
+///          to raise an exception. Currently, SyncExpression does not memoize
+///          exception raising.
+///
+/// This provides a common consumable API for matchers to utilize to allow
+/// Nimble to change internals to how the captured closure is managed.
+public struct AsyncExpression<Value> {
+    internal let _expression: (Bool) async throws -> Value?
+    internal let _withoutCaching: Bool
+    public let location: SourceLocation
+    public let isClosure: Bool
+
+    /// Creates a new expression struct. Normally, expect(...) will manage this
+    /// creation process. The expression is memoized.
+    ///
+    /// - Parameter expression: The closure that produces a given value.
+    /// - Parameter location: The source location that this closure originates from.
+    /// - Parameter isClosure: A bool indicating if the captured expression is a
+    ///                  closure or internally produced closure. Some matchers
+    ///                  may require closures. For example, toEventually()
+    ///                  requires an explicit closure. This gives Nimble
+    ///                  flexibility if @autoclosure behavior changes between
+    ///                  Swift versions. Nimble internals always sets this true.
+    public init(expression: @escaping () async throws -> Value?, location: SourceLocation, isClosure: Bool = true) {
+        self._expression = memoizedClosure(expression)
+        self.location = location
+        self._withoutCaching = false
+        self.isClosure = isClosure
+    }
+
+    /// Creates a new expression struct. Normally, expect(...) will manage this
+    /// creation process.
+    ///
+    /// - Parameter expression: The closure that produces a given value.
+    /// - Parameter location: The source location that this closure originates from.
+    /// - Parameter withoutCaching: Indicates if the struct should memoize the given
+    ///                       closure's result. Subsequent evaluate() calls will
+    ///                       not call the given closure if this is true.
+    /// - Parameter isClosure: A bool indicating if the captured expression is a
+    ///                  closure or internally produced closure. Some matchers
+    ///                  may require closures. For example, toEventually()
+    ///                  requires an explicit closure. This gives Nimble
+    ///                  flexibility if @autoclosure behavior changes between
+    ///                  Swift versions. Nimble internals always sets this true.
+    public init(memoizedExpression: @escaping (Bool) async throws -> Value?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
+        self._expression = memoizedExpression
+        self.location = location
+        self._withoutCaching = withoutCaching
+        self.isClosure = isClosure
+    }
+
+    /// Creates a new synchronous expression, for use in Predicates.
+    public func toSynchronousExpression() async -> Expression<Value> {
+        let value: Result<Value?, Error>
+        do {
+            value = .success(try await _expression(self._withoutCaching))
+        } catch {
+            value = .failure(error)
+        }
+        return Expression(
+            memoizedExpression: { _ in try value.get() },
+            location: location,
+            withoutCaching: false,
+            isClosure: isClosure
+        )
+    }
+
+    /// Returns a new Expression from the given expression. Identical to a map()
+    /// on this type. This should be used only to typecast the Expression's
+    /// closure value.
+    ///
+    /// The returned expression will preserve location and isClosure.
+    ///
+    /// - Parameter block: The block that can cast the current Expression value to a
+    ///              new type.
+    public func cast<U>(_ block: @escaping (Value?) throws -> U?) -> AsyncExpression<U> {
+        return AsyncExpression<U>(
+            expression: ({ try await block(self.evaluate()) }),
+            location: self.location,
+            isClosure: self.isClosure
+        )
+    }
+
+    public func evaluate() async throws -> Value? {
+        return try await self._expression(_withoutCaching)
+    }
+
+    public func withoutCaching() -> AsyncExpression<Value> {
+        return AsyncExpression(
+            memoizedExpression: self._expression,
+            location: location,
+            withoutCaching: true,
+            isClosure: isClosure
+        )
+    }
+}
+

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -15,8 +15,8 @@ private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping () async throws -> T?) async -> AsyncExpectation<T> {
     return AsyncExpectation(
-        expression: Expression(
-            expression: await convertAsyncExpression(expression),
+        expression: AsyncExpression(
+            expression: expression,
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
@@ -24,8 +24,8 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
-        expression: Expression(
-            expression: await convertAsyncExpression(expression()),
+        expression: AsyncExpression(
+            expression: expression(),
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
@@ -33,8 +33,8 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
-        expression: Expression(
-            expression: await convertAsyncExpression(expression()),
+        expression: AsyncExpression(
+            expression: expression(),
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }
@@ -42,8 +42,8 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
-        expression: Expression(
-            expression: await convertAsyncExpression(expression()),
+        expression: AsyncExpression(
+            expression: expression(),
             location: SourceLocation(file: file, line: line),
             isClosure: true))
 }

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -2,18 +2,8 @@
 import Dispatch
 #endif
 
-private func convertAsyncExpression<T>(_ asyncExpression: () async throws -> T) async -> (() throws -> T) {
-    let result: Result<T, Error>
-    do {
-        result = .success(try await asyncExpression())
-    } catch {
-        result = .failure(error)
-    }
-    return { try result.get() }
-}
-
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping () async throws -> T?) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping () async throws -> T?) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
@@ -22,7 +12,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T)) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -31,7 +21,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T?)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -40,7 +30,47 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
+public func expect(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> Void)) -> AsyncExpectation<Void> {
+    return AsyncExpectation(
+        expression: AsyncExpression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
+/// This is provided to avoid  confusion between `expect -> SyncExpectation` and `expect -> AsyncExpectation`.
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () async throws -> T?) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: AsyncExpression(
+            expression: expression,
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T)) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: AsyncExpression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
+    return AsyncExpectation(
+        expression: AsyncExpression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
+public func expecta(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,4 +1,4 @@
-/// Make an ``Expectation`` on a given actual value. The value given is lazily evaluated.
+/// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () throws -> T?) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
@@ -7,7 +7,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
             isClosure: true))
 }
 
-/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
@@ -16,7 +16,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
             isClosure: true))
 }
 
-/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T?)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
@@ -25,8 +25,48 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
             isClosure: true))
 }
 
-/// Make an ``Expectation`` on a given actual value. The closure is lazily invoked.
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 public func expect(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> Void)) -> SyncExpectation<Void> {
+    return SyncExpectation(
+        expression: Expression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
+/// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
+public func expects<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () throws -> T?) -> SyncExpectation<T> {
+    return SyncExpectation(
+        expression: Expression(
+            expression: expression,
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
+public func expects<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T)) -> SyncExpectation<T> {
+    return SyncExpectation(
+        expression: Expression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
+public func expects<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> T?)) -> SyncExpectation<T> {
+    return SyncExpectation(
+        expression: Expression(
+            expression: expression(),
+            location: SourceLocation(file: file, line: line),
+            isClosure: true))
+}
+
+/// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
+/// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
+public func expects(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() throws -> Void)) -> SyncExpectation<Void> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),

--- a/Sources/Nimble/Expectation.swift
+++ b/Sources/Nimble/Expectation.swift
@@ -62,8 +62,6 @@ extension ExpectationStatus {
 }
 
 public protocol Expectation {
-    associatedtype Value
-
     var location: SourceLocation { get }
 
     /// The status of the test after predicates have been evaluated.

--- a/Sources/Nimble/Matchers/BeCloseTo.swift
+++ b/Sources/Nimble/Matchers/BeCloseTo.swift
@@ -121,37 +121,61 @@ public func beCloseTo<Value: FloatingPoint, Values: Collection>(
 
 infix operator ≈ : ComparisonPrecedence
 
-// swiftlint:disable:next identifier_name
-public func ≈<Exp: Expectation, Value>(lhs: Exp, rhs: Value) where Value: Collection, Value.Element: FloatingPoint, Exp.Value == Value {
+// swiftlint:disable identifier_name
+public func ≈<Value>(lhs: SyncExpectation<Value>, rhs: Value) where Value: Collection, Value.Element: FloatingPoint {
     lhs.to(beCloseTo(rhs))
 }
 
-// swiftlint:disable:next identifier_name
-public func ≈<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: Value) where Exp.Value == Value {
+public func ≈<Value>(lhs: AsyncExpectation<Value>, rhs: Value) async where Value: Collection, Value.Element: FloatingPoint {
+    await lhs.to(beCloseTo(rhs))
+}
+
+public func ≈<Value: FloatingPoint>(lhs: SyncExpectation<Value>, rhs: Value) {
     lhs.to(beCloseTo(rhs))
 }
 
-// swiftlint:disable:next identifier_name
-public func ≈<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: (expected: Value, delta: Value)) where Exp.Value == Value {
+public func ≈<Value: FloatingPoint>(lhs: AsyncExpectation<Value>, rhs: Value) async {
+    await lhs.to(beCloseTo(rhs))
+}
+
+public func ≈<Value: FloatingPoint>(lhs: SyncExpectation<Value>, rhs: (expected: Value, delta: Value)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
-public func ==<Exp: Expectation, Value: FloatingPoint>(lhs: Exp, rhs: (expected: Value, delta: Value)) where Exp.Value == Value {
+public func ≈<Value: FloatingPoint>(lhs: AsyncExpectation<Value>, rhs: (expected: Value, delta: Value)) async {
+    await lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
+
+public func ==<Value: FloatingPoint>(lhs: SyncExpectation<Value>, rhs: (expected: Value, delta: Value)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
-// swiftlint:disable:next identifier_name
-public func ≈<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: Value) where Exp.Value == Value {
+public func ==<Value: FloatingPoint>(lhs: AsyncExpectation<Value>, rhs: (expected: Value, delta: Value)) async {
+    await lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
+
+public func ≈<Value: NMBDoubleConvertible>(lhs: SyncExpectation<Value>, rhs: Value) {
     lhs.to(beCloseTo(rhs))
 }
 
-// swiftlint:disable:next identifier_name
-public func ≈<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: (expected: Value, delta: Double)) where Exp.Value == Value {
+public func ≈<Value: NMBDoubleConvertible>(lhs: AsyncExpectation<Value>, rhs: Value) async {
+    await lhs.to(beCloseTo(rhs))
+}
+
+public func ≈<Value: NMBDoubleConvertible>(lhs: SyncExpectation<Value>, rhs: (expected: Value, delta: Double)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
-public func ==<Exp: Expectation, Value: NMBDoubleConvertible>(lhs: Exp, rhs: (expected: Value, delta: Double)) where Exp.Value == Value {
+public func ≈<Value: NMBDoubleConvertible>(lhs: AsyncExpectation<Value>, rhs: (expected: Value, delta: Double)) async {
+    await lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
+
+public func ==<Value: NMBDoubleConvertible>(lhs: SyncExpectation<Value>, rhs: (expected: Value, delta: Double)) {
     lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
+}
+
+public func ==<Value: NMBDoubleConvertible>(lhs: AsyncExpectation<Value>, rhs: (expected: Value, delta: Double)) async {
+    await lhs.to(beCloseTo(rhs.expected, within: rhs.delta))
 }
 
 // make this higher precedence than exponents so the Doubles either end aren't pulled in
@@ -161,11 +185,11 @@ precedencegroup PlusMinusOperatorPrecedence {
 }
 
 infix operator ± : PlusMinusOperatorPrecedence
-// swiftlint:disable:next identifier_name
 public func ±<Value: FloatingPoint>(lhs: Value, rhs: Value) -> (expected: Value, delta: Value) {
     return (expected: lhs, delta: rhs)
 }
-// swiftlint:disable:next identifier_name
 public func ±<Value: NMBDoubleConvertible>(lhs: Value, rhs: Double) -> (expected: Value, delta: Double) {
     return (expected: lhs, delta: rhs)
 }
+
+// swiftlint:enable identifier_name

--- a/Sources/Nimble/Matchers/BeGreaterThan.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThan.swift
@@ -8,8 +8,12 @@ public func beGreaterThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-public func ><Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
+public func ><T: Comparable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(beGreaterThan(rhs))
+}
+
+public func ><T: Comparable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(beGreaterThan(rhs))
 }
 
 #if canImport(Darwin)
@@ -26,8 +30,12 @@ public func beGreaterThan<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T>
     }
 }
 
-public func ><Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T?) where Exp.Value == T {
+public func ><T: NMBComparable>(lhs: SyncExpectation<T>, rhs: T?) {
     lhs.to(beGreaterThan(rhs))
+}
+
+public func ><T: NMBComparable>(lhs: AsyncExpectation<T>, rhs: T?) async {
+    await lhs.to(beGreaterThan(rhs))
 }
 
 extension NMBPredicate {

--- a/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
+++ b/Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift
@@ -9,8 +9,12 @@ public func beGreaterThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predic
     }
 }
 
-public func >=<Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
+public func >=<T: Comparable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
+}
+
+public func >=<T: Comparable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
 #if canImport(Darwin)
@@ -27,8 +31,12 @@ public func beGreaterThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Pre
     }
 }
 
-public func >=<Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T) where Exp.Value == T {
+public func >=<T: NMBComparable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(beGreaterThanOrEqualTo(rhs))
+}
+
+public func >=<T: NMBComparable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(beGreaterThanOrEqualTo(rhs))
 }
 
 extension NMBPredicate {

--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -15,12 +15,20 @@ public func beIdenticalTo(_ expected: AnyObject?) -> Predicate<AnyObject> {
     }
 }
 
-public func ===<Exp: Expectation>(lhs: Exp, rhs: AnyObject?) where Exp.Value == AnyObject {
+public func ===(lhs: SyncExpectation<AnyObject>, rhs: AnyObject?) {
     lhs.to(beIdenticalTo(rhs))
 }
 
-public func !==<Exp: Expectation>(lhs: Exp, rhs: AnyObject?) where Exp.Value == AnyObject {
+public func ===(lhs: AsyncExpectation<AnyObject>, rhs: AnyObject?) async {
+    await lhs.to(beIdenticalTo(rhs))
+}
+
+public func !==(lhs: SyncExpectation<AnyObject>, rhs: AnyObject?) {
     lhs.toNot(beIdenticalTo(rhs))
+}
+
+public func !==(lhs: AsyncExpectation<AnyObject>, rhs: AnyObject?) async {
+    await lhs.toNot(beIdenticalTo(rhs))
 }
 
 /// A Nimble matcher that succeeds when the actual value is the same instance

--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -8,8 +8,12 @@ public func beLessThan<T: Comparable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-public func <<Exp: Expectation, V: Comparable>(lhs: Exp, rhs: V) where Exp.Value == V {
+public func <<V: Comparable>(lhs: SyncExpectation<V>, rhs: V) {
     lhs.to(beLessThan(rhs))
+}
+
+public func <<V: Comparable>(lhs: AsyncExpectation<V>, rhs: V) async {
+    await lhs.to(beLessThan(rhs))
 }
 
 #if canImport(Darwin)
@@ -25,8 +29,12 @@ public func beLessThan<T: NMBComparable>(_ expectedValue: T?) -> Predicate<T> {
     }
 }
 
-public func <<Exp: Expectation, V: NMBComparable>(lhs: Exp, rhs: V?) where Exp.Value == V {
+public func <<V: NMBComparable>(lhs: SyncExpectation<V>, rhs: V?) {
     lhs.to(beLessThan(rhs))
+}
+
+public func <<V: NMBComparable>(lhs: AsyncExpectation<V>, rhs: V?) async {
+    await lhs.to(beLessThan(rhs))
 }
 
 extension NMBPredicate {

--- a/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
+++ b/Sources/Nimble/Matchers/BeLessThanOrEqual.swift
@@ -8,8 +8,12 @@ public func beLessThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Predicate
     }
 }
 
-public func <=<Exp: Expectation, T: Comparable>(lhs: Exp, rhs: T) where Exp.Value == T {
+public func <=<T: Comparable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
+}
+
+public func <=<T: Comparable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(beLessThanOrEqualTo(rhs))
 }
 
 #if canImport(Darwin)
@@ -25,8 +29,12 @@ public func beLessThanOrEqualTo<T: NMBComparable>(_ expectedValue: T?) -> Predic
     }
 }
 
-public func <=<Exp: Expectation, T: NMBComparable>(lhs: Exp, rhs: T) where Exp.Value == T {
+public func <=<T: NMBComparable>(lhs: SyncExpectation<T>, rhs: T) {
     lhs.to(beLessThanOrEqualTo(rhs))
+}
+
+public func <=<T: NMBComparable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(beLessThanOrEqualTo(rhs))
 }
 
 extension NMBPredicate {

--- a/Sources/Nimble/Matchers/BeNil.swift
+++ b/Sources/Nimble/Matchers/BeNil.swift
@@ -34,12 +34,12 @@ extension SyncExpectation {
 }
 
 extension AsyncExpectation {
-    public static func == (lhs: AsyncExpectation, rhs: ExpectationNil) {
-        lhs.to(beNil())
+    public static func == (lhs: AsyncExpectation, rhs: ExpectationNil) async {
+        await lhs.to(beNil())
     }
 
-    public static func != (lhs: AsyncExpectation, rhs: ExpectationNil) {
-        lhs.toNot(beNil())
+    public static func != (lhs: AsyncExpectation, rhs: ExpectationNil) async {
+        await lhs.toNot(beNil())
     }
 }
 

--- a/Sources/Nimble/Matchers/BeVoid.swift
+++ b/Sources/Nimble/Matchers/BeVoid.swift
@@ -6,10 +6,18 @@ public func beVoid() -> Predicate<()> {
     }
 }
 
-public func ==<Exp: Expectation>(lhs: Exp, rhs: ()) where Exp.Value == () {
+public func ==(lhs: SyncExpectation<()>, rhs: ()) {
     lhs.to(beVoid())
 }
 
-public func !=<Exp: Expectation>(lhs: Exp, rhs: ()) where Exp.Value == () {
+public func ==(lhs: AsyncExpectation<()>, rhs: ()) async {
+    await lhs.to(beVoid())
+}
+
+public func !=(lhs: SyncExpectation<()>, rhs: ()) {
     lhs.toNot(beVoid())
+}
+
+public func !=(lhs: AsyncExpectation<()>, rhs: ()) async {
+    await lhs.toNot(beVoid())
 }

--- a/Sources/Nimble/Matchers/Equal+Tuple.swift
+++ b/Sources/Nimble/Matchers/Equal+Tuple.swift
@@ -20,8 +20,8 @@ public func ==<T1: Equatable, T2: Equatable>(
 public func ==<T1: Equatable, T2: Equatable>(
     lhs: AsyncExpectation<(T1, T2)>,
     rhs: (T1, T2)?
-) {
-    lhs.to(equal(rhs))
+) async {
+    await lhs.to(equal(rhs))
 }
 
 public func !=<T1: Equatable, T2: Equatable>(
@@ -34,8 +34,8 @@ public func !=<T1: Equatable, T2: Equatable>(
 public func !=<T1: Equatable, T2: Equatable>(
     lhs: AsyncExpectation<(T1, T2)>,
     rhs: (T1, T2)?
-) {
-    lhs.toNot(equal(rhs))
+) async {
+    await lhs.toNot(equal(rhs))
 }
 
 // MARK: Tuple3
@@ -58,8 +58,8 @@ public func ==<T1: Equatable, T2: Equatable, T3: Equatable>(
 public func ==<T1: Equatable, T2: Equatable, T3: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3)>,
     rhs: (T1, T2, T3)?
-) {
-    lhs.to(equal(rhs))
+) async {
+    await lhs.to(equal(rhs))
 }
 
 
@@ -73,8 +73,8 @@ public func !=<T1: Equatable, T2: Equatable, T3: Equatable>(
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3)>,
     rhs: (T1, T2, T3)?
-) {
-    lhs.toNot(equal(rhs))
+) async {
+    await lhs.toNot(equal(rhs))
 }
 
 
@@ -98,8 +98,8 @@ public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
 public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4)>,
     rhs: (T1, T2, T3, T4)?
-) {
-    lhs.to(equal(rhs))
+) async {
+    await lhs.to(equal(rhs))
 }
 
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
@@ -112,8 +112,8 @@ public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4)>,
     rhs: (T1, T2, T3, T4)?
-) {
-    lhs.toNot(equal(rhs))
+) async {
+    await lhs.toNot(equal(rhs))
 }
 
 
@@ -137,8 +137,8 @@ public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: E
 public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4, T5)>,
     rhs: (T1, T2, T3, T4, T5)?
-) {
-    lhs.to(equal(rhs))
+) async {
+    await lhs.to(equal(rhs))
 }
 
 
@@ -152,8 +152,8 @@ public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: E
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4, T5)>,
     rhs: (T1, T2, T3, T4, T5)?
-) {
-    lhs.toNot(equal(rhs))
+) async {
+    await lhs.toNot(equal(rhs))
 }
 
 
@@ -177,8 +177,8 @@ public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: E
 public func ==<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4, T5, T6)>,
     rhs: (T1, T2, T3, T4, T5, T6)?
-) {
-    lhs.to(equal(rhs))
+) async {
+    await lhs.to(equal(rhs))
 }
 
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
@@ -191,8 +191,8 @@ public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: E
 public func !=<T1: Equatable, T2: Equatable, T3: Equatable, T4: Equatable, T5: Equatable, T6: Equatable>(
     lhs: AsyncExpectation<(T1, T2, T3, T4, T5, T6)>,
     rhs: (T1, T2, T3, T4, T5, T6)?
-) {
-    lhs.toNot(equal(rhs))
+) async {
+    await lhs.toNot(equal(rhs))
 }
 
 // swiftlint:enable large_tuple vertical_whitespace

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -195,68 +195,68 @@ public func !=<T, C: Equatable>(lhs: SyncExpectation<[T: C]>, rhs: [T: C]?) {
     lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) {
-    lhs.to(equal(rhs))
+public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.to(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) {
-    lhs.to(equal(rhs))
+public func ==<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) async {
+    await lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) {
-    lhs.toNot(equal(rhs))
+public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) {
-    lhs.toNot(equal(rhs))
+public func !=<T: Equatable>(lhs: AsyncExpectation<T>, rhs: T?) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) {
-    lhs.to(equal(rhs))
+public func ==<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) async {
+    await lhs.to(equal(rhs))
 }
 
-public func !=<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) {
-    lhs.toNot(equal(rhs))
+public func !=<T: Equatable>(lhs: AsyncExpectation<[T]>, rhs: [T]?) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
-    lhs.to(equal(rhs))
+public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) async {
+    await lhs.to(equal(rhs))
 }
 
-public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
-    lhs.to(equal(rhs))
+public func == <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) async {
+    await lhs.to(equal(rhs))
 }
 
-public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
-    lhs.toNot(equal(rhs))
+public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
-    lhs.toNot(equal(rhs))
+public func != <T>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
-    lhs.to(equal(rhs))
+public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) async {
+    await lhs.to(equal(rhs))
 }
 
-public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
-    lhs.to(equal(rhs))
+public func ==<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) async {
+    await lhs.to(equal(rhs))
 }
 
-public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) {
-    lhs.toNot(equal(rhs))
+public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) {
-    lhs.toNot(equal(rhs))
+public func !=<T: Comparable>(lhs: AsyncExpectation<Set<T>>, rhs: Set<T>?) async {
+    await lhs.toNot(equal(rhs))
 }
 
-public func ==<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) {
-    lhs.to(equal(rhs))
+public func ==<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) async {
+    await lhs.to(equal(rhs))
 }
 
-public func !=<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) {
-    lhs.toNot(equal(rhs))
+public func !=<T, C: Equatable>(lhs: AsyncExpectation<[T: C]>, rhs: [T: C]?) async {
+    await lhs.toNot(equal(rhs))
 }
 
 #if canImport(Darwin)

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -3,7 +3,7 @@
 import Dispatch
 
 @MainActor
-private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to: String, description: String?, predicateExecutor: () async throws -> PredicateResult) async -> (Bool, FailureMessage) {
+private func execute<T>(_ expression: AsyncExpression<T>, style: ExpectationStyle, to: String, description: String?, predicateExecutor: () async throws -> PredicateResult) async -> (Bool, FailureMessage) {
     let msg = FailureMessage()
     msg.userDescription = description
     msg.to = to
@@ -11,7 +11,7 @@ private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to
         let result = try await predicateExecutor()
         result.message.update(failureMessage: msg)
         if msg.actualValue == "" {
-            msg.actualValue = "<\(stringify(try expression.evaluate()))>"
+            msg.actualValue = "<\(stringify(try await expression.evaluate()))>"
         }
         return (result.toBoolean(expectation: style), msg)
     } catch let error {
@@ -22,13 +22,13 @@ private func execute<T>(_ expression: Expression<T>, style: ExpectationStyle, to
 
 // swiftlint:disable:next function_parameter_count
 private func poll<T>(
-    expression: Expression<T>,
+    expression: AsyncExpression<T>,
     style: ExpectationStyle,
     matchStyle: AsyncMatchStyle,
     timeout: DispatchTimeInterval,
     poll: DispatchTimeInterval,
     fnName: String,
-    predicateRunner: @escaping () throws -> PredicateResult
+    predicateRunner: @escaping () async throws -> PredicateResult
 ) async -> PredicateResult {
     let fnName = "expect(...).\(fnName)(...)"
     var lastPredicateResult: PredicateResult?
@@ -38,13 +38,155 @@ private func poll<T>(
         file: expression.location.file,
         line: expression.location.line,
         fnName: fnName) {
-            lastPredicateResult = try predicateRunner()
+            lastPredicateResult = try await predicateRunner()
             return lastPredicateResult!.toBoolean(expectation: style)
         }
     return processPollResult(result, matchStyle: matchStyle, lastPredicateResult: lastPredicateResult, fnName: fnName)
 }
 
+private extension Expression {
+    func toAsyncExpression() -> AsyncExpression<Value> {
+        AsyncExpression(
+            memoizedExpression: { memoize in try _expression(memoize) },
+            location: location,
+            withoutCaching: _withoutCaching,
+            isClosure: isClosure
+        )
+    }
+}
+
 extension SyncExpectation {
+    /// Tests the actual value using a matcher to match by checking continuously
+    /// at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let asyncExpression = expression.toAsyncExpression()
+
+        let (pass, msg) = await execute(
+            asyncExpression,
+            style: .toMatch,
+            to: "to eventually",
+            description: description) {
+                await poll(
+                    expression: asyncExpression,
+                    style: .toMatch,
+                    matchStyle: .eventually,
+                    timeout: timeout,
+                    poll: pollInterval,
+                    fnName: "toEventually") {
+                        try predicate.satisfies(expression.withoutCaching())
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+
+        let asyncExpression = expression.toAsyncExpression()
+
+        let (pass, msg) = await execute(
+            asyncExpression,
+            style: .toNotMatch,
+            to: "to eventually not",
+            description: description) {
+                await poll(
+                    expression: asyncExpression,
+                    style: .toNotMatch,
+                    matchStyle: .eventually,
+                    timeout: timeout,
+                    poll: pollInterval,
+                    fnName: "toEventuallyNot") {
+                        try predicate.satisfies(expression.withoutCaching())
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to not match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toEventuallyNot()
+    @discardableResult
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
+    }
+
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    @discardableResult
+    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+        let asyncExpression = expression.toAsyncExpression()
+
+        let (pass, msg) = await execute(
+            asyncExpression,
+            style: .toNotMatch,
+            to: "to never",
+            description: description) {
+                await poll(
+                    expression: asyncExpression,
+                    style: .toMatch,
+                    matchStyle: .never,
+                    timeout: until,
+                    poll: pollInterval,
+                    fnName: "toNever") {
+                        try predicate.satisfies(expression.withoutCaching())
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to never match by checking
+    /// continuously at each pollInterval until the timeout is reached.
+    ///
+    /// Alias of toNever()
+    @discardableResult
+    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
+    }
+
+    /// Tests the actual value using a matcher to always match by checking
+    /// continusouly at each pollInterval until the timeout is reached
+    @discardableResult
+    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
+        let asyncExpression = expression.toAsyncExpression()
+
+        let (pass, msg) = await execute(
+            asyncExpression,
+            style: .toMatch,
+            to: "to always",
+            description: description) {
+                await poll(
+                    expression: asyncExpression,
+                    style: .toNotMatch,
+                    matchStyle: .always,
+                    timeout: until,
+                    poll: pollInterval,
+                    fnName: "toAlways") {
+                        try predicate.satisfies(expression.withoutCaching())
+                    }
+            }
+        return verify(pass, msg)
+    }
+
+    /// Tests the actual value using a matcher to always match by checking
+    /// continusouly at each pollInterval until the timeout is reached
+    ///
+    /// Alias of toAlways()
+    @discardableResult
+    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+        return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
+    }
+}
+
+extension AsyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     @discardableResult
@@ -63,7 +205,7 @@ extension SyncExpectation {
                     timeout: timeout,
                     poll: pollInterval,
                     fnName: "toEventually") {
-                        try predicate.satisfies(expression.withoutCaching())
+                        try predicate.satisfies(await expression.withoutCaching().toSynchronousExpression())
                     }
             }
         return verify(pass, msg)
@@ -87,7 +229,7 @@ extension SyncExpectation {
                     timeout: timeout,
                     poll: pollInterval,
                     fnName: "toEventuallyNot") {
-                        try predicate.satisfies(expression.withoutCaching())
+                        try predicate.satisfies(await expression.withoutCaching().toSynchronousExpression())
                     }
             }
         return verify(pass, msg)
@@ -120,7 +262,7 @@ extension SyncExpectation {
                     timeout: until,
                     poll: pollInterval,
                     fnName: "toNever") {
-                        try predicate.satisfies(expression.withoutCaching())
+                        try predicate.satisfies(await expression.withoutCaching().toSynchronousExpression())
                     }
             }
         return verify(pass, msg)
@@ -153,7 +295,7 @@ extension SyncExpectation {
                     timeout: until,
                     poll: pollInterval,
                     fnName: "toAlways") {
-                        try predicate.satisfies(expression.withoutCaching())
+                        try predicate.satisfies(await expression.withoutCaching().toSynchronousExpression())
                     }
             }
         return verify(pass, msg)

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -45,6 +45,21 @@ final class AsyncAwaitTest: XCTestCase {
         }
     }
 
+    func testToEventuallyWithAsyncExpressions() async {
+        actor ExampleActor {
+            private var count = 0
+
+            func value() -> Int {
+                count += 1
+                return count
+            }
+        }
+
+        let subject = ExampleActor()
+
+        await expect { await subject.value() }.toEventually(equal(2))
+    }
+
     func testToEventuallySyncCase() async {
         await expect(1).toEventually(equal(1), timeout: .seconds(300))
     }

--- a/Tests/NimbleTests/DSLTest.swift
+++ b/Tests/NimbleTests/DSLTest.swift
@@ -46,27 +46,29 @@ final class DSLTest: XCTestCase {
     }
 
     func testExpectAsyncClosure() async throws {
-        let _: AsyncExpectation<Int> = await expect { 1 }
-        let _: AsyncExpectation<Int> = await expect { await nonThrowingAsyncInt() }
-        let _: AsyncExpectation<Int> = await expect { try await throwingAsyncInt() }
-        let _: AsyncExpectation<Int> = await expect { () -> Int in 1 }
-        let _: AsyncExpectation<Int> = await expect { () -> Int? in 1 }
-        let _: AsyncExpectation<Int> = await expect { () -> Int? in nil }
+        let _: AsyncExpectation<Int> = expect { 1 }
+        let _: AsyncExpectation<Int> = expect { await nonThrowingAsyncInt() }
+        let _: AsyncExpectation<Int> = expect { try await throwingAsyncInt() }
+        let _: AsyncExpectation<Int> = expect { () -> Int in 1 }
+        let _: AsyncExpectation<Int> = expect { () -> Int? in 1 }
+        let _: AsyncExpectation<Int> = expect { () -> Int? in nil }
 
-        let _: AsyncExpectation<Void> = await expect { }
-        let _: AsyncExpectation<Void> = await expect { () -> Void in }
+        let _: AsyncExpectation<Void> = expect { }
+        let _: AsyncExpectation<Void> = expect { () -> Void in }
 
-        let _: AsyncExpectation<Void> = await expect { return }
-        let _: AsyncExpectation<Void> = await expect { () -> Void in return }
+        let _: AsyncExpectation<Void> = expect { return }
+        let _: AsyncExpectation<Void> = expect { () -> Void in return }
 
-        let _: AsyncExpectation<Void> = await expect { return () }
-        let _: AsyncExpectation<Void> = await expect { () -> Void in return () }
+        let _: AsyncExpectation<Void> = expect { return () }
+        let _: AsyncExpectation<Void> = expect { () -> Void in return () }
     }
 
     func testExpectCombinedSyncAndAsyncExpects() async throws {
         await expect { await nonThrowingAsyncInt() }.to(equal(1))
+        await expecta(await nonThrowingAsyncInt()).to(equal(1))
         expect(1).to(equal(1))
 
         expect { nonThrowingInt() }.to(equal(1))
+        expects { nonThrowingInt() }.to(equal(1))
     }
 }

--- a/Tests/NimbleTests/Helpers/utils.swift
+++ b/Tests/NimbleTests/Helpers/utils.swift
@@ -137,7 +137,13 @@ func suppressErrors<T>(closure: () -> T) -> T {
     return output!
 }
 
-func producesStatus<Exp: Expectation, T>(_ status: ExpectationStatus, file: FileString = #file, line: UInt = #line, closure: () -> Exp) where Exp.Value == T {
+func producesStatus<T>(_ status: ExpectationStatus, file: FileString = #file, line: UInt = #line, closure: () -> SyncExpectation<T>) {
+    let expectation = suppressErrors(closure: closure)
+
+    expect(file: file, line: line, expectation.status).to(equal(status))
+}
+
+func producesStatus<T>(_ status: ExpectationStatus, file: FileString = #file, line: UInt = #line, closure: () -> AsyncExpectation<T>) {
     let expectation = suppressErrors(closure: closure)
 
     expect(file: file, line: line, expectation.status).to(equal(status))


### PR DESCRIPTION
- Provide `expecta` to allow autoclosures with async expressions.
- Provide `expects` to allow you to force synchronous expectations in Nimble.

Changes to the readme also documents this.

basically, this now allows the following code:

```swift
await expect { await someAsyncFunction() }.toEventually(equal(someValue))

await expecta(await someAsyncFunction()).to(equal(someValue))
```

`toEventually` will continuously call (and wait for) the expression passed in to evaluate, it's just now compatible with async expressions. It does kick off a new task each time it polls. This is due to the fact that toEventually uses dispatch queues under the hood, and dispatch queues are always synchronous contexts. If the expression you're verifying needs to run on the main thread, you'll likely have to force it to do so. Either by marking the test itself as running on the main thread, or by marking the expression as running on the main thread, like so:

```swift
@MainActor func test_something() async {
    await expect { await someFunctionThatMustRunOnTheMainThread() }.toEventually(equal(someValue))
}

func test_something() async {
    await expect { @MainActor in await someFunctionThatMustRunOnTheMainThread() }.toEventually(equal(someValue))
}
```

Predicates are unchanged. This implementation converts the async expression to a synchronous expression as part of the `to`/`toNot`/`toEventually` ... call. This does mean that a large amount of operator overloads are now duplicated, because we need to do the awaiting as part of the operator, and this change does break operator overloads for anyone else using this.