### PR TITLE
Return Never from requireFail

### DIFF
--- a/Sources/Nimble/DSL+Require.swift
+++ b/Sources/Nimble/DSL+Require.swift
@@ -294,7 +294,7 @@ public func unwrapa<T>(fileID: String = #fileID, file: FileString = #filePath, l
 ///
 /// - Parameter message: A custom message to use in place of the default one.
 /// - Parameter customError: A custom error to throw in place of a ``RequireError``.
-public func requireFail(_ message: String? = nil, customError: Error? = nil, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column) throws {
+public func requireFail(_ message: String? = nil, customError: Error? = nil, fileID: String = #fileID, filePath: FileString = #filePath, line: UInt = #line, column: UInt = #column) throws -> Never {
     let location = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     let handler = NimbleEnvironment.activeInstance.assertionHandler
 


### PR DESCRIPTION
I want to use `requireFail` in some test cases where `require` doesn't feel right.  The problem is that while it's guaranteed to throw, the code doesn't know that, so it can't be used in a guard statement.

For example, the following code has a compiler error _"'guard' body must not fall through, consider using a 'return' or 'throw' to exit the scope"_

```swift
guard interaction.responds(to: #selector(PrivateMethods._presentMenuAtLocation)) else {
    try requireFail("Cannot trigger UIContextMenuInteraction")
}
```

I've been getting around this locally with a simple wrapper:

```swift
func failHard(_ message: String, fileID: String = #fileID, file: FileString = #filePath, line: UInt = #line, column: UInt = #column) throws -> Never {
    try requireFail(message, fileID: fileID, filePath: file, line: line, column: column)
    preconditionFailure("This line should never be called, since requireFail should always throw")
}
```

We can improve `requireFail` by simply adding the `Never` return type.  When compiling Nimble, Swift validates that `requireFail` does indeed always throw and when compiling tests, it knows no code will ever execute after `requireFail`.

This is an API change but should be source compatible.  Any code below a `requireFail` call will receive a "Will never be executed" warning but still compile.

Checklist - While not every PR needs it, new features should consider this list:

- [ ] Does this have tests?
- [ ] Does this have documentation?
- [ ] Does this break the public API (Requires major version bump)?
- [ ] Is this a new feature (Requires minor version bump)?
