### PR TITLE
Make expect for async closures take in Sendable closures

### DIFF
--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -3,7 +3,7 @@ import Dispatch
 #endif
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping () async throws -> T?) -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
@@ -12,7 +12,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T)) -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @Sendable () -> (@Sendable () async throws -> T)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -21,7 +21,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> T?)) -> AsyncExpectation<T> {
+public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression: @Sendable () -> (@Sendable () async throws -> T?)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -30,7 +30,7 @@ public func expect<T>(file: FileString = #file, line: UInt = #line, _ expression
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(file: FileString = #file, line: UInt = #line, _ expression: () -> (() async throws -> Void)) -> AsyncExpectation<Void> {
+public func expect(file: FileString = #file, line: UInt = #line, _ expression: @Sendable () -> (@Sendable () async throws -> Void)) -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -40,7 +40,7 @@ public func expect(file: FileString = #file, line: UInt = #line, _ expression: (
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation` and `expect -> AsyncExpectation`.
-public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping () async throws -> T?) async -> AsyncExpectation<T> {
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
@@ -50,7 +50,7 @@ public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expressio
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T)) async -> AsyncExpectation<T> {
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -60,7 +60,7 @@ public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expressio
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> T?)) async -> AsyncExpectation<T> {
+public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T?)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -70,7 +70,7 @@ public func expecta<T>(file: FileString = #file, line: UInt = #line, _ expressio
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure () -> (() async throws -> Void)) async -> AsyncExpectation<Void> {
+public func expecta(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -8,7 +8,7 @@ import NimbleSharedTestHelpers
 
 final class AsyncAwaitTest: XCTestCase {
     func testToPositiveMatches() async {
-        func someAsyncFunction() async throws -> Int {
+        @Sendable func someAsyncFunction() async throws -> Int {
             try await Task.sleep(nanoseconds: 1_000_000) // 1 millisecond
             return 1
         }
@@ -119,7 +119,7 @@ final class AsyncAwaitTest: XCTestCase {
     func testToEventuallyWithAsyncExpectationDoesNotNecessarilyExecutesExpressionOnMainActor() async {
         // This prevents a "Class property 'isMainThread' is unavailable from asynchronous contexts; Work intended for the main actor should be marked with @MainActor; this is an error in Swift 6" warning.
         // However, the functionality actually works as you'd expect it to, you're just expected to tag things to use the main actor.
-        func isMainThread() -> Bool { Thread.isMainThread }
+        @Sendable func isMainThread() -> Bool { Thread.isMainThread }
 
         await expecta(isMainThread()).toEventually(beFalse())
         await expecta(isMainThread()).toEventuallyNot(beTrue())
@@ -131,7 +131,7 @@ final class AsyncAwaitTest: XCTestCase {
     func testToEventuallyWithAsyncExpectationDoesExecuteExpressionOnMainActorWhenTestRunsOnMainActor() async {
         // This prevents a "Class property 'isMainThread' is unavailable from asynchronous contexts; Work intended for the main actor should be marked with @MainActor; this is an error in Swift 6" warning.
         // However, the functionality actually works as you'd expect it to, you're just expected to tag things to use the main actor.
-        func isMainThread() -> Bool { Thread.isMainThread }
+        @Sendable func isMainThread() -> Bool { Thread.isMainThread }
 
         await expecta(isMainThread()).toEventually(beTrue())
         await expecta(isMainThread()).toEventuallyNot(beFalse())

--- a/Tests/NimbleTests/Matchers/AlwaysFailMatcher.swift
+++ b/Tests/NimbleTests/Matchers/AlwaysFailMatcher.swift
@@ -4,7 +4,7 @@ import Nimble
 import NimbleSharedTestHelpers
 #endif
 
-func alwaysFail<T>() -> Predicate<T> {
+func alwaysFail<T>() -> Nimble.Predicate<T> {
     return Predicate { _ throws -> PredicateResult in
         return PredicateResult(status: .fail, message: .fail("This matcher should always fail"))
     }

--- a/Tests/NimbleTests/Matchers/EqualTest.swift
+++ b/Tests/NimbleTests/Matchers/EqualTest.swift
@@ -313,7 +313,7 @@ final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
         expect(originalArray) != expectedArray.reversed()
         expect(originalArray) != []
 
-        let originalArrayAsync = { () async in originalArray }
+        let originalArrayAsync = { @Sendable () async in originalArray }
         await expect(originalArrayAsync).toEventually(equal(expectedArray))
         await expect(originalArrayAsync).toEventuallyNot(equal(expectedArray.reversed()))
         await expect(originalArrayAsync).toEventuallyNot(equal([]))
@@ -346,7 +346,7 @@ final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
         expect(originalArray) != expectedArray.reversed()
         expect(originalArray) != []
 
-        let originalArrayAsync = { () async in originalArray }
+        let originalArrayAsync = { @Sendable () async in originalArray }
         await expect(originalArrayAsync).toEventually(equal(expectedArray))
         await expect(originalArrayAsync).toEventuallyNot(equal(expectedArray.reversed()))
         await expect(originalArrayAsync).toEventuallyNot(equal([]))
@@ -379,7 +379,7 @@ final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
         expect(originalArray) != expectedArray.reversed()
         expect(originalArray) != []
 
-        let originalArrayAsync = { () async in originalArray }
+        let originalArrayAsync = { @Sendable () async in originalArray }
         await expect(originalArrayAsync).toEventually(equal(expectedArray))
         await expect(originalArrayAsync).toEventuallyNot(equal(expectedArray.reversed()))
         await expect(originalArrayAsync).toEventuallyNot(equal([]))
@@ -412,7 +412,7 @@ final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
         expect(originalArray) != expectedArray.reversed()
         expect(originalArray) != []
 
-        let originalArrayAsync = { () async in originalArray }
+        let originalArrayAsync = { @Sendable () async in originalArray }
         await expect(originalArrayAsync).toEventually(equal(expectedArray))
         await expect(originalArrayAsync).toEventuallyNot(equal(expectedArray.reversed()))
         await expect(originalArrayAsync).toEventuallyNot(equal([]))
@@ -445,7 +445,7 @@ final class EqualTest: XCTestCase { // swiftlint:disable:this type_body_length
         expect(originalArray) != expectedArray.reversed()
         expect(originalArray) != []
 
-        let originalArrayAsync = { () async in originalArray }
+        let originalArrayAsync = { @Sendable () async in originalArray }
         await expect(originalArrayAsync).toEventually(equal(expectedArray))
         await expect(originalArrayAsync).toEventuallyNot(equal(expectedArray.reversed()))
         await expect(originalArrayAsync).toEventuallyNot(equal([]))


### PR DESCRIPTION
This removes a bunch of warnings in Nimble around using the async forms of `expect`/`expecta`.

This should have been included in #1067, but I forgot to push the commit. 🤦‍♀️