### PR TITLE
Allow beAKindOf and beAnInstanceOf to nest inside of other matchers

### DIFF
--- a/Sources/Nimble/Matchers/BeAKindOf.swift
+++ b/Sources/Nimble/Matchers/BeAKindOf.swift
@@ -6,7 +6,7 @@ private func matcherMessage(forClass expectedClass: AnyClass) -> String {
 }
 
 /// A Nimble matcher that succeeds when the actual value is an instance of the given class.
-public func beAKindOf<T>(_ expectedType: T.Type) -> Matcher<Any> {
+public func beAKindOf<T, U>(_ expectedType: T.Type) -> Matcher<U> {
     return Matcher.define { actualExpression in
         let message: ExpectationMessage
 

--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A Nimble matcher that succeeds when the actual value is an _exact_ instance of the given class.
-public func beAnInstanceOf<T>(_ expectedType: T.Type) -> Matcher<Any> {
+public func beAnInstanceOf<T, U>(_ expectedType: T.Type) -> Matcher<U> {
     let errorMessage = "be an instance of \(String(describing: expectedType))"
     return Matcher.define { actualExpression in
         let instance = try actualExpression.evaluate()

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -34,6 +34,12 @@ final class BeAKindOfSwiftTest: XCTestCase {
         expect(testProtocolStruct).toNot(beAKindOf(TestClassConformingToProtocol.self))
     }
 
+    func testNestedMatchers() {
+        // This test is successful if it even compiles.
+        let result: Result<Int, Error> = .success(1)
+        expect(result).to(beSuccess(beAKindOf(Int.self)))
+    }
+
     func testFailureMessages() {
         failsWithErrorMessage("expected to not be a kind of Int, got <Int instance>") {
             expect(1).toNot(beAKindOf(Int.self))

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -36,6 +36,12 @@ final class BeAnInstanceOfTest: XCTestCase {
         expect(testProtocolStruct).toNot(beAnInstanceOf(TestClassConformingToProtocol.self))
     }
 
+    func testNestedMatchers() {
+        // This test is successful if it even compiles.
+        let result: Result<Int, Error> = .success(1)
+        expect(result).to(beSuccess(beAnInstanceOf(Int.self)))
+    }
+
     func testFailureMessages() {
         failsWithErrorMessageForNil("expected to not be an instance of NSNull, got <nil>") {
             expect(nil as NSNull?).toNot(beAnInstanceOf(NSNull.self))


### PR DESCRIPTION
When you nest `beAKindOf` and `beAnInstanceOf` inside of other matchers (such as `beSuccess`), you get a build error.

This changes the definition of those 2 matchers to allow nesting, without otherwise changing their logic.

In my opinion, this is more of a compiler bug than anything else, but fixing it on Nimble's end is simple enough.