### PR TITLE
Nimble 14: Remove usage of the swift 6 only sending keyword

### DIFF
--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -14,13 +14,13 @@ private func from(objcMatcher: NMBMatcher) -> Matcher<NSObject> {
 
 // Equivalent to Expectation, but for Nimble's Objective-C interface
 public final class NMBExpectation: NSObject, Sendable {
-    internal let _actualBlock: @Sendable () -> sending NSObject?
+    internal let _actualBlock: @Sendable () -> NSObject?
     internal let _negative: Bool
     internal let _file: FileString
     internal let _line: UInt
     internal let _timeout: NimbleTimeInterval
 
-    @objc public init(actualBlock: @escaping @Sendable () -> sending NSObject?, negative: Bool, file: FileString, line: UInt) {
+    @objc public init(actualBlock: @escaping @Sendable () -> NSObject?, negative: Bool, file: FileString, line: UInt) {
         self._actualBlock = actualBlock
         self._negative = negative
         self._file = file
@@ -28,7 +28,7 @@ public final class NMBExpectation: NSObject, Sendable {
         self._timeout = .seconds(1)
     }
 
-    private init(actualBlock: @escaping @Sendable () -> sending NSObject?, negative: Bool, file: FileString, line: UInt, timeout: NimbleTimeInterval) {
+    private init(actualBlock: @escaping @Sendable () -> NSObject?, negative: Bool, file: FileString, line: UInt, timeout: NimbleTimeInterval) {
         self._actualBlock = actualBlock
         self._negative = negative
         self._file = file

--- a/Sources/Nimble/AsyncExpression.swift
+++ b/Sources/Nimble/AsyncExpression.swift
@@ -67,7 +67,7 @@ private final class MemoizedClosure<T: Sendable>: Sendable {
 // Memoizes the given closure, only calling the passed
 // closure once; even if repeat calls to the returned closure
 private func memoizedClosure<T: Sendable>(
-    _ closure: sending @escaping @Sendable () async throws -> T
+    _ closure: @escaping @Sendable () async throws -> T
 ) -> @Sendable (Bool) async throws -> T {
     let memoized = MemoizedClosure(closure)
     return memoized.callAsFunction(_:)
@@ -85,7 +85,7 @@ private func memoizedClosure<T: Sendable>(
 /// This provides a common consumable API for matchers to utilize to allow
 /// Nimble to change internals to how the captured closure is managed.
 public actor AsyncExpression<Value: Sendable> {
-    internal let _expression: @Sendable (Bool) async throws -> sending Value?
+    internal let _expression: @Sendable (Bool) async throws -> Value?
     internal let _withoutCaching: Bool
     public let location: SourceLocation
     public let isClosure: Bool
@@ -101,7 +101,7 @@ public actor AsyncExpression<Value: Sendable> {
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(expression: sending @escaping @Sendable () async throws -> sending Value?, location: SourceLocation, isClosure: Bool = true) {
+    public init(expression: @escaping @Sendable () async throws -> Value?, location: SourceLocation, isClosure: Bool = true) {
         self._expression = memoizedClosure(expression)
         self.location = location
         self._withoutCaching = false
@@ -122,7 +122,7 @@ public actor AsyncExpression<Value: Sendable> {
     ///                  requires an explicit closure. This gives Nimble
     ///                  flexibility if @autoclosure behavior changes between
     ///                  Swift versions. Nimble internals always sets this true.
-    public init(memoizedExpression: @escaping @Sendable (Bool) async throws -> sending Value?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
+    public init(memoizedExpression: @escaping @Sendable (Bool) async throws -> Value?, location: SourceLocation, withoutCaching: Bool, isClosure: Bool = true) {
         self._expression = memoizedExpression
         self.location = location
         self._withoutCaching = withoutCaching
@@ -153,7 +153,7 @@ public actor AsyncExpression<Value: Sendable> {
     ///
     /// - Parameter block: The block that can cast the current Expression value to a
     ///              new type.
-    public func cast<U>(_ block: @escaping @Sendable (Value?) throws -> sending U?) -> AsyncExpression<U> {
+    public func cast<U>(_ block: @escaping @Sendable (Value?) throws -> U?) -> AsyncExpression<U> {
         AsyncExpression<U>(
             expression: ({ try await block(self.evaluate()) }),
             location: self.location,
@@ -161,7 +161,7 @@ public actor AsyncExpression<Value: Sendable> {
         )
     }
 
-    public func cast<U>(_ block: @escaping @Sendable (Value?) async throws -> sending U?) -> AsyncExpression<U> {
+    public func cast<U>(_ block: @escaping @Sendable (Value?) async throws -> U?) -> AsyncExpression<U> {
         AsyncExpression<U>(
             expression: ({ try await block(self.evaluate()) }),
             location: self.location,
@@ -169,7 +169,7 @@ public actor AsyncExpression<Value: Sendable> {
         )
     }
 
-    public func evaluate() async throws -> sending Value? {
+    public func evaluate() async throws -> Value? {
         try await self._expression(_withoutCaching)
     }
 

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -3,7 +3,7 @@ import Dispatch
 #endif
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @escaping @Sendable () async throws -> sending T?) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
@@ -12,7 +12,7 @@ public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> sending T)) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> T)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -21,7 +21,7 @@ public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> sending T?)) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> T?)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -30,7 +30,7 @@ public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> sending Void)) -> AsyncExpectation<Void> {
+public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> Void)) -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -40,7 +40,7 @@ public func expect(fileID: String = #fileID, file: FileString = #filePath, line:
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation` and `expect -> AsyncExpectation`.
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () async throws -> sending T?) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
@@ -50,7 +50,7 @@ public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> sending T)) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -60,7 +60,7 @@ public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> sending T?)) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T?)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
@@ -70,7 +70,7 @@ public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> sending Void)) async -> AsyncExpectation<Void> {
+public func expecta(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),

--- a/Sources/Nimble/DSL+Require.swift
+++ b/Sources/Nimble/DSL+Require.swift
@@ -3,7 +3,7 @@
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) -> SyncRequirement<T> {
+public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression,
@@ -17,7 +17,7 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T)) -> SyncRequirement<T> {
+public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -31,7 +31,7 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) -> SyncRequirement<T> {
+public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -45,7 +45,7 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending Void)) -> SyncRequirement<Void> {
+public func require(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -61,7 +61,7 @@ public func require(fileID: String = #fileID, file: FileString = #filePath, line
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) -> SyncRequirement<T> {
+public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression,
@@ -77,7 +77,7 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T)) -> SyncRequirement<T> {
+public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -93,7 +93,7 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) -> SyncRequirement<T> {
+public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -109,7 +109,7 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending Void)) -> SyncRequirement<Void> {
+public func requires(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
@@ -123,7 +123,7 @@ public func requires(fileID: String = #fileID, file: FileString = #filePath, lin
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @escaping @Sendable () async throws -> sending T?) -> AsyncRequirement<T> {
+public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression,
@@ -137,7 +137,7 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> sending T)) -> AsyncRequirement<T> {
+public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T)) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
@@ -151,7 +151,7 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> sending T?)) -> AsyncRequirement<T> {
+public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T?)) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
@@ -167,7 +167,7 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement` and `require -> AsyncRequirement`.
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> sending T?) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression,
@@ -183,7 +183,7 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement`  and `require -> AsyncRequirement`
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> sending T)) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T)) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
@@ -199,7 +199,7 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement`  and `require -> AsyncRequirement`
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> sending T?)) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
@@ -216,7 +216,7 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) throws -> T {
+public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
     try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
@@ -226,7 +226,7 @@ public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, li
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) throws -> T {
+public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
     try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
@@ -236,7 +236,7 @@ public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, li
 /// `unwraps` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) throws -> T {
+public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
     try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
@@ -246,7 +246,7 @@ public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `unwraps` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) throws -> T {
+public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
     try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
@@ -266,7 +266,7 @@ public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: () -> (@Sendable () async throws -> sending T?)) async throws -> T {
+public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: () -> (@Sendable () async throws -> T?)) async throws -> T {
     try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
@@ -286,7 +286,7 @@ public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `unwrapa` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> sending T?)) async throws -> T {
+public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async throws -> T {
     try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
 }
 

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,5 +1,5 @@
 /// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) -> SyncExpectation<T> {
+public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression,
@@ -8,7 +8,7 @@ public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, li
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending T)) -> SyncExpectation<T> {
+public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
@@ -17,7 +17,7 @@ public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, li
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) -> SyncExpectation<T> {
+public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
@@ -26,7 +26,7 @@ public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, li
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending Void)) -> SyncExpectation<Void> {
+public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
@@ -36,7 +36,7 @@ public func expect(fileID: String = #fileID, file: FileString = #filePath, line:
 
 /// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> sending T?) -> SyncExpectation<T> {
+public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression,
@@ -46,7 +46,7 @@ public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, l
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending T)) -> SyncExpectation<T> {
+public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
@@ -56,7 +56,7 @@ public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, l
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) -> SyncExpectation<T> {
+public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
@@ -66,7 +66,7 @@ public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, l
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> sending Void)) -> SyncExpectation<Void> {
+public func expects(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
     // It would seem like `sending` isn't necessary for the `expression` argument
     // because the closure returns void. However, this gets rid of a type
     // conversion warning/error.

--- a/Sources/Nimble/Matchers/Equal.swift
+++ b/Sources/Nimble/Matchers/Equal.swift
@@ -44,7 +44,7 @@ public func equal<T: Equatable>(_ expectedValue: [T?]) -> Matcher<[T?]> {
 ///
 /// @see beCloseTo if you want to match imprecise types (eg - floats, doubles).
 public func equal<T: Equatable>(_ expectedValue: T?) -> Matcher<T> {
-    equal(expectedValue, by: ==)
+    equal(expectedValue, by: { $0 == $1 })
 }
 
 /// A Nimble matcher that succeeds when the actual set is equal to the expected set.

--- a/Sources/Nimble/Matchers/Matcher.swift
+++ b/Sources/Nimble/Matchers/Matcher.swift
@@ -225,7 +225,7 @@ public class NMBMatcher: NSObject, @unchecked Sendable {
         self.init(matcher: predicate)
     }
 
-    func satisfies(_ expression: @escaping @Sendable () throws -> sending NSObject?, location: SourceLocation) -> NMBMatcherResult {
+    func satisfies(_ expression: @escaping @Sendable () throws -> NSObject?, location: SourceLocation) -> NMBMatcherResult {
         let expr = Expression(expression: expression, location: location)
         do {
             return try self.matcher(expr)

--- a/Sources/Nimble/Polling+Require.swift
+++ b/Sources/Nimble/Polling+Require.swift
@@ -715,7 +715,7 @@ public func pollUnwrap<T>(file: FileString = #file, line: UInt = #line, _ expres
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrap<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) throws -> T {
+public func pollUnwrap<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
     try require(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
@@ -729,7 +729,7 @@ public func pollUnwraps<T>(file: FileString = #file, line: UInt = #line, timeout
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwraps<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> sending T?)) throws -> T {
+public func pollUnwraps<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
     try require(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -316,7 +316,7 @@ internal class Awaiter {
     func performBlock<T: Sendable>(
         file: FileString,
         line: UInt,
-        _ closure: sending @escaping (@escaping @Sendable (T) -> Void) throws -> Void
+        _ closure: @escaping (@escaping @Sendable (T) -> Void) throws -> Void
         ) -> AwaitPromiseBuilder<T> {
             let promise = AwaitPromise<T>()
             let timeoutSource = createTimerSource(timeoutQueue)

--- a/Tests/NimbleTests/Matchers/NegationTest.swift
+++ b/Tests/NimbleTests/Matchers/NegationTest.swift
@@ -22,7 +22,7 @@ final class NegationTest: XCTestCase {
     }
 
     func testAsyncNil() async {
-        @Sendable func nilFunc() async -> sending Int? {
+        @Sendable func nilFunc() async -> Int? {
             nil
         }
 


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

- What behavior was changed?
- What code was refactored / updated to support this change?
- What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
