### PR TITLE
Make FailureMessage Sendable.

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		892FDF1329D3EA7700523A80 /* AsyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892FDF1229D3EA7700523A80 /* AsyncExpression.swift */; };
 		896962412A5FABD000A7929D /* AsyncAllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 896962402A5FABD000A7929D /* AsyncAllPass.swift */; };
 		8969624A2A5FAD5F00A7929D /* AsyncAllPassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 896962452A5FAD4500A7929D /* AsyncAllPassTest.swift */; };
+		897F84F42BA922B500BF354B /* NSLocking+Nimble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897F84F32BA922B500BF354B /* NSLocking+Nimble.swift */; };
 		898F28B025D9F4C30052B8D0 /* AlwaysFailMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */; };
 		899441EF2902EE4B00C1FAF9 /* AsyncAwaitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */; };
 		899441F82902EF2500C1FAF9 /* DSL+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */; };
@@ -322,6 +323,7 @@
 		8952ADDC2B4F159400D9305F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		896962402A5FABD000A7929D /* AsyncAllPass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAllPass.swift; sourceTree = "<group>"; };
 		896962452A5FAD4500A7929D /* AsyncAllPassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAllPassTest.swift; sourceTree = "<group>"; };
+		897F84F32BA922B500BF354B /* NSLocking+Nimble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLocking+Nimble.swift"; sourceTree = "<group>"; };
 		898F28AF25D9F4C30052B8D0 /* AlwaysFailMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysFailMatcher.swift; sourceTree = "<group>"; };
 		899441EE2902EE4B00C1FAF9 /* AsyncAwaitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTest.swift; sourceTree = "<group>"; };
 		899441F32902EF0900C1FAF9 /* DSL+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSL+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 			isa = PBXGroup;
 			children = (
 				1FD8CD261968AB07008ED995 /* PollAwait.swift */,
+				897F84F32BA922B500BF354B /* NSLocking+Nimble.swift */,
 				89F5E08B290B8D22001F9377 /* AsyncAwait.swift */,
 				891A04702AB0164500B46613 /* AsyncTimerSequence.swift */,
 				1FD8CD271968AB07008ED995 /* SourceLocation.swift */,
@@ -875,6 +878,7 @@
 				1FD8CD571968AB07008ED995 /* Contain.swift in Sources */,
 				7A0A26231E7F52360092A34E /* ToSucceed.swift in Sources */,
 				89F5E0862908E655001F9377 /* Polling+AsyncAwait.swift in Sources */,
+				897F84F42BA922B500BF354B /* NSLocking+Nimble.swift in Sources */,
 				899441F82902EF2500C1FAF9 /* DSL+AsyncAwait.swift in Sources */,
 				1FD8CD491968AB07008ED995 /* BeGreaterThanOrEqualTo.swift in Sources */,
 				1FE661571E6574E30035F243 /* ExpectationMessage.swift in Sources */,

--- a/Sources/Nimble/ExpectationMessage.swift
+++ b/Sources/Nimble/ExpectationMessage.swift
@@ -174,33 +174,6 @@ public indirect enum ExpectationMessage: Sendable {
     }
 }
 
-extension FailureMessage {
-    internal func toExpectationMessage() -> ExpectationMessage {
-        let defaultMessage = FailureMessage()
-        if expected != defaultMessage.expected || _stringValueOverride != nil {
-            return .fail(stringValue)
-        }
-
-        var message: ExpectationMessage = .fail(userDescription ?? "")
-        if actualValue != "" && actualValue != nil {
-            message = .expectedCustomValueTo(postfixMessage, actual: actualValue ?? "")
-        } else if postfixMessage != defaultMessage.postfixMessage {
-            if actualValue == nil {
-                message = .expectedTo(postfixMessage)
-            } else {
-                message = .expectedActualValueTo(postfixMessage)
-            }
-        }
-        if postfixActual != defaultMessage.postfixActual {
-            message = .appends(message, postfixActual)
-        }
-        if let extended = extendedMessage {
-            message = .details(message, extended)
-        }
-        return message
-    }
-}
-
 #if canImport(Darwin)
 import class Foundation.NSObject
 

--- a/Sources/Nimble/Utils/NSLocking+Nimble.swift
+++ b/Sources/Nimble/Utils/NSLocking+Nimble.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension NSLocking {
+    internal func sync<T>(_ closure: () throws -> T) rethrows -> T {
+        lock()
+        defer {
+            unlock()
+        }
+        return try closure()
+    }
+}


### PR DESCRIPTION
- Makes FailureMessage Sendable
- Adds a helper for NSLocking that essentially backports `withLock` (under `sync`) for older Xcodes.