### PR TITLE
Make PollingDefaults threadsafe

### DIFF
--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -34,9 +34,28 @@ public struct AsyncDefaults {
 /// or slow down poll interval. Default timeout interval is 1, and poll interval is 0.01.
 ///
 /// - Note: This used to be known as ``AsyncDefaults``.
-public struct PollingDefaults {
-    public static var timeout: NimbleTimeInterval = .seconds(1)
-    public static var pollInterval: NimbleTimeInterval = .milliseconds(10)
+public struct PollingDefaults: @unchecked Sendable {
+    private static let lock = NSRecursiveLock()
+
+    private static var _timeout: NimbleTimeInterval = .seconds(1)
+    private static var _pollInterval: NimbleTimeInterval = .milliseconds(10)
+
+    public static var timeout: NimbleTimeInterval {
+        get {
+            return lock.withLock { return _timeout }
+        }
+        set {
+            lock.withLock { _timeout = newValue }
+        }
+    }
+    public static var pollInterval: NimbleTimeInterval {
+        get {
+            return lock.withLock { return _pollInterval }
+        }
+        set {
+            lock.withLock { _pollInterval = newValue }
+        }
+    }
 }
 
 internal enum AsyncMatchStyle {

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -42,18 +42,26 @@ public struct PollingDefaults: @unchecked Sendable {
 
     public static var timeout: NimbleTimeInterval {
         get {
-            return lock.withLock { return _timeout }
+            lock.lock()
+            defer { lock.unlock() }
+            return _timeout
         }
         set {
-            lock.withLock { _timeout = newValue }
+            lock.lock()
+            defer { lock.unlock() }
+            _timeout = newValue
         }
     }
     public static var pollInterval: NimbleTimeInterval {
         get {
-            return lock.withLock { return _pollInterval }
+            lock.lock()
+            defer { lock.unlock() }
+            return _pollInterval
         }
         set {
-            lock.withLock { _pollInterval = newValue }
+            lock.lock()
+            defer { lock.unlock() }
+            _pollInterval = newValue
         }
     }
 }


### PR DESCRIPTION
As Swift 6 is becoming more and more of a thing, I'm bringing in the low-hanging fruit from the Nimble-Next PR. First up: Sendable PollingDefaults!

It's https://github.com/Quick/Nimble/pull/1078, but targeting main.

This will require a minor version update when we release it, because it's technically new behavior.