### PR TITLE
Allow beIdenticalTo and be matchers to be used as composed matchers

### DIFF
--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -1,6 +1,6 @@
 /// A Nimble matcher that succeeds when the actual value is the same instance
 /// as the expected instance.
-public func beIdenticalTo(_ expected: AnyObject?) -> Matcher<AnyObject> {
+public func beIdenticalTo<T: AnyObject>(_ expected: T?) -> Matcher<T> {
     return Matcher.define { actualExpression in
         let actual = try actualExpression.evaluate()
 
@@ -35,7 +35,7 @@ public func !== (lhs: AsyncExpectation<AnyObject>, rhs: AnyObject?) async {
 /// as the expected instance.
 ///
 /// Alias for "beIdenticalTo".
-public func be(_ expected: AnyObject?) -> Matcher<AnyObject> {
+public func be<T: AnyObject>(_ expected: T?) -> Matcher<T> {
     return beIdenticalTo(expected)
 }
 

--- a/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -12,6 +12,8 @@ final class BeIdenticalToObjectTest: XCTestCase {
 
     func testBeIdenticalToPositive() {
         expect(self.testObjectA).to(beIdenticalTo(testObjectA))
+        // check that the typing works out when used as a submatcher.
+        expect(self.testObjectA).to(map({ $0 }, beIdenticalTo(testObjectA)))
     }
 
     func testBeIdenticalToNegative() {


### PR DESCRIPTION
Because `beIdenticalTo` and `be` are typed to `AnyObject`, they do not build when used as a composed matcher (e.g. as part of `satisfyAnyOf`, or `map`). Which is justifiably rather frustrating.

This is a very small change with no need for documentation. I actually view this as a bugfix change.

This is very similar to what https://github.com/Quick/Nimble/pull/1173 did, but now to 2 other matchers.

Checklist - While not every PR needs it, new features should consider this list:

- [x] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
