### PR TITLE
Build the carthage frameworks in a github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: "Release Artifacts"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  carthage_archive:
+    name: Darwin, Xcode 14.0
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: ["14.0.1"]
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Archive Nimble
+        run: |
+          carthage build --archive --use-xcframeworks
+          zip -r Nimble.xcframework.zip Carthage/Build/Nimble.xcframework
+      - name: Upload Nimble.xcframework.zip
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Nimble.xcframework.zip
+            Nimble.framework.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Archive Nimble
         run: |
-          carthage build --archive --use-xcframeworks
+          ./test carthage
           zip -r Nimble.xcframework.zip Carthage/Build/Nimble.xcframework
       - name: Upload Nimble.xcframework.zip
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,3 @@ jobs:
         with:
           files: |
             Nimble.xcframework.zip
-            Nimble.framework.zip

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,0 @@
-github "mattgallagher/CwlCatchException" ~> 2.0
-github "mattgallagher/CwlPreconditionTesting" ~> 2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "mattgallagher/CwlCatchException" "2.0.0"
-github "mattgallagher/CwlPreconditionTesting" "2.1.0"

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1036,6 +1036,7 @@
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 23.0;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
@@ -1110,6 +1111,7 @@
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 23.0;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
@@ -1150,7 +1152,6 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DRIVERKIT_DEPLOYMENT_TARGET = 20.0;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1180,7 +1181,7 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator driverkit iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -1194,7 +1195,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
-				DRIVERKIT_DEPLOYMENT_TARGET = 20.0;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1223,7 +1223,7 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator driverkit iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/script/release
+++ b/script/release
@@ -4,7 +4,6 @@ POD_NAME=Nimble
 PODSPEC=Nimble.podspec
 
 POD=${COCOAPODS:-"bundle exec pod"}
-CARTHAGE=${CARTHAGE:-"carthage"}
 GH=${GH:-"gh"}
 
 function help {
@@ -41,11 +40,6 @@ if [ -z "`which $POD`" ]; then
     die "Cocoapods is required to produce a release. Install with rubygems using 'gem install cocoapods'. Aborting."
 fi
 echo " > Cocoapods is installed"
-
-if [ -z "`which $CARTHAGE`" ]; then
-    die "Carthage is required to produce a release. Install with brew using 'brew install carthage'. Aborting."
-fi
-echo " > Carthage is installed"
 
 if [ -z "`which $GH`" ]; then
     die "gh (github CLI) is required to produce a release. Install with brew using 'brew install gh'. Aborting."
@@ -164,10 +158,6 @@ echo "Pushing to pod trunk..."
 
 $POD trunk push "$PODSPEC"
 
-echo "Creating a carthage archive to include in the release"
-$CARTHAGE build --archive --use-xcframeworks
-zip -r Nimble.xcframework.zip Carthage/Build/Nimble.xcframework
-
 # Check version tag to determine whether to mark the release as a prerelease version or not.
 echo $VERSION_TAG | grep -q -E "^v\d+\.\d+\.\d+\$"
 if [ $? -eq 0 ]; then
@@ -178,7 +168,7 @@ fi
 
 echo "Creating a github release using auto-generated notes."
 
-$GH release create -R Quick/Nimble $VERSION_TAG Nimble.xcframework.zip Nimble.framework.zip --generate-notes $PRERELEASE_FLAGS
+$GH release create -R Quick/Nimble $VERSION_TAG --generate-notes $PRERELEASE_FLAGS
 
 echo
 echo "================ Finalizing the Release ================"
@@ -186,6 +176,7 @@ echo
 echo " - Opening GitHub to allow for any edits to the release notes."
 echo "   - You should add a Highlights section at the top to call out any notable changes or fixes."
 echo "   - In particular, any breaking changes should be listed under Highlights."
+echo "   - Carthage archive frameworks will be automatically uploaded after the release is published."
 echo " - Announce!"
 
 open "https://github.com/Quick/Nimble/releases/tag/$VERSION_TAG"

--- a/test
+++ b/test
@@ -127,7 +127,7 @@ function test_carthage {
     echo "Gathering Carthage installation information..."
     run carthage version
     echo "Verifying that Carthage artifacts build"
-    run carthage build archive --use-xcframeworks --verbose
+    run carthage build --archive --use-xcframeworks --verbose
 }
 
 function test_swiftpm {

--- a/test
+++ b/test
@@ -127,7 +127,7 @@ function test_carthage {
     echo "Gathering Carthage installation information..."
     run carthage version
     echo "Verifying that Carthage artifacts build"
-    run carthage build --archive --use-xcframeworks --verbose
+    run carthage build --no-skip-current --use-xcframeworks --verbose
 }
 
 function test_swiftpm {


### PR DESCRIPTION
Build the Nimble Carthage artifact on Xcode 14, which corresponds to swift 5.7 - the oldest version we currently support.

Remove building the Carthage artifact from the release script, because GitHub actions should be doing this for us.
