### PR TITLE
Fix regression in beAnInstanceOf

### DIFF
--- a/Sources/Nimble/Matchers/BeAnInstanceOf.swift
+++ b/Sources/Nimble/Matchers/BeAnInstanceOf.swift
@@ -5,7 +5,7 @@ public func beAnInstanceOf<T, U>(_ expectedType: T.Type) -> Matcher<U> {
     let errorMessage = "be an instance of \(String(describing: expectedType))"
     return Matcher.define { actualExpression in
         let instance = try actualExpression.evaluate()
-        guard let validInstance = instance else {
+        guard let validInstance: Any = instance else {
             return MatcherResult(
                 status: .doesNotMatch,
                 message: .expectedActualValueTo(errorMessage)

--- a/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAKindOfTest.swift
@@ -28,16 +28,25 @@ final class BeAKindOfSwiftTest: XCTestCase {
         expect(testProtocolClass).to(beAKindOf(TestProtocol.self))
         expect(testProtocolClass).toNot(beAKindOf(TestStructConformingToProtocol.self))
 
+        expect(testProtocolClass as TestProtocol).to(beAKindOf(TestClassConformingToProtocol.self))
+        expect(testProtocolClass as TestProtocol).to(beAKindOf(TestProtocol.self))
+        expect(testProtocolClass as TestProtocol).toNot(beAKindOf(TestStructConformingToProtocol.self))
+
         let testProtocolStruct = TestStructConformingToProtocol()
         expect(testProtocolStruct).to(beAKindOf(TestStructConformingToProtocol.self))
         expect(testProtocolStruct).to(beAKindOf(TestProtocol.self))
         expect(testProtocolStruct).toNot(beAKindOf(TestClassConformingToProtocol.self))
+
+        expect(testProtocolStruct as TestProtocol).to(beAKindOf(TestStructConformingToProtocol.self))
+        expect(testProtocolStruct as TestProtocol).to(beAKindOf(TestProtocol.self))
+        expect(testProtocolStruct as TestProtocol).toNot(beAKindOf(TestClassConformingToProtocol.self))
     }
 
     func testNestedMatchers() {
         // This test is successful if it even compiles.
-        let result: Result<Int, Error> = .success(1)
-        expect(result).to(beSuccess(beAKindOf(Int.self)))
+        expect(Result<Int, Error>.success(1)).to(beSuccess(beAKindOf(Int.self)))
+        expect(Result<TestProtocol, Error>.success(TestClassConformingToProtocol())).to(beSuccess(beAKindOf(TestClassConformingToProtocol.self)))
+        expect(Result<TestProtocol, Error>.success(TestClassConformingToProtocol())).to(beSuccess(beAKindOf(TestProtocol.self)))
     }
 
     func testFailureMessages() {

--- a/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
+++ b/Tests/NimbleTests/Matchers/BeAnInstanceOfTest.swift
@@ -30,16 +30,25 @@ final class BeAnInstanceOfTest: XCTestCase {
         expect(testProtocolClass).toNot(beAnInstanceOf(TestProtocol.self))
         expect(testProtocolClass).toNot(beAnInstanceOf(TestStructConformingToProtocol.self))
 
+        expect(testProtocolClass as TestProtocol).to(beAnInstanceOf(TestClassConformingToProtocol.self))
+        expect(testProtocolClass as TestProtocol).toNot(beAnInstanceOf(TestProtocol.self))
+        expect(testProtocolClass as TestProtocol).toNot(beAnInstanceOf(TestStructConformingToProtocol.self))
+
         let testProtocolStruct = TestStructConformingToProtocol()
         expect(testProtocolStruct).to(beAnInstanceOf(TestStructConformingToProtocol.self))
         expect(testProtocolStruct).toNot(beAnInstanceOf(TestProtocol.self))
         expect(testProtocolStruct).toNot(beAnInstanceOf(TestClassConformingToProtocol.self))
+
+        expect(testProtocolStruct as TestProtocol).to(beAnInstanceOf(TestStructConformingToProtocol.self))
+        expect(testProtocolStruct as TestProtocol).toNot(beAnInstanceOf(TestProtocol.self))
+        expect(testProtocolStruct as TestProtocol).toNot(beAnInstanceOf(TestClassConformingToProtocol.self))
     }
 
     func testNestedMatchers() {
         // This test is successful if it even compiles.
-        let result: Result<Int, Error> = .success(1)
-        expect(result).to(beSuccess(beAnInstanceOf(Int.self)))
+        expect(Result<Int, Error>.success(1)).to(beSuccess(beAnInstanceOf(Int.self)))
+        expect(Result<TestProtocol, Error>.success(TestClassConformingToProtocol())).to(beSuccess(beAnInstanceOf(TestClassConformingToProtocol.self)))
+        expect(Result<TestProtocol, Error>.success(TestClassConformingToProtocol())).toNot(beSuccess(beAnInstanceOf(TestProtocol.self)))
     }
 
     func testFailureMessages() {


### PR DESCRIPTION
beAnInstanceOf was not correctly matching when an exact type as was expected was given. This fixes that by emulating the previous typing of beAnInstanceOf while still working when used as a submatcher

bugfix pr.
