### PR TITLE
Add visionOS support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/skumor-foreflight/CwlPreconditionTesting",
+      "state" : {
+        "branch" : "master",
+        "revision" : "7b56109705a508ff5cb273da549268a57245dab5"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Nimble",
     platforms: [
-      .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .custom("visionOS", versionString: "0.1")
     ],
     products: [
         .library(
@@ -19,7 +19,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", .upToNextMajor(from: "2.1.0")),
+        .package(url: "https://github.com/skumor-foreflight/CwlPreconditionTesting", branch: "master")
     ],
     targets: {
         var testHelperDependencies: [PackageDescription.Target.Dependency] = ["Nimble"]
@@ -31,7 +31,7 @@ let package = Package(
                 name: "Nimble",
                 dependencies: [
                     .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting",
-                             condition: .when(platforms: [.macOS, .iOS, .macCatalyst])),
+                             condition: .when(platforms: [.macOS, .iOS, .macCatalyst, .visionOS])),
                     .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting",
                              condition: .when(platforms: [.tvOS, .watchOS]))
                 ],

--- a/Sources/Nimble/Matchers/Predicate.swift
+++ b/Sources/Nimble/Matchers/Predicate.swift
@@ -16,6 +16,10 @@
 /// The Predicate provide the heavy lifting on how to assert against a given value. Internally,
 /// predicates are simple wrappers around closures to provide static type information and
 /// allow composition and wrapping of existing behaviors.
+///
+///
+public typealias NimblePredicate<T> = Predicate<T>
+
 public struct Predicate<T> {
     fileprivate var matcher: (Expression<T>) throws -> PredicateResult
 

--- a/Sources/Nimble/Matchers/ThrowAssertion.swift
+++ b/Sources/Nimble/Matchers/ThrowAssertion.swift
@@ -1,5 +1,5 @@
 // swiftlint:disable all
-#if canImport(CwlPreconditionTesting) && (os(macOS) || os(iOS))
+#if canImport(CwlPreconditionTesting) && (os(macOS) || os(iOS) || os(visionOS))
 import CwlPreconditionTesting
 #elseif canImport(CwlPosixPreconditionTesting)
 import CwlPosixPreconditionTesting
@@ -81,8 +81,8 @@ public func catchBadInstruction(block: @escaping () -> Void) -> BadInstructionEx
 }
 #endif
 
-public func throwAssertion<Out>() -> Predicate<Out> {
-    return Predicate { actualExpression in
+public func throwAssertion<Out>() -> NimblePredicate<Out> {
+    return NimblePredicate { actualExpression in
     #if (arch(x86_64) || arch(arm64)) && (canImport(Darwin) || canImport(Glibc))
         let message = ExpectationMessage.expectedTo("throw an assertion")
         var actualError: Error?

--- a/Tests/NimbleTests/Matchers/AlwaysFailMatcher.swift
+++ b/Tests/NimbleTests/Matchers/AlwaysFailMatcher.swift
@@ -4,8 +4,8 @@ import Nimble
 import NimbleSharedTestHelpers
 #endif
 
-func alwaysFail<T>() -> Predicate<T> {
-    return Predicate { _ throws -> PredicateResult in
+func alwaysFail<T>() -> NimblePredicate<T> {
+    return NimblePredicate { _ throws -> PredicateResult in
         return PredicateResult(status: .fail, message: .fail("This matcher should always fail"))
     }
 }


### PR DESCRIPTION
I am adding support for visionOS as currently Nimble will not compile for it. There is no other changes besides adding the `Typealias`

Waiting for this [pr](https://github.com/mattgallagher/CwlPreconditionTesting/pull/31) to be merged as well. Right now this pr has is referencing my fork of `CwlPreconditionTesting ` with the updates.

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [x] Is this a new feature (Requires minor version bump)?
