### PR TITLE
Replace public usage of DispatchTimeInterval with a new NimbleTimeInterval

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -21,9 +21,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0477153523B740AD00402D4E /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* DispatchTimeInterval.swift */; };
-		0477153623B740B700402D4E /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* DispatchTimeInterval.swift */; };
-		0477153723B740B800402D4E /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* DispatchTimeInterval.swift */; };
+		0477153523B740AD00402D4E /* NimbleTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* NimbleTimeInterval.swift */; };
+		0477153623B740B700402D4E /* NimbleTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* NimbleTimeInterval.swift */; };
+		0477153723B740B800402D4E /* NimbleTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* NimbleTimeInterval.swift */; };
 		106112BD2251DFE7000A5848 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106112BC2251DFE7000A5848 /* BeResult.swift */; };
 		106112C02251E0FA000A5848 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106112BC2251DFE7000A5848 /* BeResult.swift */; };
 		106112C22251E0FD000A5848 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106112BC2251DFE7000A5848 /* BeResult.swift */; };
@@ -554,7 +554,7 @@
 		D95F8982267EA20A004B1B4D /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472FD1341B9E085700C7B8DA /* HaveCount.swift */; };
 		D95F8983267EA20A004B1B4D /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F6B5BC2070186D00FCB5ED /* SatisfyAllOf.swift */; };
 		D95F8984267EA20E004B1B4D /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD271968AB07008ED995 /* SourceLocation.swift */; };
-		D95F8985267EA20E004B1B4D /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* DispatchTimeInterval.swift */; };
+		D95F8985267EA20E004B1B4D /* NimbleTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0477153423B740AD00402D4E /* NimbleTimeInterval.swift */; };
 		D95F8986267EA20E004B1B4D /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD281968AB07008ED995 /* Stringers.swift */; };
 		D95F8987267EA20E004B1B4D /* PollAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD8CD261968AB07008ED995 /* PollAwait.swift */; };
 		D95F8988267EA20E004B1B4D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4BA9AC1C88DDB500B73906 /* Errors.swift */; };
@@ -654,7 +654,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0477153423B740AD00402D4E /* DispatchTimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchTimeInterval.swift; sourceTree = "<group>"; };
+		0477153423B740AD00402D4E /* NimbleTimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleTimeInterval.swift; sourceTree = "<group>"; };
 		106112BC2251DFE7000A5848 /* BeResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeResult.swift; sourceTree = "<group>"; };
 		106112C42251E13B000A5848 /* BeResultTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeResultTest.swift; sourceTree = "<group>"; };
 		1F0648CB19639F5A001F9C46 /* ObjectWithLazyProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectWithLazyProperty.swift; sourceTree = "<group>"; };
@@ -1104,7 +1104,7 @@
 				1FD8CD271968AB07008ED995 /* SourceLocation.swift */,
 				1FD8CD281968AB07008ED995 /* Stringers.swift */,
 				AE4BA9AC1C88DDB500B73906 /* Errors.swift */,
-				0477153423B740AD00402D4E /* DispatchTimeInterval.swift */,
+				0477153423B740AD00402D4E /* NimbleTimeInterval.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1612,7 +1612,7 @@
 				AE4BA9AD1C88DDB500B73906 /* Errors.swift in Sources */,
 				1FD8CD3C1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				892FDF1429D3EA7700523A80 /* AsyncExpression.swift in Sources */,
-				0477153623B740B700402D4E /* DispatchTimeInterval.swift in Sources */,
+				0477153623B740B700402D4E /* NimbleTimeInterval.swift in Sources */,
 				7A6AB2C51E7F628900A2F694 /* ToSucceed.swift in Sources */,
 				1FD8CD501968AB07008ED995 /* BeLogical.swift in Sources */,
 				1F1871CB1CA89EDB00A34BF2 /* NMBExpectation.swift in Sources */,
@@ -1816,7 +1816,7 @@
 				CDD80B851F20307B0002CD65 /* MatcherProtocols.swift in Sources */,
 				1F5DF1721BDCA0F500C3A531 /* Expectation.swift in Sources */,
 				7B5358C01C38479700A23FAA /* SatisfyAnyOf.swift in Sources */,
-				0477153723B740B800402D4E /* DispatchTimeInterval.swift in Sources */,
+				0477153723B740B800402D4E /* NimbleTimeInterval.swift in Sources */,
 				7B13BA0C1DD361D300C9098C /* ContainElementSatisfying.swift in Sources */,
 				1F5DF1871BDCA0F500C3A531 /* Match.swift in Sources */,
 			);
@@ -1921,7 +1921,7 @@
 				1FDBD8681AF8A4FF0089F27B /* AssertionDispatcher.swift in Sources */,
 				AE4BA9AE1C88DDB500B73906 /* Errors.swift in Sources */,
 				892FDF1329D3EA7700523A80 /* AsyncExpression.swift in Sources */,
-				0477153523B740AD00402D4E /* DispatchTimeInterval.swift in Sources */,
+				0477153523B740AD00402D4E /* NimbleTimeInterval.swift in Sources */,
 				1FD8CD3D1968AB07008ED995 /* BeAnInstanceOf.swift in Sources */,
 				1FD8CD511968AB07008ED995 /* BeLogical.swift in Sources */,
 				1F1871D91CA89EF100A34BF2 /* NMBExpectation.swift in Sources */,
@@ -2090,7 +2090,7 @@
 				D95F8968267EA20A004B1B4D /* BeGreaterThan.swift in Sources */,
 				D95F8972267EA20A004B1B4D /* Match.swift in Sources */,
 				D95F8986267EA20E004B1B4D /* Stringers.swift in Sources */,
-				D95F8985267EA20E004B1B4D /* DispatchTimeInterval.swift in Sources */,
+				D95F8985267EA20E004B1B4D /* NimbleTimeInterval.swift in Sources */,
 				D95F895A267EA205004B1B4D /* Expression.swift in Sources */,
 				D95F897A267EA20A004B1B4D /* BeNil.swift in Sources */,
 				D95F895E267EA205004B1B4D /* DSL.swift in Sources */,

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -3,7 +3,6 @@
 #if canImport(Darwin) && !SWIFT_PACKAGE
 import class Foundation.NSObject
 import typealias Foundation.TimeInterval
-import enum Dispatch.DispatchTimeInterval
 
 private func from(objcPredicate: NMBPredicate) -> Predicate<NSObject> {
     return Predicate { actualExpression in
@@ -19,7 +18,7 @@ public class NMBExpectation: NSObject {
     internal var _negative: Bool
     internal let _file: FileString
     internal let _line: UInt
-    internal var _timeout: DispatchTimeInterval = .seconds(1)
+    internal var _timeout: NimbleTimeInterval = .seconds(1)
 
     @objc public init(actualBlock: @escaping () -> NSObject?, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock
@@ -33,7 +32,7 @@ public class NMBExpectation: NSObject {
     }
 
     @objc public var withTimeout: (TimeInterval) -> NMBExpectation {
-        return { timeout in self._timeout = timeout.dispatchInterval
+        return { timeout in self._timeout = timeout.nimbleInterval
             return self
         }
     }

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -87,7 +87,7 @@ public func expecta(file: FileString = #file, line: UInt = #line, _ expression: 
 ///
 /// @warning
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
-public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) async -> Void) async {
+public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) async -> Void) async {
     await throwableUntil(timeout: timeout) { done in
         await action(done)
     }
@@ -100,7 +100,7 @@ public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, fil
 ///
 /// @warning
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
-public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) async {
+public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) async {
     await throwableUntil(timeout: timeout, file: file, line: line) { done in
         action(done)
     }
@@ -112,7 +112,7 @@ private enum ErrorResult {
 }
 
 private func throwableUntil(
-    timeout: DispatchTimeInterval,
+    timeout: NimbleTimeInterval,
     file: FileString = #file,
     line: UInt = #line,
     action: @escaping (@escaping () -> Void) async throws -> Void) async {

--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -23,13 +23,13 @@ internal class NMBWait: NSObject {
         file: FileString = #file,
         line: UInt = #line,
         action: @escaping (@escaping () -> Void) -> Void) {
-            // Convert TimeInterval to DispatchTimeInterval
-            until(timeout: timeout.dispatchInterval, file: file, line: line, action: action)
+            // Convert TimeInterval to NimbleTimeInterval
+            until(timeout: timeout.nimbleInterval, file: file, line: line, action: action)
     }
 #endif
 
     internal class func until(
-        timeout: DispatchTimeInterval,
+        timeout: NimbleTimeInterval,
         file: FileString = #file,
         line: UInt = #line,
         action: @escaping (@escaping () -> Void) -> Void) {
@@ -40,7 +40,7 @@ internal class NMBWait: NSObject {
 
     // Using a throwable closure makes this method not objc compatible.
     internal class func throwableUntil(
-        timeout: DispatchTimeInterval,
+        timeout: NimbleTimeInterval,
         file: FileString = #file,
         line: UInt = #line,
         action: @escaping (@escaping () -> Void) throws -> Void) {
@@ -104,7 +104,7 @@ internal class NMBWait: NSObject {
 #endif
 }
 
-internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: DispatchTimeInterval) -> String {
+internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: NimbleTimeInterval) -> String {
     // swiftlint:disable:next line_length
     return "\(fnName) timed out but was unable to run the timeout handler because the main thread is unresponsive (\(leeway.description) is allow after the wait times out). Conditions that may cause this include processing blocking IO on the main thread, calls to sleep(), deadlocks, and synchronous IPC. Nimble forcefully stopped run loop which may cause future failures in test run."
 }
@@ -117,7 +117,7 @@ internal func blockedRunLoopErrorMessageFor(_ fnName: String, leeway: DispatchTi
 /// This function manages the main run loop (`NSRunLoop.mainRunLoop()`) while this function
 /// is executing. Any attempts to touch the run loop may cause non-deterministic behavior.
 @available(*, noasync, message: "the sync version of `waitUntil` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-public func waitUntil(timeout: DispatchTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
+public func waitUntil(timeout: NimbleTimeInterval = AsyncDefaults.timeout, file: FileString = #file, line: UInt = #line, action: @escaping (@escaping () -> Void) -> Void) {
     NMBWait.until(timeout: timeout, file: file, line: line, action: action)
 }
 

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -25,8 +25,8 @@ private func poll<T>(
     expression: AsyncExpression<T>,
     style: ExpectationStyle,
     matchStyle: AsyncMatchStyle,
-    timeout: DispatchTimeInterval,
-    poll: DispatchTimeInterval,
+    timeout: NimbleTimeInterval,
+    poll: NimbleTimeInterval,
     fnName: String,
     predicateRunner: @escaping () async throws -> PredicateResult
 ) async -> PredicateResult {
@@ -59,7 +59,7 @@ extension SyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let asyncExpression = expression.toAsyncExpression()
@@ -85,7 +85,7 @@ extension SyncExpectation {
     /// Tests the actual value using a matcher to not match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let asyncExpression = expression.toAsyncExpression()
@@ -113,14 +113,14 @@ extension SyncExpectation {
     ///
     /// Alias of toEventuallyNot()
     @discardableResult
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to never match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
         let asyncExpression = expression.toAsyncExpression()
 
@@ -147,14 +147,14 @@ extension SyncExpectation {
     ///
     /// Alias of toNever()
     @discardableResult
-    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to always match by checking
     /// continusouly at each pollInterval until the timeout is reached
     @discardableResult
-    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
         let asyncExpression = expression.toAsyncExpression()
 
@@ -181,7 +181,7 @@ extension SyncExpectation {
     ///
     /// Alias of toAlways()
     @discardableResult
-    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }
@@ -190,7 +190,7 @@ extension AsyncExpectation {
     /// Tests the actual value using a matcher to match by checking continuously
     /// at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -214,7 +214,7 @@ extension AsyncExpectation {
     /// Tests the actual value using a matcher to not match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -240,14 +240,14 @@ extension AsyncExpectation {
     ///
     /// Alias of toEventuallyNot()
     @discardableResult
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to never match by checking
     /// continuously at each pollInterval until the timeout is reached.
     @discardableResult
-    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -273,14 +273,14 @@ extension AsyncExpectation {
     ///
     /// Alias of toNever()
     @discardableResult
-    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
     /// Tests the actual value using a matcher to always match by checking
     /// continusouly at each pollInterval until the timeout is reached
     @discardableResult
-    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = await execute(
@@ -306,7 +306,7 @@ extension AsyncExpectation {
     ///
     /// Alias of toAlways()
     @discardableResult
-    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) async -> Self {
         return await toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -6,8 +6,8 @@ import Dispatch
 /// If you are running on a slower machine, it could be useful to increase the default timeout value
 /// or slow down poll interval. Default timeout interval is 1, and poll interval is 0.01.
 public struct AsyncDefaults {
-    public static var timeout: DispatchTimeInterval = .seconds(1)
-    public static var pollInterval: DispatchTimeInterval = .milliseconds(10)
+    public static var timeout: NimbleTimeInterval = .seconds(1)
+    public static var pollInterval: NimbleTimeInterval = .milliseconds(10)
 }
 
 internal enum AsyncMatchStyle {
@@ -19,8 +19,8 @@ private func poll<T>(
     style: ExpectationStyle,
     matchStyle: AsyncMatchStyle,
     predicate: Predicate<T>,
-    timeout: DispatchTimeInterval,
-    poll: DispatchTimeInterval,
+    timeout: NimbleTimeInterval,
+    poll: NimbleTimeInterval,
     fnName: String
 ) -> Predicate<T> {
     return Predicate { actualExpression in
@@ -100,7 +100,7 @@ extension SyncExpectation {
     /// This form of `toEventually` does not work in any kind of async context. Use the async form of `toEventually` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -133,7 +133,7 @@ extension SyncExpectation {
     /// Use the async form of `toEventuallyNot` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toEventuallyNot` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toEventuallyNot(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -168,7 +168,7 @@ extension SyncExpectation {
     /// Use the async form of `toNotEventually` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toNotEventually` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toNotEventually(_ predicate: Predicate<Value>, timeout: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNotEventually(_ predicate: Predicate<Value>, timeout: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toEventuallyNot(predicate, timeout: timeout, pollInterval: pollInterval, description: description)
     }
 
@@ -184,7 +184,7 @@ extension SyncExpectation {
     /// Use the async form of `toNever` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toNever` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toNever(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toNever(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -219,7 +219,7 @@ extension SyncExpectation {
     /// Use the async form of `neverTo` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `neverTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func neverTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func neverTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toNever(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 
@@ -235,7 +235,7 @@ extension SyncExpectation {
     /// Use the async form of `toAlways` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `toAlways` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func toAlways(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func toAlways(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         nimblePrecondition(expression.isClosure, "NimbleInternalError", toEventuallyRequiresClosureError.stringValue)
 
         let (pass, msg) = execute(
@@ -270,7 +270,7 @@ extension SyncExpectation {
     /// Use the async form of `alwaysTo` if you are running tests in an async context.
     @discardableResult
     @available(*, noasync, message: "the sync version of `alwaysTo` does not work in async contexts. Use the async version with the same name as a drop-in replacement")
-    public func alwaysTo(_ predicate: Predicate<Value>, until: DispatchTimeInterval = AsyncDefaults.timeout, pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
+    public func alwaysTo(_ predicate: Predicate<Value>, until: NimbleTimeInterval = AsyncDefaults.timeout, pollInterval: NimbleTimeInterval = AsyncDefaults.pollInterval, description: String? = nil) -> Self {
         return toAlways(predicate, until: until, pollInterval: pollInterval, description: description)
     }
 }

--- a/Sources/Nimble/Utils/NimbleTimeInterval.swift
+++ b/Sources/Nimble/Utils/NimbleTimeInterval.swift
@@ -6,26 +6,44 @@ import Dispatch
 import CDispatch
 #endif
 
-extension DispatchTimeInterval {
-    // ** Note: We cannot simply divide the time interval because DispatchTimeInterval associated value type is Int
-    var divided: DispatchTimeInterval {
+/// A reimplementation of `NimbleTimeInterval` without the `never` case, and conforming to `Sendable`.
+public enum NimbleTimeInterval: Sendable, Equatable {
+    case seconds(Int)
+    case milliseconds(Int)
+    case microseconds(Int)
+    case nanoseconds(Int)
+}
+
+extension NimbleTimeInterval: CustomStringConvertible {
+    internal var dispatchTimeInterval: DispatchTimeInterval {
+        switch self {
+        case .seconds(let int):
+            return .seconds(int)
+        case .milliseconds(let int):
+            return .milliseconds(int)
+        case .microseconds(let int):
+            return .microseconds(int)
+        case .nanoseconds(let int):
+            return .nanoseconds(int)
+        }
+    }
+
+    // ** Note: We cannot simply divide the time interval because NimbleTimeInterval associated value type is Int
+    internal var divided: NimbleTimeInterval {
         switch self {
         case let .seconds(val): return val < 2 ? .milliseconds(Int(Float(val)/2*1000)) : .seconds(val/2)
         case let .milliseconds(val): return .milliseconds(val/2)
         case let .microseconds(val): return .microseconds(val/2)
         case let .nanoseconds(val): return .nanoseconds(val/2)
-        case .never: return .never
-        @unknown default: fatalError("Unknown DispatchTimeInterval value")
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
         case let .seconds(val): return val == 1 ? "\(Float(val)) second" : "\(Float(val)) seconds"
         case let .milliseconds(val): return "\(Float(val)/1_000) seconds"
         case let .microseconds(val): return "\(Float(val)/1_000_000) seconds"
         case let .nanoseconds(val): return "\(Float(val)/1_000_000_000) seconds"
-        default: fatalError("Unknown DispatchTimeInterval value")
         }
     }
 }
@@ -34,7 +52,7 @@ extension DispatchTimeInterval {
 import typealias Foundation.TimeInterval
 
 extension TimeInterval {
-    var dispatchInterval: DispatchTimeInterval {
+    var nimbleInterval: NimbleTimeInterval {
         let microseconds = Int64(self * TimeInterval(USEC_PER_SEC))
         // perhaps use nanoseconds, though would more often be > Int.max
         return microseconds < Int.max ? .microseconds(Int(microseconds)) : .seconds(Int(self))

--- a/Sources/Nimble/Utils/NimbleTimeInterval.swift
+++ b/Sources/Nimble/Utils/NimbleTimeInterval.swift
@@ -6,7 +6,7 @@ import Dispatch
 import CDispatch
 #endif
 
-/// A reimplementation of `NimbleTimeInterval` without the `never` case, and conforming to `Sendable`.
+/// A reimplementation of `DispatchTimeInterval` without the `never` case, and conforming to `Sendable`.
 public enum NimbleTimeInterval: Sendable, Equatable {
     case seconds(Int)
     case milliseconds(Int)


### PR DESCRIPTION
NimbleTimeInterval is effectively the same as DispatchTimeInterval, except that it conforms to Sendable, and there is no never case. NimbleTimeInterval values are converted to DispatchTimeInterval values only when they actually need to be used with other Dispatch APIs.

This is a simple enough change that we can and should ship it prior to enabling concurrency checking.

This breaks the public API (a type signature changed, you can no longer use the `never` case with toEventually et al. Not that that was a good idea anyway.).

Resolves https://github.com/Quick/Nimble/issues/1031