### PR TITLE
Fix build on cocoapods by specifying the correct location for the CocoaWithLove exception helper libraries

### DIFF
--- a/Sources/Nimble/Nimble.h
+++ b/Sources/Nimble/Nimble.h
@@ -4,8 +4,13 @@
 #import <Nimble/DSL.h>
 
 #if TARGET_OS_OSX || TARGET_OS_IOS
+#if COCOAPODS
+    #import <CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.h>
+    #import <CwlCatchExceptionSupport/CwlCatchException.h>
+#else
     #import "CwlMachBadInstructionHandler.h"
     #import "CwlCatchException.h"
+#endif
 #endif
 
 FOUNDATION_EXPORT double NimbleVersionNumber;


### PR DESCRIPTION
I broke the cocoapods distribution in a way that the podfile lint didn't catch, and it took actually pulling in the cocoa pod to figure out.