### PR TITLE
Remove duplicated RunLoop code

### DIFF
--- a/Sources/Nimble/Utils/AsyncAwait.swift
+++ b/Sources/Nimble/Utils/AsyncAwait.swift
@@ -1,9 +1,5 @@
 #if !os(WASI)
 
-#if canImport(CoreFoundation)
-import CoreFoundation
-#endif
-
 import Dispatch
 import Foundation
 

--- a/Sources/Nimble/Utils/AsyncTimerSequence.swift
+++ b/Sources/Nimble/Utils/AsyncTimerSequence.swift
@@ -1,8 +1,5 @@
 #if !os(WASI)
 
-#if canImport(CoreFoundation)
-import CoreFoundation
-#endif
 import Dispatch
 import Foundation
 

--- a/Sources/Nimble/Utils/PollAwait.swift
+++ b/Sources/Nimble/Utils/PollAwait.swift
@@ -1,8 +1,5 @@
 #if !os(WASI)
 
-#if canImport(CoreFoundation)
-import CoreFoundation
-#endif
 import Dispatch
 import Foundation
 
@@ -198,48 +195,24 @@ internal class AwaitPromiseBuilder<T> {
             let timedOutSem = DispatchSemaphore(value: 0)
             let semTimedOutOrBlocked = DispatchSemaphore(value: 0)
             semTimedOutOrBlocked.signal()
-            #if canImport(CoreFoundation)
-            let runLoop = CFRunLoopGetMain()
-            #if canImport(Darwin)
-                let runLoopMode = CFRunLoopMode.defaultMode.rawValue
-            #else
-                let runLoopMode = kCFRunLoopDefaultMode
-            #endif
-            CFRunLoopPerformBlock(runLoop, runLoopMode) {
-                if semTimedOutOrBlocked.wait(timeout: .now()) == .success {
-                    timedOutSem.signal()
-                    semTimedOutOrBlocked.signal()
-                    if self.promise.resolveResult(.timedOut) {
-                        CFRunLoopStop(CFRunLoopGetMain())
-                    }
-                }
-            }
-            // potentially interrupt blocking code on run loop to let timeout code run
-            CFRunLoopStop(runLoop)
-            #else
             let runLoop = RunLoop.main
             runLoop.perform(inModes: [.default], block: {
                 if semTimedOutOrBlocked.wait(timeout: .now()) == .success {
                     timedOutSem.signal()
                     semTimedOutOrBlocked.signal()
                     if self.promise.resolveResult(.timedOut) {
-                        RunLoop.main._stop()
+                        RunLoop.main.stop()
                     }
                 }
             })
             // potentially interrupt blocking code on run loop to let timeout code run
-            runLoop._stop()
-            #endif
+            runLoop.stop()
             let now = DispatchTime.now() + forcefullyAbortTimeout.dispatchTimeInterval
             let didNotTimeOut = timedOutSem.wait(timeout: now) != .success
             let timeoutWasNotTriggered = semTimedOutOrBlocked.wait(timeout: .now()) == .success
             if didNotTimeOut && timeoutWasNotTriggered {
                 if self.promise.resolveResult(.blockedRunLoop) {
-                    #if canImport(CoreFoundation)
-                    CFRunLoopStop(CFRunLoopGetMain())
-                    #else
-                    RunLoop.main._stop()
-                    #endif
+                    runLoop.stop()
                 }
             }
         }
@@ -327,11 +300,7 @@ internal class Awaiter {
                     if completionCount < 2 {
                         func completeBlock() {
                             if promise.resolveResult(.completed(result)) {
-                                #if canImport(CoreFoundation)
-                                CFRunLoopStop(CFRunLoopGetMain())
-                                #else
-                                RunLoop.main._stop()
-                                #endif
+                                RunLoop.main.stop()
                             }
                         }
 
@@ -369,20 +338,12 @@ internal class Awaiter {
                 do {
                     if let result = try closure() {
                         if promise.resolveResult(.completed(result)) {
-                            #if canImport(CoreFoundation)
-                            CFRunLoopStop(CFRunLoopGetCurrent())
-                            #else
-                            RunLoop.current._stop()
-                            #endif
+                            RunLoop.current.stop()
                         }
                     }
                 } catch let error {
                     if promise.resolveResult(.errorThrown(error)) {
-                        #if canImport(CoreFoundation)
-                        CFRunLoopStop(CFRunLoopGetCurrent())
-                        #else
-                        RunLoop.current._stop()
-                        #endif
+                        RunLoop.current.stop()
                     }
                 }
             }
@@ -415,5 +376,24 @@ internal func pollBlock(
 
         return result
 }
+
+#if canImport(CoreFoundation)
+import CoreFoundation
+
+extension RunLoop {
+    func stop() {
+        CFRunLoopStop(getCFRunLoop())
+    }
+}
+
+#else
+
+extension RunLoop {
+    func stop() {
+        _stop()
+    }
+}
+
+#endif
 
 #endif // #if !os(WASI)

--- a/Tests/NimbleTests/PollingTest+Require.swift
+++ b/Tests/NimbleTests/PollingTest+Require.swift
@@ -1,9 +1,6 @@
 #if !os(WASI)
 
 import Dispatch
-#if canImport(CoreFoundation)
-import CoreFoundation
-#endif
 import Foundation
 import XCTest
 import Nimble


### PR DESCRIPTION
To add support for Windows, #1088 used `RunLoop` in place of `CFRunLoop` on systems that can't import CoreFoundation, leading to a moderate amount of code duplication.

On systems that can import CoreFoundation, `RunLoop` is actually just [a wrapper around `CFRunLoop`](https://github.com/swiftlang/swift-corelibs-foundation/blob/main/Sources/Foundation/RunLoop.swift), meaning we can remove the duplicated code.  The only exception is that `_stop` isn't exposed and needs to be included using an extension.

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
