### PR TITLE
Make AsyncPredicate Sendable, constrain it to Sendable types

### DIFF
--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -1,4 +1,4 @@
-public indirect enum ExpectationMessage {
+public indirect enum ExpectationMessage: Sendable {
     // --- Primary Expectations ---
     /// includes actual value in output ("expected to <message>, got <actual>")
     case expectedActualValueTo(/* message: */ String)
@@ -204,7 +204,7 @@ extension FailureMessage {
 #if canImport(Darwin)
 import class Foundation.NSObject
 
-public class NMBExpectationMessage: NSObject {
+public final class NMBExpectationMessage: NSObject, Sendable {
     private let msg: ExpectationMessage
 
     internal init(swift msg: ExpectationMessage) {


### PR DESCRIPTION
As part of concurrency checking, `AsyncPredicate` needs to be Sendable. Part of that is that the closure needs to be Sendable and `AsyncPredicate` needs to be constrained to only Sendable types.

As part of interop with `AsyncPredicate`, `Predicate` needs to be Sendable. Though, it's ok to only make `Predicate` Sendable when the type it works with is `Sendable` (that is, we have: `extension Predicate: Sendable where T: Sendable {}`).

This also fixes compiler errors in Nimble associated with making the closures passed to Predicate Sendable.
