### PR TITLE
Do not fail on timeout for `toAlways` and `toNever`

### DIFF
--- a/Sources/Nimble/DSL+Wait.swift
+++ b/Sources/Nimble/DSL+Wait.swift
@@ -69,7 +69,7 @@ public class NMBWait: NSObject {
                         }
                     }
                 }
-            }.timeout(timeout, forcefullyAbortTimeout: leeway).wait(
+            }.timeout(timeout, forcefullyAbortTimeout: leeway, isContinuous: false).wait(
                 "waitUntil(...)",
                 sourceLocation: SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
             )

--- a/Sources/Nimble/Polling+AsyncAwait.swift
+++ b/Sources/Nimble/Polling+AsyncAwait.swift
@@ -42,12 +42,12 @@ internal actor Poller<T> {
             fnName: fnName) {
                 if self.updateMatcherResult(result: try await matcherRunner())
                     .toBoolean(expectation: style) {
-                    if matchStyle.isContinous {
+                    if matchStyle.isContinuous {
                         return .incomplete
                     }
                     return .finished(true)
                 } else {
-                    if matchStyle.isContinous {
+                    if matchStyle.isContinuous {
                         return .finished(false)
                     } else {
                         return .incomplete

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -96,7 +96,8 @@ internal func poll<T>(
             pollInterval: poll,
             timeoutInterval: timeout,
             sourceLocation: actualExpression.location,
-            fnName: fnName) {
+            fnName: fnName,
+            isContinuous: matchStyle.isContinous) {
                 lastMatcherResult = try matcher.satisfies(uncachedExpression)
                 if lastMatcherResult!.toBoolean(expectation: style) {
                     if matchStyle.isContinous {

--- a/Sources/Nimble/Polling.swift
+++ b/Sources/Nimble/Polling.swift
@@ -69,7 +69,7 @@ public struct PollingDefaults: @unchecked Sendable {
 internal enum AsyncMatchStyle {
     case eventually, never, always
 
-    var isContinous: Bool {
+    var isContinuous: Bool {
         switch self {
         case .eventually:
             return false
@@ -97,15 +97,15 @@ internal func poll<T>(
             timeoutInterval: timeout,
             sourceLocation: actualExpression.location,
             fnName: fnName,
-            isContinuous: matchStyle.isContinous) {
+            isContinuous: matchStyle.isContinuous) {
                 lastMatcherResult = try matcher.satisfies(uncachedExpression)
                 if lastMatcherResult!.toBoolean(expectation: style) {
-                    if matchStyle.isContinous {
+                    if matchStyle.isContinuous {
                         return .incomplete
                     }
                     return .finished(true)
                 } else {
-                    if matchStyle.isContinous {
+                    if matchStyle.isContinuous {
                         return .finished(false)
                     } else {
                         return .incomplete

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -159,7 +159,7 @@ internal class AwaitPromiseBuilder<T> {
             self.trigger = trigger
     }
 
-    func timeout(_ timeoutInterval: NimbleTimeInterval, forcefullyAbortTimeout: NimbleTimeInterval) -> Self {
+    func timeout(_ timeoutInterval: NimbleTimeInterval, forcefullyAbortTimeout: NimbleTimeInterval, isContinuous: Bool) -> Self {
         /// = Discussion =
         ///
         /// There's a lot of technical decisions here that is useful to elaborate on. This is
@@ -234,7 +234,7 @@ internal class AwaitPromiseBuilder<T> {
             let didNotTimeOut = timedOutSem.wait(timeout: now) != .success
             let timeoutWasNotTriggered = semTimedOutOrBlocked.wait(timeout: .now()) == .success
             if didNotTimeOut && timeoutWasNotTriggered {
-                if self.promise.resolveResult(.blockedRunLoop) {
+                if self.promise.resolveResult(isContinuous ? .timedOut : .blockedRunLoop) {
                     #if canImport(CoreFoundation)
                     CFRunLoopStop(CFRunLoopGetMain())
                     #else
@@ -402,6 +402,7 @@ internal func pollBlock(
     timeoutInterval: NimbleTimeInterval,
     sourceLocation: SourceLocation,
     fnName: String = #function,
+    isContinuous: Bool,
     expression: @escaping () throws -> PollStatus) -> PollResult<Bool> {
         let awaiter = NimbleEnvironment.activeInstance.awaiter
         let result = awaiter.poll(pollInterval) { () throws -> Bool? in
@@ -410,7 +411,7 @@ internal func pollBlock(
             }
             return nil
         }
-            .timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided)
+            .timeout(timeoutInterval, forcefullyAbortTimeout: timeoutInterval.divided, isContinuous: isContinuous)
             .wait(fnName, sourceLocation: sourceLocation)
 
         return result

--- a/Tests/NimbleTests/PollingTest.swift
+++ b/Tests/NimbleTests/PollingTest.swift
@@ -139,6 +139,33 @@ final class PollingTest: XCTestCase {
             }
         }
     }
+    
+    func testToEventuallyDetectsStalledMainThreadActivity() {
+        func spinAndReturnTrue() -> Bool {
+            Thread.sleep(forTimeInterval: 0.5)
+            return true
+        }
+        let msg = "expected to eventually be true, got <true> (timed out, but main run loop was unresponsive)."
+        failsWithErrorMessage(msg) {
+            expect(spinAndReturnTrue()).toEventually(beTrue())
+        }
+    }
+    
+    func testToNeverDoesNotFailStalledMainThreadActivity() {
+        func spinAndReturnTrue() -> Bool {
+            Thread.sleep(forTimeInterval: 0.5)
+            return true
+        }
+        expect(spinAndReturnTrue()).toNever(beFalse())
+    }
+    
+    func testToAlwaysDetectsStalledMainThreadActivity() {
+        func spinAndReturnTrue() -> Bool {
+            Thread.sleep(forTimeInterval: 0.5)
+            return true
+        }
+        expect(spinAndReturnTrue()).toAlways(beTrue())
+    }
 
     func testCombiningAsyncWaitUntilAndToEventuallyIsNotAllowed() {
         // Currently we are unable to catch Objective-C exceptions when built by the Swift Package Manager


### PR DESCRIPTION
Our CI system runs on up to 4 parallel simulators, putting the CPU under higher-than-average stress levels.  As a result, we get occasional flakiness when `toEventually`, `toAlways` and `toNever` encounter a blocked run loop.

In this scenario, it doesn't really make sense for `toAlways` and `toNever` to fail, since the conditions weren't violated in the extended timeout window.

This change addresses that issue by resolving with `.timeOut` for continous `AsyncMatchStyle`s even when the main loop is blocked.

Checklist - While not every PR needs it, new features should consider this list:

- [x] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
