### PR TITLE
Replace usage of all the FileID/FilePath/line/column macros with SourceLocation

### DIFF
--- a/Sources/Nimble/Adapters/AssertionRecorder+Async.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder+Async.swift
@@ -8,10 +8,7 @@
 ///
 /// @see AssertionHandler
 public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
-                                 fileID: String = #fileID,
-                                 file: FileString = #filePath,
-                                 line: UInt = #line,
-                                 column: UInt = #column,
+                                 location: SourceLocation = SourceLocation(),
                                  closure: () async throws -> Void) async {
     let environment = NimbleEnvironment.activeInstance
     let oldRecorder = environment.assertionHandler
@@ -27,7 +24,6 @@ public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
     } catch {
         let failureMessage = FailureMessage()
         failureMessage.stringValue = "unexpected error thrown: <\(error)>"
-        let location = SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
         tempAssertionHandler.assert(false, message: failureMessage, location: location)
     }
 }

--- a/Sources/Nimble/Adapters/AssertionRecorder.swift
+++ b/Sources/Nimble/Adapters/AssertionRecorder.swift
@@ -71,10 +71,7 @@ extension NMBExceptionCapture {
 ///
 /// @see AssertionHandler
 public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
-                                 fileID: String = #fileID,
-                                 file: FileString = #filePath,
-                                 line: UInt = #line,
-                                 column: UInt = #column,
+                                 location: SourceLocation = SourceLocation(),
                                  closure: () throws -> Void) {
     let environment = NimbleEnvironment.activeInstance
     let oldRecorder = environment.assertionHandler
@@ -92,11 +89,6 @@ public func withAssertionHandler(_ tempAssertionHandler: AssertionHandler,
     } catch {
         let failureMessage = FailureMessage()
         failureMessage.stringValue = "unexpected error thrown: <\(error)>"
-        let location = SourceLocation(
-            fileID: fileID,
-            filePath: file,
-            line: line, column: column
-        )
         tempAssertionHandler.assert(false, message: failureMessage, location: location)
     }
 }

--- a/Sources/Nimble/Adapters/NMBExpectation.swift
+++ b/Sources/Nimble/Adapters/NMBExpectation.swift
@@ -37,7 +37,7 @@ public final class NMBExpectation: NSObject, Sendable {
     }
 
     private var expectValue: SyncExpectation<NSObject> {
-        return expect(file: _file, line: _line, self._actualBlock() as NSObject?)
+        return expect(location: SourceLocation(fileID: "unknown/\(_file)", filePath: _file, line: _line, column: 0), self._actualBlock() as NSObject?)
     }
 
     @objc public var withTimeout: (TimeInterval) -> NMBExpectation {

--- a/Sources/Nimble/DSL+AsyncAwait.swift
+++ b/Sources/Nimble/DSL+AsyncAwait.swift
@@ -3,78 +3,78 @@ import Dispatch
 #endif
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @escaping @Sendable () async throws -> T?) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> T)) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @Sendable () -> (@Sendable () async throws -> T)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> T?)) -> AsyncExpectation<T> {
+public func expect<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @Sendable () -> (@Sendable () async throws -> T?)) -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @Sendable () -> (@Sendable () async throws -> Void)) -> AsyncExpectation<Void> {
+public func expect(location: SourceLocation = SourceLocation(), _ expression: @Sendable () -> (@Sendable () async throws -> Void)) -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The value given is lazily evaluated.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation` and `expect -> AsyncExpectation`.
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T)) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T?)) async -> AsyncExpectation<T> {
+public func expecta<T: Sendable>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> T?)) async -> AsyncExpectation<T> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make an ``AsyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided to avoid  confusion between `expect -> SyncExpectation`  and `expect -> AsyncExpectation`
-public func expecta(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> Void)) async -> AsyncExpectation<Void> {
+public func expecta(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @Sendable () -> (@Sendable () async throws -> Void)) async -> AsyncExpectation<Void> {
     return AsyncExpectation(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
@@ -89,15 +89,12 @@ public func expecta(fileID: String = #fileID, file: FileString = #filePath, line
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
 public func waitUntil(
     timeout: NimbleTimeInterval = PollingDefaults.timeout,
-    fileID: String = #fileID,
-    file: FileString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column,
+    location: SourceLocation = SourceLocation(),
     action: @escaping @Sendable (@escaping @Sendable () -> Void) async -> Void
 ) async {
     await throwableUntil(
         timeout: timeout,
-        sourceLocation: SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
+        sourceLocation: location
     ) { done in
         await action(done)
     }
@@ -112,15 +109,12 @@ public func waitUntil(
 /// Unlike the synchronous version of this call, this does not support catching Objective-C exceptions.
 public func waitUntil(
     timeout: NimbleTimeInterval = PollingDefaults.timeout,
-    fileID: String = #fileID,
-    file: FileString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column,
+    location: SourceLocation = SourceLocation(),
     action: @escaping @Sendable (@escaping @Sendable () -> Void) -> Void
 ) async {
     await throwableUntil(
         timeout: timeout,
-        sourceLocation: SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
+        sourceLocation: location
     ) { done in
         action(done)
     }
@@ -154,34 +148,22 @@ private func throwableUntil(
         case .blockedRunLoop:
             fail(
                 blockedRunLoopErrorMessageFor("-waitUntil()", leeway: leeway),
-                fileID: sourceLocation.fileID,
-                file: sourceLocation.filePath,
-                line: sourceLocation.line,
-                column: sourceLocation.column
+                location: sourceLocation
             )
         case .timedOut:
             fail(
                 "Waited more than \(timeout.description)",
-                fileID: sourceLocation.fileID,
-                file: sourceLocation.filePath,
-                line: sourceLocation.line,
-                column: sourceLocation.column
+                location: sourceLocation
             )
         case let .errorThrown(error):
             fail(
                 "Unexpected error thrown: \(error)",
-                fileID: sourceLocation.fileID,
-                file: sourceLocation.filePath,
-                line: sourceLocation.line,
-                column: sourceLocation.column
+                location: sourceLocation
             )
         case .completed(.error(let error)):
             fail(
                 "Unexpected error thrown: \(error)",
-                fileID: sourceLocation.fileID,
-                file: sourceLocation.filePath,
-                line: sourceLocation.line,
-                column: sourceLocation.column
+                location: sourceLocation
             )
         case .completed(.none): // success
             break

--- a/Sources/Nimble/DSL+Require.swift
+++ b/Sources/Nimble/DSL+Require.swift
@@ -3,11 +3,11 @@
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
+public func require<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -17,11 +17,11 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
+public func require<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -31,11 +31,11 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
+public func require<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -45,11 +45,11 @@ public func require<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
+public func require(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -61,11 +61,11 @@ public func require(fileID: String = #fileID, file: FileString = #filePath, line
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
+public func requires<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -77,11 +77,11 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
+public func requires<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -93,11 +93,11 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
+public func requires<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncRequirement<T> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -109,11 +109,11 @@ public func requires<T>(fileID: String = #fileID, file: FileString = #filePath, 
 ///
 /// This is provided as an alternative to ``require``, for when you want to be specific about whether you're using ``SyncRequirement`` or ``AsyncRequirement``.
 @discardableResult
-public func requires(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
+public func requires(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncRequirement<Void> {
     return SyncRequirement(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -123,11 +123,11 @@ public func requires(fileID: String = #fileID, file: FileString = #filePath, lin
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncRequirement<T> {
+public func require<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @escaping @Sendable () async throws -> T?) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -137,11 +137,11 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T)) -> AsyncRequirement<T> {
+public func require<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T)) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -151,11 +151,11 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `require` will return the result of the expression if the matcher passes, and throw an error if not.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T?)) -> AsyncRequirement<T> {
+public func require<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: () -> (@Sendable () async throws -> T?)) -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -167,11 +167,11 @@ public func require<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement` and `require -> AsyncRequirement`.
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -183,11 +183,11 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement`  and `require -> AsyncRequirement`
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T)) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T)) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -199,11 +199,11 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 ///
 /// This is provided to avoid  confusion between `require -> SyncRequirement`  and `require -> AsyncRequirement`
 @discardableResult
-public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async -> AsyncRequirement<T> {
+public func requirea<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async -> AsyncRequirement<T> {
     return AsyncRequirement(
         expression: AsyncExpression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true),
         customError: customError)
 }
@@ -216,8 +216,8 @@ public func requirea<T: Sendable>(fileID: String = #fileID, file: FileString = #
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
-    try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
+public func unwrap<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
+    try requires(location: location, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
@@ -226,18 +226,8 @@ public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, li
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
-    try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
-}
-
-/// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
-/// As you can tell, this is a much less verbose equivalent to `require(expression).toNot(beNil())`.
-///
-/// `unwraps` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
-/// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
-@discardableResult
-public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
-    try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
+public func unwrap<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
+    try requires(location: location, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
@@ -246,8 +236,18 @@ public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `unwraps` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
-    try requires(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
+public func unwraps<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
+    try requires(location: location, customError: customError, expression()).toNot(beNil(), description: description)
+}
+
+/// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
+/// As you can tell, this is a much less verbose equivalent to `require(expression).toNot(beNil())`.
+///
+/// `unwraps` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
+/// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
+@discardableResult
+public func unwraps<T>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
+    try requires(location: location, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
@@ -256,8 +256,8 @@ public func unwraps<T>(fileID: String = #fileID, file: FileString = #filePath, l
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @escaping () async throws -> T?) async throws -> T {
-    try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, try await expression()).toNot(beNil(), description: description)
+public func unwrap<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @escaping () async throws -> T?) async throws -> T {
+    try await requirea(location: location, customError: customError, try await expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
@@ -266,8 +266,8 @@ public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 /// `unwrap` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: () -> (@Sendable () async throws -> T?)) async throws -> T {
-    try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
+public func unwrap<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: () -> (@Sendable () async throws -> T?)) async throws -> T {
+    try await requirea(location: location, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
@@ -276,8 +276,8 @@ public func unwrap<T: Sendable>(fileID: String = #fileID, file: FileString = #fi
 /// `unwrapa` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping () async throws -> T?) async throws -> T {
-    try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, try await expression()).toNot(beNil(), description: description)
+public func unwrapa<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure @escaping () async throws -> T?) async throws -> T {
+    try await requirea(location: location, customError: customError, try await expression()).toNot(beNil(), description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
@@ -286,16 +286,15 @@ public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #f
 /// `unwrapa` will return the result of the expression if it is non-nil, and throw an error if the value is nil.
 /// if a `customError` is given, then that will be thrown. Otherwise, a ``RequireError`` will be thrown.
 @discardableResult
-public func unwrapa<T: Sendable>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async throws -> T {
-    try await requirea(fileID: fileID, file: file, line: line, column: column, customError: customError, expression()).toNot(beNil(), description: description)
+public func unwrapa<T: Sendable>(location: SourceLocation = SourceLocation(), customError: Error? = nil, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async throws -> T {
+    try await requirea(location: location, customError: customError, expression()).toNot(beNil(), description: description)
 }
 
 /// Always fails the test and throw an error to prevent further test execution.
 ///
 /// - Parameter message: A custom message to use in place of the default one.
 /// - Parameter customError: A custom error to throw in place of a ``RequireError``.
-public func requireFail(_ message: String? = nil, customError: Error? = nil, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column) throws {
-    let location = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
+public func requireFail(_ message: String? = nil, customError: Error? = nil, location: SourceLocation = SourceLocation()) throws {
     let handler = NimbleEnvironment.activeInstance.assertionHandler
 
     let msg = message ?? "requireFail() always fails"

--- a/Sources/Nimble/DSL.swift
+++ b/Sources/Nimble/DSL.swift
@@ -1,96 +1,91 @@
 /// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
+public func expect<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
+public func expect<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
+public func expect<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
-public func expect(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
+public func expect(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The value given is lazily evaluated.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
+public func expects<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @escaping @Sendable () throws -> T?) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression,
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
+public func expects<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> T)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects<T>(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
+public func expects<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> T?)) -> SyncExpectation<T> {
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Make a ``SyncExpectation`` on a given actual value. The closure is lazily invoked.
 /// This is provided as an alternative to `expect` which avoids overloading with `expect -> AsyncExpectation`.
-public func expects(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column, _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
+public func expects(location: SourceLocation = SourceLocation(), _ expression: @autoclosure () -> (@Sendable () throws -> Void)) -> SyncExpectation<Void> {
     // It would seem like `sending` isn't necessary for the `expression` argument
     // because the closure returns void. However, this gets rid of a type
     // conversion warning/error.
     return SyncExpectation(
         expression: Expression(
             expression: expression(),
-            location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column),
+            location: location,
             isClosure: true))
 }
 
 /// Always fails the test with a message and a specified location.
-public func fail(_ message: String, location: SourceLocation) {
+public func fail(_ message: String, location: SourceLocation = SourceLocation()) {
     let handler = NimbleEnvironment.activeInstance.assertionHandler
     handler.assert(false, message: FailureMessage(stringValue: message), location: location)
 }
 
-/// Always fails the test with a message.
-public func fail(_ message: String, fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column) {
-    fail(message, location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column))
-}
-
 /// Always fails the test.
-public func fail(fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column) {
-    fail("fail() always fails", location: SourceLocation(fileID: fileID, filePath: file, line: line, column: column))
+public func fail(location: SourceLocation = SourceLocation()) {
+    fail("fail() always fails", location: location)
 }
 
 /// Like Swift's precondition(), but raises NSExceptions instead of sigaborts

--- a/Sources/Nimble/Polling+Require.swift
+++ b/Sources/Nimble/Polling+Require.swift
@@ -708,57 +708,57 @@ extension AsyncRequirement {
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrap<T>(file: FileString = #file, line: UInt = #line, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
-    try require(file: file, line: line, expression()).toEventuallyNot(beNil())
+public func pollUnwrap<T>(location: SourceLocation = SourceLocation(), _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
+    try require(location: location, expression()).toEventuallyNot(beNil())
 }
 
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrap<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
-    try require(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwrap<T>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
+    try require(location: location, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwraps<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
-    try require(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwraps<T>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () throws -> T?) throws -> T {
+    try require(location: location, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `require(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwraps<T>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
-    try require(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwraps<T>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () throws -> T?)) throws -> T {
+    try require(location: location, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `requirea(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrap<T: Sendable>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @escaping @Sendable () async throws -> T?) async throws -> T {
-    try await requirea(file: file, line: line, try await expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwrap<T: Sendable>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @escaping @Sendable () async throws -> T?) async throws -> T {
+    try await requirea(location: location, try await expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `requirea(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrap<T: Sendable>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: () -> (@Sendable () async throws -> T?)) async throws -> T {
-    try await requirea(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwrap<T: Sendable>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: () -> (@Sendable () async throws -> T?)) async throws -> T {
+    try await requirea(location: location, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `requirea(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrapa<T: Sendable>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async throws -> T {
-    try await requirea(file: file, line: line, try await expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwrapa<T: Sendable>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure @escaping @Sendable () async throws -> T?) async throws -> T {
+    try await requirea(location: location, try await expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 /// Makes sure that the async expression evaluates to a non-nil value, otherwise throw an error.
 /// As you can tell, this is a much less verbose equivalent to `requirea(expression).toEventuallyNot(beNil())`
 @discardableResult
-public func pollUnwrapa<T: Sendable>(file: FileString = #file, line: UInt = #line, timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async throws -> T {
-    try await requirea(file: file, line: line, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
+public func pollUnwrapa<T: Sendable>(location: SourceLocation = SourceLocation(), timeout: NimbleTimeInterval = PollingDefaults.timeout, pollInterval: NimbleTimeInterval = PollingDefaults.pollInterval, description: String? = nil, _ expression: @autoclosure () -> (@Sendable () async throws -> T?)) async throws -> T {
+    try await requirea(location: location, expression()).toEventuallyNot(beNil(), timeout: timeout, pollInterval: pollInterval, description: description)
 }
 
 #endif // #if !os(WASI)

--- a/Sources/Nimble/Utils/AsyncAwait.swift
+++ b/Sources/Nimble/Utils/AsyncAwait.swift
@@ -286,10 +286,7 @@ private func runAwaitTrigger<T>(
                     } else {
                         fail(
                             "waitUntil(..) expects its completion closure to be only called once",
-                            fileID: sourceLocation.fileID,
-                            file: sourceLocation.filePath,
-                            line: sourceLocation.line,
-                            column: sourceLocation.column
+                            location: sourceLocation
                         )
                     }
                 }

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -314,8 +314,7 @@ internal class Awaiter {
     }
 
     func performBlock<T: Sendable>(
-        file: FileString,
-        line: UInt,
+        location: SourceLocation,
         _ closure: @escaping (@escaping @Sendable (T) -> Void) throws -> Void
         ) -> AwaitPromiseBuilder<T> {
             let promise = AwaitPromise<T>()
@@ -344,7 +343,7 @@ internal class Awaiter {
                             }
                         } else {
                             fail("waitUntil(..) expects its completion closure to be only called once",
-                                 file: file, line: line)
+                                 location: location)
                         }
                     }
                 }

--- a/Sources/Nimble/Utils/SourceLocation.swift
+++ b/Sources/Nimble/Utils/SourceLocation.swift
@@ -11,6 +11,7 @@ public typealias FileString = StaticString
 public typealias FileString = String
 #endif
 
+@objc
 public final class SourceLocation: NSObject, Sendable {
     public let fileID: String
     @available(*, deprecated, renamed: "filePath")
@@ -19,14 +20,8 @@ public final class SourceLocation: NSObject, Sendable {
     public let line: UInt
     public let column: UInt
 
-    override init() {
-        fileID = "Unknown/File"
-        filePath = "Unknown File"
-        line = 0
-        column = 0
-    }
-
-    init(fileID: String, filePath: FileString, line: UInt, column: UInt) {
+    @objc
+    public init(fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column) {
         self.fileID = fileID
         self.filePath = filePath
         self.line = line

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -155,22 +155,22 @@ NIMBLE_EXPORT NMBObjCRaiseExceptionMatcher *NMB_raiseException(void) {
 NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line) {
     return ^(NSTimeInterval timeout, void (^ _Nonnull action)(void (^ _Nonnull)(void))) {
         [NMBWait untilTimeout:timeout
-                       fileID:[NSString stringWithFormat:@"Unknown/%@", file]
-                         file:file
-                         line:line
-                       column:0
+                     location: [[SourceLocation alloc] initWithFileID:[NSString stringWithFormat:@"Unknown/%@", file]
+                                                             filePath:file
+                                                                 line:line
+                                                               column:0]
                        action:action];
     };
 }
 
 NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line) {
-  return ^(void (^ _Nonnull action)(void (^ _Nonnull)(void))) {
-    [NMBWait untilFileID:[NSString stringWithFormat:@"Unknown/%@", file]
-                      file:file
-                      line:line
-                    column:0
-                    action:action];
-  };
+    return ^(void (^ _Nonnull action)(void (^ _Nonnull)(void))) {
+        [NMBWait untilLocation:[[SourceLocation alloc] initWithFileID:[NSString stringWithFormat:@"Unknown/%@", file]
+                                                             filePath:file
+                                                                 line:line
+                                                               column:0]
+                        action:action];
+    };
 }
 
 NS_ASSUME_NONNULL_END

--- a/Sources/NimbleSharedTestHelpers/utils.swift
+++ b/Sources/NimbleSharedTestHelpers/utils.swift
@@ -10,17 +10,13 @@ import XCTest
 
 public func failsWithErrorMessage(
     _ messages: [String],
-    fileID: String = #fileID,
-    filePath: FileString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column,
+    location: SourceLocation = SourceLocation(),
     preferOriginalSourceLocation: Bool = false,
     closure: () throws -> Void
 ) {
-    var location = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
-
+    var location = location
     let recorder = AssertionRecorder()
-    withAssertionHandler(recorder, fileID: fileID, file: filePath, line: line, column: column, closure: closure)
+    withAssertionHandler(recorder, location: location, closure: closure)
 
     for msg in messages {
         var lastFailure: AssertionRecord?
@@ -64,14 +60,11 @@ public func failsWithErrorMessage(
 // Verifies that the error message matches the given regex.
 public func failsWithErrorRegex(
     _ regex: String,
-    fileID: String = #fileID,
-    filePath: FileString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column,
+    location: SourceLocation = SourceLocation(),
     closure: () throws -> Void
 ) {
     let recorder = AssertionRecorder()
-    withAssertionHandler(recorder, fileID: fileID, file: filePath, line: line, column: column, closure: closure)
+    withAssertionHandler(recorder, location: location, closure: closure)
 
     for assertion in recorder.assertions where assertion.message.stringValue.range(of: regex, options: .regularExpression) != nil && !assertion.success {
         return
@@ -85,48 +78,46 @@ public func failsWithErrorRegex(
                 Assertions Received:
                 \(recorder.assertions)
                 """
-    NimbleAssertionHandler.assert(false,
-                                  message: FailureMessage(stringValue: message),
-                                  location: SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column))
+    NimbleAssertionHandler.assert(
+        false,
+        message: FailureMessage(stringValue: message),
+        location: location
+    )
 }
 
 public func failsWithErrorMessage(
     _ message: String,
-    fileID: String = #fileID,
-    filePath: FileString = #filePath,
-    line: UInt = #line,
-    column: UInt = #column,
+    location: SourceLocation = SourceLocation(),
     preferOriginalSourceLocation: Bool = false,
     closure: () throws -> Void
 ) {
     failsWithErrorMessage(
         [message],
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column,
+        location: location,
         preferOriginalSourceLocation: preferOriginalSourceLocation,
         closure: closure
     )
 }
 
-public func failsWithErrorMessageForNil(_ message: String, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, preferOriginalSourceLocation: Bool = false, closure: () throws -> Void) {
+public func failsWithErrorMessageForNil(
+    _ message: String,
+    location: SourceLocation = SourceLocation(),
+    preferOriginalSourceLocation: Bool = false,
+    closure: () throws -> Void
+) {
     failsWithErrorMessage(
         "\(message) (use beNil() to match nils)",
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column,
+        location: location,
         preferOriginalSourceLocation: preferOriginalSourceLocation,
         closure: closure
     )
 }
 
-public func failsWithErrorMessage(_ messages: [String], fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
-    var sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
+public func failsWithErrorMessage(_ messages: [String], location: SourceLocation = SourceLocation(), preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+    var sourceLocation = location
 
     let recorder = AssertionRecorder()
-    await withAssertionHandler(recorder, fileID: fileID, file: filePath, line: line, column: column, closure: closure)
+    await withAssertionHandler(recorder, location: location, closure: closure)
 
     for msg in messages {
         var lastFailure: AssertionRecord?
@@ -167,25 +158,29 @@ public func failsWithErrorMessage(_ messages: [String], fileID: String = #fileID
     }
 }
 
-public func failsWithErrorMessage(_ message: String, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+public func failsWithErrorMessage(
+    _ message: String,
+    location: SourceLocation = SourceLocation(),
+    preferOriginalSourceLocation: Bool = false,
+    closure: () async throws -> Void
+) async {
     await failsWithErrorMessage(
         [message],
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column,
+        location: location,
         preferOriginalSourceLocation: preferOriginalSourceLocation,
         closure: closure
     )
 }
 
-public func failsWithErrorMessageForNil(_ message: String, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, preferOriginalSourceLocation: Bool = false, closure: () async throws -> Void) async {
+public func failsWithErrorMessageForNil(
+    _ message: String,
+    location: SourceLocation = SourceLocation(),
+    preferOriginalSourceLocation: Bool = false,
+    closure: () async throws -> Void
+) async {
     await failsWithErrorMessage(
         "\(message) (use beNil() to match nils)",
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column,
+        location: location,
         preferOriginalSourceLocation: preferOriginalSourceLocation,
         closure: closure
     )
@@ -201,16 +196,20 @@ public func suppressErrors<T>(closure: () -> T) -> T {
     return output!
 }
 
-public func producesStatus<T>(_ status: ExpectationStatus, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, closure: () -> SyncExpectation<T>) {
+public func producesStatus<T>(
+    _ status: ExpectationStatus,
+    location: SourceLocation = SourceLocation(),
+    closure: () -> SyncExpectation<T>
+) {
     let expectation = suppressErrors(closure: closure)
 
-    expect(fileID: fileID, file: filePath, line: line, column: column, expectation.status).to(equal(status))
+    expect(location: location, expectation.status).to(equal(status))
 }
 
-public func producesStatus<T>(_ status: ExpectationStatus, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column, closure: () -> AsyncExpectation<T>) {
+public func producesStatus<T>(_ status: ExpectationStatus, location: SourceLocation = SourceLocation(), closure: () -> AsyncExpectation<T>) {
     let expectation = suppressErrors(closure: closure)
 
-    expect(fileID: fileID, file: filePath, line: line, column: column, expectation.status).to(equal(status))
+    expect(location: location, expectation.status).to(equal(status))
 }
 
 #if !os(WASI)
@@ -227,10 +226,12 @@ public class NimbleHelper: NSObject {
     @objc public class func expectFailureMessage(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(
             String(describing: message),
-            fileID: "Unknown/\(file)",
-            filePath: file,
-            line: line,
-            column: 0,
+            location: SourceLocation(
+                fileID: "Unknown/\(file)",
+                filePath: file,
+                line: line,
+                column: 0
+            ),
             preferOriginalSourceLocation: true,
             closure: block
         )
@@ -239,10 +240,12 @@ public class NimbleHelper: NSObject {
     @objc public class func expectFailureMessages(_ messages: [NSString], block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessage(
             messages.map({String(describing: $0)}),
-            fileID: "Unknown/\(file)",
-            filePath: file,
-            line: line,
-            column: 0,
+            location: SourceLocation(
+                fileID: "Unknown/\(file)",
+                filePath: file,
+                line: line,
+                column: 0
+            ),
             preferOriginalSourceLocation: true,
             closure: block
         )
@@ -251,10 +254,12 @@ public class NimbleHelper: NSObject {
     @objc public class func expectFailureMessageForNil(_ message: NSString, block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorMessageForNil(
             String(describing: message),
-            fileID: "Unknown/\(file)",
-            filePath: file,
-            line: line,
-            column: 0,
+            location: SourceLocation(
+                fileID: "Unknown/\(file)",
+                filePath: file,
+                line: line,
+                column: 0
+            ),
             preferOriginalSourceLocation: true,
             closure: block
         )
@@ -263,10 +268,12 @@ public class NimbleHelper: NSObject {
     @objc public class func expectFailureMessageRegex(_ regex: NSString, block: () -> Void, file: FileString, line: UInt) {
         failsWithErrorRegex(
             String(describing: regex),
-            fileID: "Unknown/\(file)",
-            filePath: file,
-            line: line,
-            column: 0,
+            location: SourceLocation(
+                fileID: "Unknown/\(file)",
+                filePath: file,
+                line: line,
+                column: 0
+            ),
             closure: block
         )
     }

--- a/Tests/NimbleTests/AsyncAwaitTest.swift
+++ b/Tests/NimbleTests/AsyncAwaitTest.swift
@@ -284,7 +284,7 @@ final class AsyncAwaitTest: XCTestCase { // swiftlint:disable:this type_body_len
 
         for index in 0..<100 {
             if failed { break }
-            await waitUntil(line: UInt(index)) { done in
+            await waitUntil(location: SourceLocation(column: UInt(index))) { done in
                 DispatchQueue(label: "Nimble.waitUntilTest.\(index)").async {
                     done()
                 }

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -202,7 +202,7 @@ final class PollingTest: XCTestCase {
 
         for index in 0..<100 {
             if failed { break }
-            waitUntil(line: UInt(index)) { done in
+            waitUntil(location: SourceLocation(column: UInt(index))) { done in
                 DispatchQueue(label: "Nimble.waitUntilTest.\(index)").async {
                     done()
                 }


### PR DESCRIPTION
Breaking change.

Simplifies the maintenance burden of passing source location information by consolidating down to SourceLocation at the callsite.


- [ ] Does this have tests?
- [ ] Does this have documentation?
- [x] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
