### PR TITLE
Fixed Swift.package: added macCatalyst to the condition for CwlPreconditionTesting dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             name: "Nimble",
             dependencies: [
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting",
-                         condition: .when(platforms: [.macOS, .iOS])),
+                         condition: .when(platforms: [.macOS, .iOS, .macCatalyst])),
                 .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
                          condition: .when(platforms: [.tvOS, .watchOS]))
             ],


### PR DESCRIPTION
Small fix in Swift.package to support macCatalyst

resolves #1027 