### PR TITLE
Fix cocoapods dependencies

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -35,8 +35,7 @@ Pod::Spec.new do |s|
   }
 
   [s.osx, s.ios].each do |platform|
-    platform.dependency 'CwlMachBadInstructionHandler', '~> 2.1.0'
-    platform.dependency 'CwlCatchException', '~> 2.1.0'
+    platform.dependency 'CwlPreconditionTesting', '~> 2.1.0'
   end
 
   s.cocoapods_version = '>= 1.4.0'


### PR DESCRIPTION
This PR fixes the cocoapods dependencies needed to make `throwAssertion()` matcher work. Since https://github.com/Quick/Nimble/pull/1108 the matching was broken due to `CwlPreconditionTesting` being missing. As a result the respective `canImport(CwlPreconditionTesting)` condition in `ThrowAssertion.swift` was always false when using cocoapods. 

Note: The existing dependencies `CwlMachBadInstructionHandler` and `CwlCatchException` are replaced by `CwlPreconditionTesting`, which adds them transitively.

This PR probably fixes https://github.com/Quick/Nimble/issues/1110.

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
