### PR TITLE
Run SyncExpectation's expression in async contexts of toEventually on the main actor.

### DIFF
--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -75,7 +75,7 @@ extension SyncExpectation {
                     matchStyle: .eventually,
                     timeout: timeout,
                     poll: pollInterval,
-                    fnName: "toEventually") {
+                    fnName: "toEventually") { @MainActor in
                         try predicate.satisfies(expression.withoutCaching())
                     }
             }
@@ -101,7 +101,7 @@ extension SyncExpectation {
                     matchStyle: .eventually,
                     timeout: timeout,
                     poll: pollInterval,
-                    fnName: "toEventuallyNot") {
+                    fnName: "toEventuallyNot") { @MainActor in
                         try predicate.satisfies(expression.withoutCaching())
                     }
             }
@@ -135,7 +135,7 @@ extension SyncExpectation {
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
-                    fnName: "toNever") {
+                    fnName: "toNever") { @MainActor in
                         try predicate.satisfies(expression.withoutCaching())
                     }
             }
@@ -169,7 +169,7 @@ extension SyncExpectation {
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
-                    fnName: "toAlways") {
+                    fnName: "toAlways") { @MainActor in
                         try predicate.satisfies(expression.withoutCaching())
                     }
             }


### PR DESCRIPTION
This PR prevents a main thread checker error.

Basically, the following test would actually fail prior to this PR:

```swift
@MainActor
func test_example() async {
    await expect(Thread.isMainThread).toEventually(beTrue())
}
```

which, if you replace the `Thread.isMainThread` part, with, say, checking a UIKit API, could cause a test crash due to the main thread checker causing crashes when run in debug mode.
