### PR TITLE
Bump the ruby version used in github workflows

### DIFF
--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
       - run: ./test carthage 

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
       - run: ./test podspec


### PR DESCRIPTION
2.7 is long out of date, let's use 3.2