### PR TITLE
Fix regression where be and beIdenticalTo matchers stopped matching against AnyObject protocols

### DIFF
--- a/Sources/Nimble/Matchers/BeIdenticalTo.swift
+++ b/Sources/Nimble/Matchers/BeIdenticalTo.swift
@@ -1,6 +1,16 @@
 /// A Nimble matcher that succeeds when the actual value is the same instance
 /// as the expected instance.
 public func beIdenticalTo<T: AnyObject>(_ expected: T?) -> Matcher<T> {
+    _beIdenticalTo(expected)
+}
+
+/// A Nimble matcher that succeeds when the actual value is the same instance
+/// as the expected instance.
+public func beIdenticalTo(_ expected: AnyObject?) -> Matcher<AnyObject> {
+    _beIdenticalTo(expected)
+}
+
+private func _beIdenticalTo<T: AnyObject>(_ expected: T?) -> Matcher<T> {
     return Matcher.define { actualExpression in
         let actual = try actualExpression.evaluate()
 
@@ -36,7 +46,15 @@ public func !== (lhs: AsyncExpectation<AnyObject>, rhs: AnyObject?) async {
 ///
 /// Alias for "beIdenticalTo".
 public func be<T: AnyObject>(_ expected: T?) -> Matcher<T> {
-    return beIdenticalTo(expected)
+    return _beIdenticalTo(expected)
+}
+
+/// A Nimble matcher that succeeds when the actual value is the same instance
+/// as the expected instance.
+///
+/// Alias for "beIdenticalTo".
+public func be(_ expected: AnyObject?) -> Matcher<AnyObject> {
+    return _beIdenticalTo(expected)
 }
 
 #if canImport(Darwin)

--- a/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
+++ b/Tests/NimbleTests/Matchers/BeIdenticalToObjectTest.swift
@@ -12,8 +12,24 @@ final class BeIdenticalToObjectTest: XCTestCase {
 
     func testBeIdenticalToPositive() {
         expect(self.testObjectA).to(beIdenticalTo(testObjectA))
+    }
+
+    func testbeIdenticalToAsSubmatcher() {
         // check that the typing works out when used as a submatcher.
+        expect(self.testObjectA).to(map({ $0 }, be(testObjectA)))
         expect(self.testObjectA).to(map({ $0 }, beIdenticalTo(testObjectA)))
+    }
+
+    func testBeIdenticalToAnyObjectProtocol() {
+        protocol SomeObject: AnyObject {}
+        class ConcreteImpl: SomeObject {
+            init() {}
+        }
+
+        let object = ConcreteImpl()
+
+        expect(object as SomeObject).to(be(object))
+        expect(object as SomeObject).to(beIdenticalTo(object))
     }
 
     func testBeIdenticalToNegative() {


### PR DESCRIPTION
Fixes https://github.com/Quick/Nimble/issues/1182

Seems like... the simplest way is to just have an overload for these that specifically take in AnyObject, instead of a generic conforming to AnyObject?

Checklist - While not every PR needs it, new features should consider this list:

- [x] Does this have tests?
- [x] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
