### PR TITLE
cast an empty array to avoid a warning during compile time

### DIFF
--- a/Tests/NimbleTests/Matchers/BeEmptyTest.swift
+++ b/Tests/NimbleTests/Matchers/BeEmptyTest.swift
@@ -62,7 +62,7 @@ final class BeEmptyTest: XCTestCase {
 
         // Array
         failsWithErrorMessage("expected to not be empty, got <[]>") {
-            expect([]).toNot(beEmpty())
+            expect([] as [Int]).toNot(beEmpty())
         }
         failsWithErrorMessage("expected to be empty, got <[1]>") {
             expect([1]).to(beEmpty())


### PR DESCRIPTION
Casts an empty array in a test for `beEmpty()`.

Gets rid of a compile warning. That's it.