### PR TITLE
Make NimbleTimeInterval.dispatchTimeInterval public

### DIFF
--- a/Sources/Nimble/Utils/NimbleTimeInterval.swift
+++ b/Sources/Nimble/Utils/NimbleTimeInterval.swift
@@ -15,7 +15,7 @@ public enum NimbleTimeInterval: Sendable, Equatable {
 }
 
 extension NimbleTimeInterval: CustomStringConvertible {
-    internal var dispatchTimeInterval: DispatchTimeInterval {
+    public var dispatchTimeInterval: DispatchTimeInterval {
         switch self {
         case .seconds(let int):
             return .seconds(int)


### PR DESCRIPTION
Just prep work prior to releasing Nimble 12.

It would be nice to make the conversion of NimbleTimeInterval -> DispatchTimeInterval public.
