### PR TITLE
Fix bug where expect(nil).toAlways(equal(0)) would erroneously pass

### DIFF
--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -41,8 +41,19 @@ internal actor Poller<T> {
             file: expression.location.file,
             line: expression.location.line,
             fnName: fnName) {
-                self.updateMatcherResult(result: try await matcherRunner())
-                    .toBoolean(expectation: style)
+                if self.updateMatcherResult(result: try await matcherRunner())
+                    .toBoolean(expectation: style) {
+                    if matchStyle.isContinous {
+                        return .incomplete
+                    }
+                    return .finished(true)
+                } else {
+                    if matchStyle.isContinous {
+                        return .finished(false)
+                    } else {
+                        return .incomplete
+                    }
+                }
             }
         return processPollResult(result.toPollResult(), matchStyle: matchStyle, lastMatcherResult: lastMatcherResult, fnName: fnName)
     }
@@ -152,7 +163,7 @@ extension SyncExpectation {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -186,7 +197,7 @@ extension SyncExpectation {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -282,7 +293,7 @@ extension SyncExpectation {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -316,7 +327,7 @@ extension SyncExpectation {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -409,7 +420,7 @@ extension AsyncExpectation {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -442,7 +453,7 @@ extension AsyncExpectation {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -533,7 +544,7 @@ extension AsyncExpectation {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -566,7 +577,7 @@ extension AsyncExpectation {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,

--- a/Sources/Nimble/Polling+Require.swift
+++ b/Sources/Nimble/Polling+Require.swift
@@ -107,7 +107,7 @@ extension SyncRequirement {
             expression,
             .toNotMatch,
             poll(
-                style: .toMatch,
+                style: .toNotMatch,
                 matchStyle: .never,
                 matcher: matcher,
                 timeout: until,
@@ -158,7 +158,7 @@ extension SyncRequirement {
             expression,
             .toMatch,
             poll(
-                style: .toNotMatch,
+                style: .toMatch,
                 matchStyle: .always,
                 matcher: matcher,
                 timeout: until,
@@ -266,7 +266,7 @@ extension SyncRequirement {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -300,7 +300,7 @@ extension SyncRequirement {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -396,7 +396,7 @@ extension SyncRequirement {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -430,7 +430,7 @@ extension SyncRequirement {
             description: description) {
                 await poll(
                     expression: asyncExpression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -523,7 +523,7 @@ extension AsyncRequirement {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -556,7 +556,7 @@ extension AsyncRequirement {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,
@@ -647,7 +647,7 @@ extension AsyncRequirement {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toMatch,
+                    style: .toNotMatch,
                     matchStyle: .never,
                     timeout: until,
                     poll: pollInterval,
@@ -680,7 +680,7 @@ extension AsyncRequirement {
             description: description) {
                 await poll(
                     expression: expression,
-                    style: .toNotMatch,
+                    style: .toMatch,
                     matchStyle: .always,
                     timeout: until,
                     poll: pollInterval,

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -41,6 +41,15 @@ public struct PollingDefaults {
 
 internal enum AsyncMatchStyle {
     case eventually, never, always
+
+    var isContinous: Bool {
+        switch self {
+        case .eventually:
+            false
+        case .never, .always:
+            true
+        }
+    }
 }
 
 // swiftlint:disable:next function_parameter_count
@@ -63,7 +72,18 @@ internal func poll<T>(
             line: actualExpression.location.line,
             fnName: fnName) {
                 lastMatcherResult = try matcher.satisfies(uncachedExpression)
-                return lastMatcherResult!.toBoolean(expectation: style)
+                if lastMatcherResult!.toBoolean(expectation: style) {
+                    if matchStyle.isContinous {
+                        return .incomplete
+                    }
+                    return .finished(true)
+                } else {
+                    if matchStyle.isContinous {
+                        return .finished(false)
+                    } else {
+                        return .incomplete
+                    }
+                }
         }
         return processPollResult(result, matchStyle: matchStyle, lastMatcherResult: lastMatcherResult, fnName: fnName)
     }
@@ -220,7 +240,7 @@ extension SyncExpectation {
             expression,
             .toNotMatch,
             poll(
-                style: .toMatch,
+                style: .toNotMatch,
                 matchStyle: .never,
                 matcher: matcher,
                 timeout: until,
@@ -271,7 +291,7 @@ extension SyncExpectation {
             expression,
             .toMatch,
             poll(
-                style: .toNotMatch,
+                style: .toMatch,
                 matchStyle: .always,
                 matcher: matcher,
                 timeout: until,

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -45,9 +45,9 @@ internal enum AsyncMatchStyle {
     var isContinous: Bool {
         switch self {
         case .eventually:
-            false
+            return false
         case .never, .always:
-            true
+            return true
         }
     }
 }

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -98,6 +98,11 @@ internal enum PollResult<T> {
     }
 }
 
+internal enum PollStatus {
+    case finished(Bool)
+    case incomplete
+}
+
 /// Holds the resulting value from an asynchronous expectation.
 /// This class is thread-safe at receiving a "response" to this promise.
 internal final class AwaitPromise<T> {
@@ -399,11 +404,11 @@ internal func pollBlock(
     file: FileString,
     line: UInt,
     fnName: String = #function,
-    expression: @escaping () throws -> Bool) -> PollResult<Bool> {
+    expression: @escaping () throws -> PollStatus) -> PollResult<Bool> {
         let awaiter = NimbleEnvironment.activeInstance.awaiter
         let result = awaiter.poll(pollInterval) { () throws -> Bool? in
-            if try expression() {
-                return true
+            if case .finished(let result) = try expression() {
+                return result
             }
             return nil
         }

--- a/Tests/NimbleTests/AsyncAwaitTest+Require.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest+Require.swift
@@ -243,6 +243,9 @@ final class AsyncAwaitRequireTest: XCTestCase { // swiftlint:disable:this type_b
         await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             try await require { try self.doThrowError() }.neverTo(equal(0))
         }
+        await failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            try await require(1).toNever(equal(1))
+        }
     }
 
     func testToAlwaysPositiveMatches() async throws {
@@ -275,6 +278,9 @@ final class AsyncAwaitRequireTest: XCTestCase { // swiftlint:disable:this type_b
         }
         await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             try await require { try self.doThrowError() }.alwaysTo(equal(0))
+        }
+        await failsWithErrorMessage("expected to always equal <0>, got <nil> (use beNil() to match nils)") {
+            try await require(nil).toAlways(equal(0))
         }
     }
 }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -372,6 +372,9 @@ final class AsyncAwaitTest: XCTestCase { // swiftlint:disable:this type_body_len
         await failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             await expect { try self.doThrowError() }.alwaysTo(equal(0))
         }
+        await failsWithErrorMessage("expected to always equal <0>, got <nil> (use beNil() to match nils)") {
+            await expect(nil).toAlways(equal(0))
+        }
     }
 }
 

--- a/Tests/NimbleTests/PollingTest+Require.swift
+++ b/Tests/NimbleTests/PollingTest+Require.swift
@@ -174,6 +174,9 @@ final class PollingRequireTest: XCTestCase {
         failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             try require { try self.doThrowError() }.neverTo(equal(0))
         }
+        failsWithErrorMessage("expected to never equal <1>, got <1>") {
+            try require(1).toNever(equal(1))
+        }
     }
 
     func testToAlwaysPositiveMatches() throws {
@@ -206,6 +209,9 @@ final class PollingRequireTest: XCTestCase {
         }
         failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             try require { try self.doThrowError() }.alwaysTo(equal(0))
+        }
+        failsWithErrorMessage("expected to always equal <1>, got <nil> (use beNil() to match nils)") {
+            try require(nil).toAlways(equal(1))
         }
     }
 }

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -295,6 +295,9 @@ final class PollingTest: XCTestCase {
         failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.neverTo(equal(0))
         }
+        failsWithErrorMessage("expected to never equal <0>, got <0>") {
+            expect(0).toNever(equal(0))
+        }
     }
 
     func testToAlwaysPositiveMatches() {
@@ -327,6 +330,9 @@ final class PollingTest: XCTestCase {
         }
         failsWithErrorMessage("unexpected error thrown: <\(errorToThrow)>") {
             expect { try self.doThrowError() }.alwaysTo(equal(0))
+        }
+        failsWithErrorMessage("expected to always equal <0>, got <nil> (use beNil() to match nils)") {
+            expect(nil).toAlways(equal(0))
         }
     }
 }


### PR DESCRIPTION
Fixes #1120

`expect(nil).toAlways(equal(0))` would erroneously pass. Interestingly, `expect(1).toAlways(equal(0))` would correctly fail. Given what changed here, I would have expected `expect(1).toAlways(equal(0))` to erroneously pass as well. Yet that matcher correctly fails without this PR. 🤷🏻‍♀️

I don't quite know why nil is special here, I think it's related to an inversion in the ExpectationStyle as passed to `execute` and `poll` for `toAlways` and `toNever`. But I'm not 100% certain.

So, this fixes that refactor, and also adds logic to catch that the continuous polling matchers (toAlways/toNever) should immediately fail if the matcher doesn't match. Just to be certain there.

Minor version bump on release.
